### PR TITLE
chore: sync ydaemon

### DIFF
--- a/strategy/1/0x00cb87656196dd835b9e4d67018ae0477a1de8c1.json
+++ b/strategy/1/0x00cb87656196dd835b9e4d67018ae0477a1de8c1.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses."
+    }
+}

--- a/strategy/1/0x05329aab081b125eef7fbbc8b857428d478e692b.json
+++ b/strategy/1/0x05329aab081b125eef7fbbc8b857428d478e692b.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 2,
+    "riskScore": {
+        "review": 1,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 5,
+        "externalProtocolCentralisation": 2,
+        "externalProtocolTvl": 3,
+        "externalProtocolLongevity": 5,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0x074134a2784f4f66b6ced6f68849382990ff3215.json
+++ b/strategy/1/0x074134a2784f4f66b6ced6f68849382990ff3215.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 2,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 4,
+        "externalProtocolType": 1,
+        "comment": "Risk depends heavily on the specific vault configuration and the curator managing the vault."
+    }
+}

--- a/strategy/1/0x0868076663bbc6638cedd27704cc8f0fa53d5b81.json
+++ b/strategy/1/0x0868076663bbc6638cedd27704cc8f0fa53d5b81.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 5,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 2,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0x09580f2305a335218bdb2eb828387d52ed8fc2f4.json
+++ b/strategy/1/0x09580f2305a335218bdb2eb828387d52ed8fc2f4.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 2,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 3,
+        "protocolIntegration": 2,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 4,
+        "externalProtocolType": 1,
+        "comment": "All collateral is in USDe. Risk depends heavily on the specific vault configuration and the curator managing the vault."
+    }
+}

--- a/strategy/1/0x17f211915f87f0aac4b67d8b311e7c38c38830d4.json
+++ b/strategy/1/0x17f211915f87f0aac4b67d8b311e7c38c38830d4.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 1,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": ""
+    }
+}

--- a/strategy/1/0x1fd862499e9b9402de6c599b6c391f83981180ab.json
+++ b/strategy/1/0x1fd862499e9b9402de6c599b6c391f83981180ab.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 2,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0x206db0a0af10bec57784045e089a418771d20227.json
+++ b/strategy/1/0x206db0a0af10bec57784045e089a418771d20227.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0x23ee3d14f09946a084350cc6a7153fc6eb918817.json
+++ b/strategy/1/0x23ee3d14f09946a084350cc6a7153fc6eb918817.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0x2478d5997324e8b47e9ff870166dba8d2e461993.json
+++ b/strategy/1/0x2478d5997324e8b47e9ff870166dba8d2e461993.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 1,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses."
+    }
+}

--- a/strategy/1/0x27ffa71dbb25a7c52a3da74c6eed8c94c9a43e0d.json
+++ b/strategy/1/0x27ffa71dbb25a7c52a3da74c6eed8c94c9a43e0d.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0x2f2bbc50db252eeadd2c9b9197beb6e5aef87e48.json
+++ b/strategy/1/0x2f2bbc50db252eeadd2c9b9197beb6e5aef87e48.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 5,
+        "complexity": 3,
+        "riskExposure": 4,
+        "protocolIntegration": 1,
+        "centralizationRisk": 4,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses."
+    }
+}

--- a/strategy/1/0x4ce9c93513dff543bc392870d57df8c04e89ba0a.json
+++ b/strategy/1/0x4ce9c93513dff543bc392870d57df8c04e89ba0a.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 5,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 2,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0x57a8b4061aa598d2bb5f70c5f931a75c9f511fc8.json
+++ b/strategy/1/0x57a8b4061aa598d2bb5f70c5f931a75c9f511fc8.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 5,
+        "complexity": 3,
+        "riskExposure": 4,
+        "protocolIntegration": 1,
+        "centralizationRisk": 4,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses."
+    }
+}

--- a/strategy/1/0x57fc2d9809f777cd5c8c433442264b6e8be7fce4.json
+++ b/strategy/1/0x57fc2d9809f777cd5c8c433442264b6e8be7fce4.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 5,
+        "complexity": 3,
+        "riskExposure": 4,
+        "protocolIntegration": 1,
+        "centralizationRisk": 4,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses."
+    }
+}

--- a/strategy/1/0x5f76526390d9cd9944d65c605c5006480fa1bfcb.json
+++ b/strategy/1/0x5f76526390d9cd9944d65c605c5006480fa1bfcb.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 2,
+    "riskScore": {
+        "review": 1,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 5,
+        "externalProtocolCentralisation": 2,
+        "externalProtocolTvl": 3,
+        "externalProtocolLongevity": 5,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0x602da189f5ada033e9ac7096fc39c7f44a77e942.json
+++ b/strategy/1/0x602da189f5ada033e9ac7096fc39c7f44a77e942.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 3,
+        "complexity": 1,
+        "riskExposure": 2,
+        "protocolIntegration": 2,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0x6164045fc2b2b269ffcab2197736a74b1725b6c6.json
+++ b/strategy/1/0x6164045fc2b2b269ffcab2197736a74b1725b6c6.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 2,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 2,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 2,
+        "externalProtocolLongevity": 5,
+        "externalProtocolType": 3,
+        "comment": ""
+    }
+}

--- a/strategy/1/0x66017371c032cd5a67fec6913a9e37d5bd1c690c.json
+++ b/strategy/1/0x66017371c032cd5a67fec6913a9e37d5bd1c690c.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses."
+    }
+}

--- a/strategy/1/0x6701dea9809deaf068b8445798d0e19b025480fe.json
+++ b/strategy/1/0x6701dea9809deaf068b8445798d0e19b025480fe.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0x68b9f74372b257fad2c9a160d2f12ee526ea9510.json
+++ b/strategy/1/0x68b9f74372b257fad2c9a160d2f12ee526ea9510.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 1,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": ""
+    }
+}

--- a/strategy/1/0x694e47afd14a64661a04eee674fb331bcdef3737.json
+++ b/strategy/1/0x694e47afd14a64661a04eee674fb331bcdef3737.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 2,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 4,
+        "externalProtocolType": 1,
+        "comment": "Risk depends heavily on the specific vault configuration and the curator managing the vault."
+    }
+}

--- a/strategy/1/0x6aceda98725505737c0f00a3da0d047304052948.json
+++ b/strategy/1/0x6aceda98725505737c0f00a3da0d047304052948.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 2,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0x76e9b1711d85bc9c88a437420787c34282956ec5.json
+++ b/strategy/1/0x76e9b1711d85bc9c88a437420787c34282956ec5.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 1,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": ""
+    }
+}

--- a/strategy/1/0x7ee351aa702c8fc735d77fb229b7676ac15d7c79.json
+++ b/strategy/1/0x7ee351aa702c8fc735d77fb229b7676ac15d7c79.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0x8294bba6671d4094a7c0e9c98e615fbc11f96388.json
+++ b/strategy/1/0x8294bba6671d4094a7c0e9c98e615fbc11f96388.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses."
+    }
+}

--- a/strategy/1/0x832c30802054f60f0cedb5be1f9a0e3da2a0cab4.json
+++ b/strategy/1/0x832c30802054f60f0cedb5be1f9a0e3da2a0cab4.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0x8a878e3149051b810f078fd3f2e0924290be34a6.json
+++ b/strategy/1/0x8a878e3149051b810f078fd3f2e0924290be34a6.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses."
+    }
+}

--- a/strategy/1/0x90759801579208b28d2d36d13b1ed7443d1b717f.json
+++ b/strategy/1/0x90759801579208b28d2d36d13b1ed7443d1b717f.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0x91f008870eef686b61a3775944d55a3fc53b7024.json
+++ b/strategy/1/0x91f008870eef686b61a3775944d55a3fc53b7024.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 5,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0x95d69641ed7ecaa5e7d5539f56dc6194b5bcd7fa.json
+++ b/strategy/1/0x95d69641ed7ecaa5e7d5539f56dc6194b5bcd7fa.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0x9784ded306e42c0b8130f668e9b7533faa72e65d.json
+++ b/strategy/1/0x9784ded306e42c0b8130f668e9b7533faa72e65d.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 2,
+    "riskScore": {
+        "review": 1,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 5,
+        "externalProtocolCentralisation": 2,
+        "externalProtocolTvl": 3,
+        "externalProtocolLongevity": 5,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0x9861708f2ad2bd1ed8d4d12436c0d8eb1ed36f1c.json
+++ b/strategy/1/0x9861708f2ad2bd1ed8d4d12436c0d8eb1ed36f1c.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 2,
+    "riskScore": {
+        "review": 2,
+        "testing": 3,
+        "complexity": 1,
+        "riskExposure": 3,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 4,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 2,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 4,
+        "comment": ""
+    }
+}

--- a/strategy/1/0xb0154f71912866bb69fe26ffc44779d99b9cae85.json
+++ b/strategy/1/0xb0154f71912866bb69fe26ffc44779d99b9cae85.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0xb2155ffa9807b2decb4a411f7330da5bb6e46c31.json
+++ b/strategy/1/0xb2155ffa9807b2decb4a411f7330da5bb6e46c31.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 5,
+        "complexity": 3,
+        "riskExposure": 4,
+        "protocolIntegration": 1,
+        "centralizationRisk": 4,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses."
+    }
+}

--- a/strategy/1/0xb8deb48bd0a2bac798f19ba8a7ee492384423fea.json
+++ b/strategy/1/0xb8deb48bd0a2bac798f19ba8a7ee492384423fea.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 1,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": ""
+    }
+}

--- a/strategy/1/0xb9ef23c587f3f3dea54f42de5b71e78f822c74e8.json
+++ b/strategy/1/0xb9ef23c587f3f3dea54f42de5b71e78f822c74e8.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses."
+    }
+}

--- a/strategy/1/0xbdac8353b03a883654d19ff60c8fcdc1a52f0be2.json
+++ b/strategy/1/0xbdac8353b03a883654d19ff60c8fcdc1a52f0be2.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 5,
+        "complexity": 3,
+        "riskExposure": 4,
+        "protocolIntegration": 1,
+        "centralizationRisk": 4,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses."
+    }
+}

--- a/strategy/1/0xbdb97ec319c41c6fa383e94ece6bdf383dfc7be4.json
+++ b/strategy/1/0xbdb97ec319c41c6fa383e94ece6bdf383dfc7be4.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0xbf2e5bed692c09af8b39677e315f36adf39bd685.json
+++ b/strategy/1/0xbf2e5bed692c09af8b39677e315f36adf39bd685.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 2,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 2,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 2,
+        "externalProtocolLongevity": 5,
+        "externalProtocolType": 3,
+        "comment": ""
+    }
+}

--- a/strategy/1/0xc08d81aba10f2dcba50f9a3efbc0988439223978.json
+++ b/strategy/1/0xc08d81aba10f2dcba50f9a3efbc0988439223978.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0xc40dc53931cd184f782f3602d95c7e3609706004.json
+++ b/strategy/1/0xc40dc53931cd184f782f3602d95c7e3609706004.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 2,
+    "riskScore": {
+        "review": 1,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 5,
+        "externalProtocolCentralisation": 2,
+        "externalProtocolTvl": 3,
+        "externalProtocolLongevity": 5,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0xc7bae383738274ea8c3292d53afbb3b42b348df0.json
+++ b/strategy/1/0xc7bae383738274ea8c3292d53afbb3b42b348df0.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0xc9fb833f11d2d8169953b144fa5242e8aec25c01.json
+++ b/strategy/1/0xc9fb833f11d2d8169953b144fa5242e8aec25c01.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 1,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": ""
+    }
+}

--- a/strategy/1/0xcc209a1c5a3757597497c83d62d1d6b6a2c7395f.json
+++ b/strategy/1/0xcc209a1c5a3757597497c83d62d1d6b6a2c7395f.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 5,
+        "complexity": 3,
+        "riskExposure": 4,
+        "protocolIntegration": 1,
+        "centralizationRisk": 4,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses."
+    }
+}

--- a/strategy/1/0xd2efb90c569ebd5b83d5cfb8632322edfac203a5.json
+++ b/strategy/1/0xd2efb90c569ebd5b83d5cfb8632322edfac203a5.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0xd789d846c1eed55161dbd135d7bf02450a836ffa.json
+++ b/strategy/1/0xd789d846c1eed55161dbd135d7bf02450a836ffa.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 1,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": ""
+    }
+}

--- a/strategy/1/0xdc0b53cc326b692a4d89e5f4cadc29a6b7265749.json
+++ b/strategy/1/0xdc0b53cc326b692a4d89e5f4cadc29a6b7265749.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 1,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": ""
+    }
+}

--- a/strategy/1/0xdda02a2fa0bb0ee45ba9179a3fd7e65e5d3b2c90.json
+++ b/strategy/1/0xdda02a2fa0bb0ee45ba9179a3fd7e65e5d3b2c90.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 5,
+        "complexity": 3,
+        "riskExposure": 4,
+        "protocolIntegration": 1,
+        "centralizationRisk": 4,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses."
+    }
+}

--- a/strategy/1/0xe403bbf2262643c2e996e7469be736e211d5b272.json
+++ b/strategy/1/0xe403bbf2262643c2e996e7469be736e211d5b272.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 5,
+        "complexity": 3,
+        "riskExposure": 4,
+        "protocolIntegration": 1,
+        "centralizationRisk": 4,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses."
+    }
+}

--- a/strategy/1/0xe5175a2eb7c40bc5f0e9de4152caa14eab0ffcb7.json
+++ b/strategy/1/0xe5175a2eb7c40bc5f0e9de4152caa14eab0ffcb7.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 5,
+        "complexity": 3,
+        "riskExposure": 4,
+        "protocolIntegration": 1,
+        "centralizationRisk": 4,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses. Underlying SY contract which holds asset is upgradable"
+    }
+}

--- a/strategy/1/0xe5323ca5b11eb8495c56473756de679e43168d57.json
+++ b/strategy/1/0xe5323ca5b11eb8495c56473756de679e43168d57.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 2,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 2,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 2,
+        "externalProtocolLongevity": 5,
+        "externalProtocolType": 3,
+        "comment": ""
+    }
+}

--- a/strategy/1/0xe5baf8b6be442811211e9339d9fbc1b8fb7d66df.json
+++ b/strategy/1/0xe5baf8b6be442811211e9339d9fbc1b8fb7d66df.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0xe838ab2eb50db41bd713f27346690d3ead2d98f1.json
+++ b/strategy/1/0xe838ab2eb50db41bd713f27346690d3ead2d98f1.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 1,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": ""
+    }
+}

--- a/strategy/1/0xe92ade9ee76681f96c8bb0b352d5410ca5b35d70.json
+++ b/strategy/1/0xe92ade9ee76681f96c8bb0b352d5410ca5b35d70.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 2,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 2,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 2,
+        "externalProtocolLongevity": 5,
+        "externalProtocolType": 3,
+        "comment": ""
+    }
+}

--- a/strategy/1/0xebf3581407ae0ceb07b8149b4c3ac995a72cb589.json
+++ b/strategy/1/0xebf3581407ae0ceb07b8149b4c3ac995a72cb589.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 5,
+        "complexity": 3,
+        "riskExposure": 4,
+        "protocolIntegration": 1,
+        "centralizationRisk": 4,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses."
+    }
+}

--- a/strategy/1/0xec48e0b9579062770888aaf900d054a1bc10a3bf.json
+++ b/strategy/1/0xec48e0b9579062770888aaf900d054a1bc10a3bf.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses."
+    }
+}

--- a/strategy/1/0xeeb6be70ff212238419cd638fab17910cf61cbe7.json
+++ b/strategy/1/0xeeb6be70ff212238419cd638fab17910cf61cbe7.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 2,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 4,
+        "externalProtocolType": 1,
+        "comment": "Risk depends heavily on the specific vault configuration and the curator managing the vault."
+    }
+}

--- a/strategy/1/0xeed00e00236cd7f36f2558d8b5fd05046449599d.json
+++ b/strategy/1/0xeed00e00236cd7f36f2558d8b5fd05046449599d.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0xf0825750791a4444c5e70743270dcfa8bb38f959.json
+++ b/strategy/1/0xf0825750791a4444c5e70743270dcfa8bb38f959.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0xf1ce36c9c0db95a052eb4b075bc334e1f5a21ef0.json
+++ b/strategy/1/0xf1ce36c9c0db95a052eb4b075bc334e1f5a21ef0.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 5,
+        "complexity": 3,
+        "riskExposure": 4,
+        "protocolIntegration": 1,
+        "centralizationRisk": 4,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses."
+    }
+}

--- a/strategy/1/0xf45eec3b50658054755a5055173ceeb82c94aa4e.json
+++ b/strategy/1/0xf45eec3b50658054755a5055173ceeb82c94aa4e.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 5,
+        "complexity": 3,
+        "riskExposure": 4,
+        "protocolIntegration": 1,
+        "centralizationRisk": 4,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses. Underlying SY contract which holds asset is upgradable"
+    }
+}

--- a/strategy/1/0xf68a6b53d907b5abc0bfdeceb8343e91fec052ee.json
+++ b/strategy/1/0xf68a6b53d907b5abc0bfdeceb8343e91fec052ee.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 1,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": ""
+    }
+}

--- a/strategy/1/0xf6e2d36c489e5b361cdc962d4568cea663ad5ddc.json
+++ b/strategy/1/0xf6e2d36c489e5b361cdc962d4568cea663ad5ddc.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 2,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 2,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 2,
+        "externalProtocolLongevity": 5,
+        "externalProtocolType": 3,
+        "comment": ""
+    }
+}

--- a/strategy/1/0xf766c7293f4e0265ddfa8369f78a808df8ac70c1.json
+++ b/strategy/1/0xf766c7293f4e0265ddfa8369f78a808df8ac70c1.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/1/0xfb7c06ddd70c74ac2f68d0f947be3b4c503e3d6c.json
+++ b/strategy/1/0xfb7c06ddd70c74ac2f68d0f947be3b4c503e3d6c.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 2,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/137/0x06ed7c67755344548fafe1822bee365c4208a57f.json
+++ b/strategy/137/0x06ed7c67755344548fafe1822bee365c4208a57f.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 2,
+    "riskScore": {
+        "review": 2,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 3,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 2,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 2,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 4,
+        "comment": ""
+    }
+}

--- a/strategy/137/0x0fefee13864c431717f5b2678607b6ce532a170c.json
+++ b/strategy/137/0x0fefee13864c431717f5b2678607b6ce532a170c.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/137/0x12c3ad898e8eb1c0ec0bb74f9748f36c46593f68.json
+++ b/strategy/137/0x12c3ad898e8eb1c0ec0bb74f9748f36c46593f68.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/137/0x2c5d0c3db75d2f8a4957c74be09194a9271cf28d.json
+++ b/strategy/137/0x2c5d0c3db75d2f8a4957c74be09194a9271cf28d.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 2,
+    "riskScore": {
+        "review": 2,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 3,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 2,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 2,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 4,
+        "comment": ""
+    }
+}

--- a/strategy/137/0x3bd8c987286d8ad00c05fdb2ae3e8c9a0f054734.json
+++ b/strategy/137/0x3bd8c987286d8ad00c05fdb2ae3e8c9a0f054734.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/137/0x4987d1856f93dff29e08aa605a805faf43dc3103.json
+++ b/strategy/137/0x4987d1856f93dff29e08aa605a805faf43dc3103.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 4,
+        "riskExposure": 4,
+        "protocolIntegration": 1,
+        "centralizationRisk": 5,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 4,
+        "externalProtocolLongevity": 5,
+        "externalProtocolType": 3,
+        "comment": ""
+    }
+}

--- a/strategy/137/0x52367c8e381edfb068e9fba1e7e9b2c847042897.json
+++ b/strategy/137/0x52367c8e381edfb068e9fba1e7e9b2c847042897.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/137/0x8bba7afd0f9b1b664c161ec31d812a8ec15f7e1a.json
+++ b/strategy/137/0x8bba7afd0f9b1b664c161ec31d812a8ec15f7e1a.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 2,
+    "riskScore": {
+        "review": 2,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 3,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 2,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 2,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 4,
+        "comment": ""
+    }
+}

--- a/strategy/137/0xb1403908f772e4374bb151f7c67e88761a0eb4f1.json
+++ b/strategy/137/0xb1403908f772e4374bb151f7c67e88761a0eb4f1.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/137/0xbeda9a5300393e00229dc15cc54d5185e7646c56.json
+++ b/strategy/137/0xbeda9a5300393e00229dc15cc54d5185e7646c56.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/137/0xdb92b89ca415c0dab40dc96e99fc411c08f20780.json
+++ b/strategy/137/0xdb92b89ca415c0dab40dc96e99fc411c08f20780.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/137/0xf4f9d5697341b4c9b0cc8151413e05a90f7dc24f.json
+++ b/strategy/137/0xf4f9d5697341b4c9b0cc8151413e05a90f7dc24f.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/42161/0x02822b7b6de0bf087dcea626f6f19a838aedb7be.json
+++ b/strategy/42161/0x02822b7b6de0bf087dcea626f6f19a838aedb7be.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 1,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": ""
+    }
+}

--- a/strategy/42161/0x08e3d13d50310afbea2da20a3dbd92aacfc503ac.json
+++ b/strategy/42161/0x08e3d13d50310afbea2da20a3dbd92aacfc503ac.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 5,
+        "complexity": 3,
+        "riskExposure": 4,
+        "protocolIntegration": 1,
+        "centralizationRisk": 4,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses."
+    }
+}

--- a/strategy/42161/0x0f2ae7531a83982f15ff1d26b165e2bf3d7566da.json
+++ b/strategy/42161/0x0f2ae7531a83982f15ff1d26b165e2bf3d7566da.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 2,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses."
+    }
+}

--- a/strategy/42161/0x127a7f610cc704be6122dfa76eb61e84c9cb0efd.json
+++ b/strategy/42161/0x127a7f610cc704be6122dfa76eb61e84c9cb0efd.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 2,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 2,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 2,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 4,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 4,
+        "comment": ""
+    }
+}

--- a/strategy/42161/0x1bd173f9a1186a1abe680071e0f57d4d83c18430.json
+++ b/strategy/42161/0x1bd173f9a1186a1abe680071e0f57d4d83c18430.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/42161/0x1dd930add968ff5913c3627daa1e6e6fcc9dc544.json
+++ b/strategy/42161/0x1dd930add968ff5913c3627daa1e6e6fcc9dc544.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 5,
+        "complexity": 3,
+        "riskExposure": 4,
+        "protocolIntegration": 1,
+        "centralizationRisk": 4,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses."
+    }
+}

--- a/strategy/42161/0x2b0b6376083c6e1f376c7439f328436a673f333c.json
+++ b/strategy/42161/0x2b0b6376083c6e1f376c7439f328436a673f333c.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 5,
+        "complexity": 3,
+        "riskExposure": 4,
+        "protocolIntegration": 1,
+        "centralizationRisk": 4,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses."
+    }
+}

--- a/strategy/42161/0x2d25ce68aad6ffef1585ff05bc621db1f9f2e499.json
+++ b/strategy/42161/0x2d25ce68aad6ffef1585ff05bc621db1f9f2e499.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 2,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 2,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 2,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 4,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 4,
+        "comment": ""
+    }
+}

--- a/strategy/42161/0x34a2b066af16409648ef15d239e656edb8790ca0.json
+++ b/strategy/42161/0x34a2b066af16409648ef15d239e656edb8790ca0.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 5,
+        "complexity": 3,
+        "riskExposure": 4,
+        "protocolIntegration": 1,
+        "centralizationRisk": 4,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses. Underlying SY contract which holds asset is upgradable"
+    }
+}

--- a/strategy/42161/0x45aceaa535830c921316085e355e4a32385e53f2.json
+++ b/strategy/42161/0x45aceaa535830c921316085e355e4a32385e53f2.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/42161/0x4ae5ce819e7d678b07e8d0f483d351e2c8e8b8d3.json
+++ b/strategy/42161/0x4ae5ce819e7d678b07e8d0f483d351e2c8e8b8d3.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/42161/0x5108db0852c0caa2df797dcf31f8a73bfb335452.json
+++ b/strategy/42161/0x5108db0852c0caa2df797dcf31f8a73bfb335452.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 2,
+    "riskScore": {
+        "review": 2,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 3,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 2,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 2,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 4,
+        "comment": ""
+    }
+}

--- a/strategy/42161/0x85968bf0f1f110c707fef10a59f80118f349c058.json
+++ b/strategy/42161/0x85968bf0f1f110c707fef10a59f80118f349c058.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/42161/0xa4b8873b4629c20f2167c0a2bc33b6af8699ddc1.json
+++ b/strategy/42161/0xa4b8873b4629c20f2167c0a2bc33b6af8699ddc1.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 2,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 2,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 2,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 4,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 4,
+        "comment": ""
+    }
+}

--- a/strategy/42161/0xaeba9f4a9293213e0e3ed18a2f688bddd7f5fb0c.json
+++ b/strategy/42161/0xaeba9f4a9293213e0e3ed18a2f688bddd7f5fb0c.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 5,
+        "complexity": 3,
+        "riskExposure": 4,
+        "protocolIntegration": 1,
+        "centralizationRisk": 4,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses."
+    }
+}

--- a/strategy/42161/0xb739ae19620f7ecb4fb84727f205453aa5bc1ad2.json
+++ b/strategy/42161/0xb739ae19620f7ecb4fb84727f205453aa5bc1ad2.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 2,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 2,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 2,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 4,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 4,
+        "comment": ""
+    }
+}

--- a/strategy/42161/0xc40da6a01ac36f39736731ee50fb3b1b8204e2d3.json
+++ b/strategy/42161/0xc40da6a01ac36f39736731ee50fb3b1b8204e2d3.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 3,
+    "riskScore": {
+        "review": 1,
+        "testing": 5,
+        "complexity": 3,
+        "riskExposure": 4,
+        "protocolIntegration": 1,
+        "centralizationRisk": 4,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 2,
+        "comment": "Withdrawals can incur losses if the PT-SY exchange rate drops. Waiting for market maturity eliminates potential losses."
+    }
+}

--- a/strategy/42161/0xcacc53bacce744ac7b5c1ec7eb7e3ab01330733b.json
+++ b/strategy/42161/0xcacc53bacce744ac7b5c1ec7eb7e3ab01330733b.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/42161/0xd89ee1e95f7728f6964cf321e2648ccd29a881f1.json
+++ b/strategy/42161/0xd89ee1e95f7728f6964cf321e2648ccd29a881f1.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 1,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 1,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 1,
+        "externalProtocolCentralisation": 1,
+        "externalProtocolTvl": 1,
+        "externalProtocolLongevity": 1,
+        "externalProtocolType": 1,
+        "comment": ""
+    }
+}

--- a/strategy/42161/0xe82d060687c014b280b65df24acd94a77251c784.json
+++ b/strategy/42161/0xe82d060687c014b280b65df24acd94a77251c784.json
@@ -1,0 +1,17 @@
+{
+    "riskLevel": 2,
+    "riskScore": {
+        "review": 3,
+        "testing": 1,
+        "complexity": 1,
+        "riskExposure": 2,
+        "protocolIntegration": 1,
+        "centralizationRisk": 1,
+        "externalProtocolAudit": 2,
+        "externalProtocolCentralisation": 3,
+        "externalProtocolTvl": 4,
+        "externalProtocolLongevity": 2,
+        "externalProtocolType": 4,
+        "comment": ""
+    }
+}


### PR DESCRIPTION
Goal of this PR is to bring all the risk scores stored in ydaemon/data/meta/vaults into current repo to have single source of truth

Related issue - https://github.com/yearn/ySHIP/issues/147
Generated via script - https://github.com/yearn/ydaemon/pull/521/files

