### PR TITLE
Feat/cdn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ htmlcov/
 *.log
 
 .cursorrules
+.vercel

--- a/api/cdn.ts
+++ b/api/cdn.ts
@@ -1,0 +1,127 @@
+export const config = { runtime: 'edge' }
+
+// @ts-ignore
+const REPO_OWNER = process.env.REPO_OWNER || 'yearn'
+// @ts-ignore  
+const REPO_NAME = process.env.REPO_NAME || 'risk-score'
+
+function getPath(url: URL) {
+  const schema = url.searchParams.get('schema')
+  const file = url.searchParams.get('file')
+  if (schema && file) {
+    return `${schema}/${file}`
+  }
+ console.info(url.pathname)
+  if (url.pathname.startsWith('/api/cdn/')) {
+    console.info(url.pathname.slice(9))
+    return url.pathname.slice(9) // Remove '/api/cdn/'
+  }
+  if (url.pathname.startsWith('/cdn/')) {
+    console.info(url.pathname.slice(5))
+    return url.pathname.slice(5) // Remove '/cdn/'
+  }
+
+  return undefined
+}
+
+export default async function (req: Request): Promise<Response> {
+  console.info(req.method)
+  if (req.method === 'OPTIONS') {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        'access-control-allow-origin': '*',
+        'access-control-allow-methods': 'GET, OPTIONS',
+        'access-control-allow-headers': '*',
+        'access-control-max-age': '86400',
+      },
+    })
+  }
+
+  if (req.method !== 'GET') {
+    return new Response('bad method', { status: 405 })
+  }
+
+  try {
+    const url = new URL(req.url)
+    const startsWithApiCdn = url.pathname.startsWith('/api/cdn/')
+    const startsWithCdn = url.pathname.startsWith('/cdn/')
+    console.info(startsWithApiCdn, startsWithCdn)
+    if (!(startsWithApiCdn || startsWithCdn)) return new Response('bad path', { status: 400 })
+
+    const path = getPath(url)
+    if (!path) {
+      return new Response('missing path', { status: 400 })
+    }
+
+    if (!/^[a-zA-Z0-9/_.-]+$/.test(path) || path.includes('..')) {
+      return new Response('invalid path', { status: 400 })
+    }
+
+    // @ts-ignore
+    const HEAD = process.env.VERCEL_GIT_COMMIT_SHA || 'main'
+    const upstream = `https://cdn.jsdelivr.net/gh/${REPO_OWNER}/${REPO_NAME}@${HEAD}/${path}`
+
+    const response = await fetch(upstream)
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        return new Response('file not found', { status: 404 })
+      }
+      return new Response('upstream error', { status: response.status })
+    }
+
+    const content = await response.text()
+    
+    // Determine content type based on file extension
+    const contentType = getContentType(path)
+    
+    return new Response(content, {
+      headers: {
+        'content-type': contentType,
+        'access-control-allow-origin': '*',
+        'cache-control': 'public, max-age=3600',
+      },
+    })
+  } catch (error) {
+    console.error('CDN error:', error)
+    return new Response('internal server error', { status: 500 })
+  }
+}
+
+function getContentType(path: string): string {
+  const extension = path.split('.').pop()?.toLowerCase()
+  
+  switch (extension) {
+    case 'json':
+      return 'application/json'
+    case 'js':
+      return 'application/javascript'
+    case 'ts':
+      return 'text/typescript'
+    case 'css':
+      return 'text/css'
+    case 'html':
+      return 'text/html'
+    case 'md':
+      return 'text/markdown'
+    case 'txt':
+      return 'text/plain'
+    case 'xml':
+      return 'application/xml'
+    case 'yaml':
+    case 'yml':
+      return 'text/yaml'
+    case 'png':
+      return 'image/png'
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg'
+    case 'gif':
+      return 'image/gif'
+    case 'svg':
+      return 'image/svg+xml'
+    default:
+      return 'text/plain'
+  }
+}

--- a/api/cdn.ts
+++ b/api/cdn.ts
@@ -39,14 +39,11 @@ export default async function handler(req: Request): Promise<Response> {
 
   try {
     const url = new URL(req.url)
-    console.info(url.pathname)
     const startsWithApiCdn = url.pathname.startsWith('/api/cdn/')
     const startsWithCdn = url.pathname.startsWith('/cdn/')
-    console.info(startsWithApiCdn, startsWithCdn)
     if (!(startsWithApiCdn || startsWithCdn)) return new Response('bad path', { status: 400 })
 
     const path = getPath(url)
-    console.info(path)
     if (!path) {
       return new Response('missing path', { status: 400 })
     }

--- a/api/cdn.ts
+++ b/api/cdn.ts
@@ -1,7 +1,8 @@
 export const config = { runtime: 'edge' }
 
-const REPO_OWNER = 'w84april'
+const REPO_OWNER = 'yearn'
 const REPO_NAME = 'risk-score'
+const HEAD = 'master'
 
 function getPath(url: URL) {
   const schema = url.searchParams.get('schema')
@@ -52,7 +53,6 @@ export default async function handler(req: Request): Promise<Response> {
       return new Response('invalid path', { status: 400 })
     }
 
-    const HEAD = 'master'
     const upstream = `https://cdn.jsdelivr.net/gh/${REPO_OWNER}/${REPO_NAME}@${HEAD}/${path}`
 
     const response = await fetch(upstream)

--- a/api/cdn.ts
+++ b/api/cdn.ts
@@ -1,9 +1,7 @@
 export const config = { runtime: 'edge' }
 
-// @ts-ignore
-const REPO_OWNER = process.env.REPO_OWNER || 'yearn'
-// @ts-ignore  
-const REPO_NAME = process.env.REPO_NAME || 'risk-score'
+const REPO_OWNER = 'w84april'
+const REPO_NAME = 'risk-score'
 
 function getPath(url: URL) {
   const schema = url.searchParams.get('schema')
@@ -11,21 +9,18 @@ function getPath(url: URL) {
   if (schema && file) {
     return `${schema}/${file}`
   }
- console.info(url.pathname)
+  
   if (url.pathname.startsWith('/api/cdn/')) {
-    console.info(url.pathname.slice(9))
     return url.pathname.slice(9) // Remove '/api/cdn/'
   }
   if (url.pathname.startsWith('/cdn/')) {
-    console.info(url.pathname.slice(5))
     return url.pathname.slice(5) // Remove '/cdn/'
   }
 
   return undefined
 }
 
-export default async function (req: Request): Promise<Response> {
-  console.info(req.method)
+export default async function handler(req: Request): Promise<Response> {
   if (req.method === 'OPTIONS') {
     return new Response(null, {
       status: 204,
@@ -44,22 +39,23 @@ export default async function (req: Request): Promise<Response> {
 
   try {
     const url = new URL(req.url)
+    console.info(url.pathname)
     const startsWithApiCdn = url.pathname.startsWith('/api/cdn/')
     const startsWithCdn = url.pathname.startsWith('/cdn/')
     console.info(startsWithApiCdn, startsWithCdn)
     if (!(startsWithApiCdn || startsWithCdn)) return new Response('bad path', { status: 400 })
 
     const path = getPath(url)
+    console.info(path)
     if (!path) {
       return new Response('missing path', { status: 400 })
     }
 
-    if (!/^[a-zA-Z0-9/_.-]+$/.test(path) || path.includes('..')) {
+    if (!/^[a-zA-Z0-9/_.-]+$/i.test(path) || path.includes('..')) {
       return new Response('invalid path', { status: 400 })
     }
 
-    // @ts-ignore
-    const HEAD = process.env.VERCEL_GIT_COMMIT_SHA || 'main'
+    const HEAD = 'master'
     const upstream = `https://cdn.jsdelivr.net/gh/${REPO_OWNER}/${REPO_NAME}@${HEAD}/${path}`
 
     const response = await fetch(upstream)

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,12 @@
 {
-  "functions": {
-    "api/cdn.ts": {
-      "runtime": "edge"
+  "rewrites": [
+    {
+      "source": "/cdn/:path*",
+      "destination": "/api/cdn"
+    },
+    {
+      "source": "/api/cdn/:path*",
+      "destination": "/api/cdn"
     }
-  }
+  ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "api/cdn.ts": {
+      "runtime": "edge"
+    }
+  }
+}


### PR DESCRIPTION
## CDN API
This PR contains a Vercel Edge Function that serves as a CDN proxy for the risk-score repository files.
## Why This Approach?
1. **CORS Headers**: Automatically adds `Access-Control-Allow-Origin: *` headers, enabling cross-origin requests from any domain
2. **Content Type Detection**: Automatically sets the correct `Content-Type` based on file extension
3. **Edge Performance**: Runs on Vercel's Edge Network for low latency globally
4. **Path Security**: Validates paths to prevent directory traversal attacks

## Related issue
https://github.com/orgs/yearn/projects/38/views/2?pane=issue&itemId=126596911&issue=yearn%7CySHIP%7C150

## How was it tested
Tested manually according to Acceptance Criteria described in issue above. You can also try it yourself - [link](https://risk-score-git-feat-cdn-yearn.vercel.app/api/cdn/strategy/1/0x000000000000000000000000000000000000dead.json) 