### PR TITLE
Risk Assessment: Flying Tulip — FT Lend + ftUSD/sftUSD (#234)

### DIFF
--- a/reports/graph/flying-tulip-ftusd.yaml
+++ b/reports/graph/flying-tulip-ftusd.yaml
@@ -37,7 +37,7 @@ nodes:
     label: MintAndRedeem
     address: "0xAa48EcBC843cF7E9A29155D112b8Cb27902bD23C"
     category: infra
-    note: Only enabled mint module. 7 bps in/out. Redeem capacity capped by FT Lend cash - USDT ~15% short. Rate-limited 10%/window, 6h delay
+    note: Only enabled mint module; collateralized. 7 bps in/out. Redemption first rate-limited 10%/window with 6h delay; USDT cash covers 89.2% of capital
   - id: ftusd-oracle
     label: ftUSD Oracle Proxy
     address: "0xA69f7a38B6c91a4bc2477f097DC8a1F16DAADFf8"
@@ -113,7 +113,7 @@ nodes:
     label: Curve ftUSD/USDC
     address: "0xafec61e7a604f8f81f7cab64ec75bfa07c542630"
     category: dependency
-    note: StableSwap-NG ~1.87M, 500K clears at 0.30%. NOT independent - 100% of LP is a Curve gauge, 99.998% of the gauge is ONE EOA, gauge manager is an admin Safe signer
+    note: StableSwap-NG ~$249K after >85% decline. 100K clears at ~0.38%; 150K incurs ~13.75%. Gauge custody is 87.1% Convex voter proxy, 7.1% EOA, 5.6% CurveYCRVVoter
   - id: dep-morpho
     label: Morpho (2 ftUSD markets)
     address: "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb"
@@ -254,7 +254,7 @@ edges:
   - from: ftusd
     to: dep-curve
     kind: routes-through
-    label: only external exit and price reference
+    label: thin secondary exit and external price reference
   - from: ftusd
     to: dep-morpho
     kind: routes-through

--- a/reports/graph/flying-tulip-ftusd.yaml
+++ b/reports/graph/flying-tulip-ftusd.yaml
@@ -53,6 +53,21 @@ nodes:
     address: "0x8263a07504d93cB95e0a74f3627bb15faaf140e2"
     category: infra
     note: Executes hedge orders. broadcastOrder has no oracle and no price bound
+  - id: trs-leverage-engine
+    label: TRS LeverageRfqEngine v2
+    address: "0x93496075909f56d93b33302DF5D1655568Eb6e70"
+    category: infra
+    note: Signed OPEN/CLOSE/SWAP orders; registered on the same FT Lend PositionsManager
+  - id: trs-session-manager
+    label: TRS SessionManager
+    address: "0x880A371CE2C5Dbb2EB47EC0023b358e8aE80071b"
+    category: infra
+    note: Delegated session authorization for TRS orders
+  - id: trs-executor
+    label: TRS Permissioned Executor
+    address: "0xa505815A526f1200c17B7ffaE0067318d734b9d8"
+    category: infra
+    note: Permissioned filler; EIP-7702 delegation target source unverified at September 4 check
 
   # === Backing custody ===
   - id: ftusd-usdc-wrapper
@@ -81,7 +96,7 @@ nodes:
     label: Admin Safe (3/5)
     address: "0x1118e1c057211306a40A4d7006C040dbfE1370Cb"
     category: governance
-    note: No timelock. ftUSD owner + masterMinter + pauser + blacklister; owner of every contract here
+    note: No timelock. ftUSD owner + masterMinter + pauser + blacklister; admin of core ftUSD and TRS engine contracts
   - id: strategy-operator-safe
     label: Strategy Operator Safe (3/5)
     address: "0x5557729b169082f07d3131D560E2f2cb5e6c48f6"
@@ -134,6 +149,10 @@ nodes:
     address: "0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6"
     category: dependency
     note: Base leg of the ftUSD oracle
+  - id: dep-trs-routes
+    label: TRS Conditional Swap Routes
+    category: dependency
+    note: KyberSwap, Velora, 0x, self-fill and ftUSD mint/redeem composite routes; no funded independent exit depth verified
 
 edges:
   # === Governance ===
@@ -165,6 +184,10 @@ edges:
     to: ftusd-oracle
     kind: controls
     label: owner - pause, bounds, staleness
+  - from: admin-safe
+    to: trs-leverage-engine
+    kind: controls
+    label: admin - upgrade, permissioned fillers and session configuration
   - from: epoch-settler
     to: sftusd
     kind: holds-role
@@ -255,6 +278,26 @@ edges:
     to: dep-curve
     kind: routes-through
     label: thin secondary exit and external price reference
+  - from: ftusd
+    to: trs-leverage-engine
+    kind: routes-through
+    label: conditional signed collateral swap
+  - from: trs-leverage-engine
+    to: trs-session-manager
+    kind: routes-through
+    label: delegated user authorization
+  - from: trs-executor
+    to: trs-leverage-engine
+    kind: holds-role
+    label: permissioned filler
+  - from: trs-executor
+    to: dep-trs-routes
+    kind: routes-through
+    label: sources RFQ execution
+  - from: dep-trs-routes
+    to: mint-and-redeem
+    kind: routes-through
+    label: mintredeem/composite path reuses queue capacity
   - from: ftusd
     to: dep-morpho
     kind: routes-through

--- a/reports/graph/flying-tulip-ftusd.yaml
+++ b/reports/graph/flying-tulip-ftusd.yaml
@@ -1,0 +1,273 @@
+slug: flying-tulip-ftusd
+title: Flying Tulip ftUSD and Staked ftUSD - Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Token / Vault
+  - id: strategy
+    label: Backing Custody
+  - id: governance
+    label: Governance
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === Token / vault layer ===
+  - id: ftusd
+    label: ftUSD
+    address: "0xF7D85EC4E7710f71992752eac2111312e73E9C9C"
+    category: vault
+    note: FiatToken-style stablecoin, 6 dec, UUPS. Supply 4,196,697. blacklist + wipeBlacklistedAddress
+  - id: sftusd
+    label: sftUSD (Staked ftUSD)
+    address: "0xeb48218a4c35C814C7678cBcae88C6Ee037F7625"
+    category: vault
+    note: ERC-4626-style vault, 1,324,455 staked, 107 holders. Rate fixed at 1.000000 - yield is FT emissions only. Has its own wipeBlacklistedAddress
+
+  # === Protocol infra ===
+  - id: ftusd-core
+    label: ftUSD Core
+    address: "0x56c5892B0cF41B792217CCDD208f0FA85B178ca9"
+    category: infra
+    note: Sole minter(). Debt-ceiling module gate, globalDebtCeiling 100M
+  - id: mint-and-redeem
+    label: MintAndRedeem
+    address: "0xAa48EcBC843cF7E9A29155D112b8Cb27902bD23C"
+    category: infra
+    note: Only enabled mint module. 7 bps in/out. Redeem capacity capped by FT Lend cash - USDT ~15% short. Rate-limited 10%/window, 6h delay
+  - id: ftusd-oracle
+    label: ftUSD Oracle Proxy
+    address: "0xA69f7a38B6c91a4bc2477f097DC8a1F16DAADFf8"
+    category: infra
+    note: FtUsdMintRedeemOracleProxy - price = f(USDC price, cumulative mint history). Structurally BLIND to ftUSD backing; 0 bps deviation tolerance
+  - id: staking-breaker
+    label: Staking CircuitBreaker
+    address: "0xCB210509F5AE2b3843B7Fb8Bb90bAFF9cE4f7355"
+    category: infra
+    note: 10% of TVL per window, 6h settlement delay, admin-settable up to 7 days
+  - id: leverage-engine
+    label: LeverageRfqEngine
+    address: "0x8263a07504d93cB95e0a74f3627bb15faaf140e2"
+    category: infra
+    note: Executes hedge orders. broadcastOrder has no oracle and no price bound
+
+  # === Backing custody ===
+  - id: ftusd-usdc-wrapper
+    label: ftUSD USDC Wrapper
+    address: "0x6aaf84563Cdb03a22Cd92EE2553698beE87E837D"
+    category: strategy
+    note: Holds 2,781,367 USDC of backing
+  - id: ftusd-usdt-wrapper
+    label: ftUSD USDT Wrapper
+    address: "0x28CCa8eEA2cD0498cE91A9da15772A1ce42347D6"
+    category: strategy
+    note: Holds 1,417,610 USDT of backing
+  - id: ftftusd-wrapper
+    label: ftftUSD Wrapper
+    address: "0xB44a9C40EFc05Eb014EfFEac3CBed6A31F8cB87f"
+    category: strategy
+    note: ftYieldWrapperV2 holding staked ftUSD. 0 strategies configured, deployed = 0
+  - id: delta-neutral
+    label: Delta Neutral Strategy
+    address: "0xe0E445967256EE60111e243e0F0F94DD1D351A59"
+    category: strategy
+    note: MultiCollateralDeltaNeutralStakingStrategy. Deploys 100% of backing into FT Lend. Order validation has NO price or slippage bound
+
+  # === Governance ===
+  - id: admin-safe
+    label: Admin Safe (3/5)
+    address: "0x1118e1c057211306a40A4d7006C040dbfE1370Cb"
+    category: governance
+    note: No timelock. ftUSD owner + masterMinter + pauser + blacklister; owner of every contract here
+  - id: strategy-operator-safe
+    label: Strategy Operator Safe (3/5)
+    address: "0x5557729b169082f07d3131D560E2f2cb5e6c48f6"
+    category: governance
+    note: Identical five signers to the admin Safe
+  - id: strategy-operator-eoa
+    label: Strategy Operator (EOA)
+    address: "0x8dc8f616af6c146906b218f2acbdc2d27c9ac221"
+    category: governance
+    note: PLAIN EOA, codesize 0. Granted operator August 3 2026. Can pre-sign trades of the backing at an arbitrary price
+  - id: epoch-settler
+    label: Epoch Settler
+    address: "0xBAE14f050Fb8cDa4D16ab47DBEC67793c7c0b566"
+    category: governance
+    note: Funds FT reward epochs. Discretionary - nothing obliges it
+  - id: yield-claimer
+    label: YieldClaimer
+    address: "0x88432bB6EA62e774cB6d87995CC5277568d01397"
+    category: governance
+    note: Holds wrapper execute() arbitrary-call and forceWithdrawToWrapper
+
+  # === External dependencies ===
+  - id: dep-ftlend
+    label: FT Lend (PositionsManager)
+    address: "0xbe4050a73a7Fb384c65E885a15C33461A4B20055"
+    category: dependency
+    note: Holds 100% of ftUSD backing. See the companion FT Lend report
+  - id: dep-curve
+    label: Curve ftUSD/USDC
+    address: "0xafec61e7a604f8f81f7cab64ec75bfa07c542630"
+    category: dependency
+    note: StableSwap-NG ~1.87M, 500K clears at 0.30%. NOT independent - 100% of LP is a Curve gauge, 99.998% of the gauge is ONE EOA, gauge manager is an admin Safe signer
+  - id: dep-morpho
+    label: Morpho (2 ftUSD markets)
+    address: "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb"
+    category: dependency
+    note: USDC/ftUSD Blue markets at 86% and 91.5% LLTV. Holds 629,675 ftUSD (15% of supply). Live market 90.1% utilized
+  - id: morpho-oracle
+    label: Morpho ftUSD Oracle
+    address: "0x7887afbe7581eb01b3d91d80c198b0275feab779"
+    category: dependency
+    note: MorphoChainlinkOracleV2. BASE_FEED_1 is Flying Tulip's OWN ftUSD feed - Morpho does not price ftUSD independently
+  - id: dep-lido
+    label: Lido / wstETH
+    address: "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"
+    category: dependency
+    note: Hedge staking leg, 76.54 wstETH held as FT Lend collateral
+  - id: dep-chainlink
+    label: Chainlink USDC/USD
+    address: "0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6"
+    category: dependency
+    note: Base leg of the ftUSD oracle
+
+edges:
+  # === Governance ===
+  - from: admin-safe
+    to: ftusd
+    kind: mints
+    label: masterMinter can enable an arbitrary mint module
+  - from: admin-safe
+    to: ftusd-core
+    kind: controls
+    label: owner - module enablement and debt ceiling
+  - from: admin-safe
+    to: mint-and-redeem
+    kind: controls
+    label: owner - fees, caps, sweepExcess, recoverERC20
+  - from: admin-safe
+    to: sftusd
+    kind: controls
+    label: owner - upgrade, pause, wipeBlacklistedAddress
+  - from: admin-safe
+    to: staking-breaker
+    kind: controls
+    label: owner - settlementDelay up to 7 days
+  - from: admin-safe
+    to: delta-neutral
+    kind: controls
+    label: owner - setOperator, setLeverageEngine, execute()
+  - from: admin-safe
+    to: ftusd-oracle
+    kind: controls
+    label: owner - pause, bounds, staleness
+  - from: epoch-settler
+    to: sftusd
+    kind: holds-role
+    label: settleEpoch - discretionary FT rewards
+  - from: strategy-operator-safe
+    to: delta-neutral
+    kind: holds-role
+    label: operator - approves hedge orders
+  - from: strategy-operator-eoa
+    to: delta-neutral
+    kind: holds-role
+    label: operator - EOA, unbounded order price
+  - from: yield-claimer
+    to: ftusd-usdc-wrapper
+    kind: holds-role
+    label: execute() arbitrary call
+  - from: yield-claimer
+    to: ftusd-usdt-wrapper
+    kind: holds-role
+    label: execute() arbitrary call
+
+  # === Mint path ===
+  - from: mint-and-redeem
+    to: ftusd-core
+    kind: routes-through
+    label: collateralized mint/redeem entry
+  - from: ftusd-core
+    to: ftusd
+    kind: mints
+    label: sole minter, module-gated
+
+  # === Backing custody chain ===
+  - from: mint-and-redeem
+    to: ftusd-usdc-wrapper
+    kind: allocates-to
+    label: deposits USDC on mint
+  - from: mint-and-redeem
+    to: ftusd-usdt-wrapper
+    kind: allocates-to
+    label: deposits USDT on mint
+  - from: ftusd-usdc-wrapper
+    to: delta-neutral
+    kind: deposits-into
+    label: "2.78M USDC"
+  - from: ftusd-usdt-wrapper
+    to: delta-neutral
+    kind: deposits-into
+    label: "1.42M USDT"
+  - from: delta-neutral
+    to: dep-ftlend
+    kind: deposits-into
+    label: 100% of backing - 35.1% of FT Lend TVL
+  - from: delta-neutral
+    to: leverage-engine
+    kind: routes-through
+    label: hedge orders, no price bound
+  - from: delta-neutral
+    to: dep-lido
+    kind: routes-through
+    label: wstETH staking leg
+
+  # === Staking path ===
+  - from: sftusd
+    to: ftftusd-wrapper
+    kind: allocates-to
+    label: 1,324,455 ftUSD held idle
+  - from: ftftusd-wrapper
+    to: staking-breaker
+    kind: routes-through
+    label: 10%/window outflow limit
+  - from: sftusd
+    to: ftusd
+    kind: routes-through
+    label: underlying asset
+
+  # === Pricing ===
+  - from: ftusd-oracle
+    to: mint-and-redeem
+    kind: routes-through
+    label: reads redeem factors - USDC price + mint history, not collateral
+  - from: ftusd-oracle
+    to: dep-chainlink
+    kind: routes-through
+    label: USDC/USD base leg
+
+  # === External venues ===
+  - from: ftusd
+    to: dep-curve
+    kind: routes-through
+    label: only external exit and price reference
+  - from: ftusd
+    to: dep-morpho
+    kind: routes-through
+    label: 629,675 posted as collateral (15% of supply)
+  - from: dep-morpho
+    to: morpho-oracle
+    kind: routes-through
+    label: prices ftUSD collateral
+  - from: morpho-oracle
+    to: ftusd-oracle
+    kind: routes-through
+    label: BASE_FEED_1 - backing-blindness propagates to Morpho
+  - from: morpho-oracle
+    to: dep-chainlink
+    kind: routes-through
+    label: QUOTE_FEED_1 USDC/USD

--- a/reports/graph/flying-tulip-ftusd.yaml
+++ b/reports/graph/flying-tulip-ftusd.yaml
@@ -37,7 +37,7 @@ nodes:
     label: MintAndRedeem
     address: "0xAa48EcBC843cF7E9A29155D112b8Cb27902bD23C"
     category: infra
-    note: Only enabled mint module; collateralized. 7 bps in/out. Redemption first rate-limited 10%/window with 6h delay; USDT cash covers 89.2% of capital
+    note: Only enabled mint module; collateralized. 7 bps in/out. Sells above live instant capacity enter a 6h queue; observed frontend threshold was 0 ftUSD. USDT cash covers 89.2% of capital
   - id: ftusd-oracle
     label: ftUSD Oracle Proxy
     address: "0xA69f7a38B6c91a4bc2477f097DC8a1F16DAADFf8"

--- a/reports/graph/flying-tulip.yaml
+++ b/reports/graph/flying-tulip.yaml
@@ -44,10 +44,30 @@ nodes:
     category: infra
     note: Chainlink-anchored prices; owner can override last good price
   - id: rfq-engine
-    label: RFQ Engines
+    label: Legacy RFQ Engine
     address: "0xEB00B335Ca52216Fb60fdFFA361397367C39Dc32"
     category: infra
-    note: RfqEngine plus LeverageRfqEngine for routed liquidations
+    note: Original RfqEngine liquidation module; remains authorized
+  - id: rfq-engine-v2
+    label: RFQ Engine v2
+    address: "0xc64516d58f8b83bc256448bc69d7bf2361557fdb"
+    category: infra
+    note: Added August 22, 2026 as PositionsManager engine and second liquidation module
+  - id: trs-leverage-engine
+    label: TRS LeverageRfqEngine v2
+    address: "0x93496075909f56d93b33302DF5D1655568Eb6e70"
+    category: infra
+    note: Signed OPEN/CLOSE/SWAP orders; permissioned fillers; user/session allowances and post-fill health checks
+  - id: trs-session-manager
+    label: TRS SessionManager
+    address: "0x880A371CE2C5Dbb2EB47EC0023b358e8aE80071b"
+    category: infra
+    note: Delegated session authorization used by the live TRS frontend
+  - id: trs-executor
+    label: TRS Permissioned Executor
+    address: "0xa505815A526f1200c17B7ffaE0067318d734b9d8"
+    category: infra
+    note: Authorized filler; EIP-7702 delegation target source unverified at September 4 check
   - id: lend-circuit-breaker
     label: Lend CircuitBreaker
     address: "0x9676E697399581AB288844cDE5F73d0887eC18e0"
@@ -187,10 +207,10 @@ nodes:
     address: "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb"
     category: dependency
     note: Holds 629,675 ftUSD as collateral. Third-party acceptance and an outward propagation channel
-  - id: dep-spot-clob
-    label: FT Spot AMM / CLOB (not wired in)
+  - id: dep-trs-routes
+    label: TRS Execution Routes
     category: dependency
-    note: Verified absent from the deployed contracts - no depth or volatility input exists in ConfigRegistry or PositionsManager, and no AMM is registered as an engine. The documented dynamic LTV is not implemented onchain
+    note: KyberSwap, Velora, 0x, internal self-fill, ftUSD MintAndRedeem and composite routes. Dynamic LTV remains unimplemented
   - id: dep-permit2
     label: Permit2
     address: "0xEB450d21ae68D3303Cf5775A54Cc84EE7c3fC8eC"
@@ -234,6 +254,14 @@ edges:
     to: lend-circuit-breaker
     kind: controls
     label: owner - can pause or reconfigure the breaker
+  - from: admin-safe
+    to: rfq-engine-v2
+    kind: controls
+    label: admin - upgrade, liquidator roles and liquidation parameters
+  - from: admin-safe
+    to: trs-leverage-engine
+    kind: controls
+    label: admin - upgrade, fillers, sessions and batch module
   - from: admin-safe
     to: usdc-wrapper
     kind: controls
@@ -361,15 +389,35 @@ edges:
   - from: positions-manager
     to: rfq-engine
     kind: routes-through
-    label: liquidations / RFQ
+    label: legacy liquidations
+  - from: positions-manager
+    to: rfq-engine-v2
+    kind: routes-through
+    label: v2 RFQ liquidations and Trade
+  - from: positions-manager
+    to: trs-leverage-engine
+    kind: routes-through
+    label: TRS borrowing and collateral swaps
   - from: positions-manager
     to: relayer-session
     kind: manages
-    label: meta-actions / session layer
-  - from: rfq-engine
-    to: dep-spot-clob
+    label: legacy meta-actions / session layer
+  - from: trs-leverage-engine
+    to: trs-session-manager
     kind: routes-through
-    label: liquidation venue
+    label: delegated user authorization
+  - from: trs-executor
+    to: trs-leverage-engine
+    kind: holds-role
+    label: permissioned filler
+  - from: trs-executor
+    to: dep-trs-routes
+    kind: routes-through
+    label: constructs and executes spot route
+  - from: dep-trs-routes
+    to: mint-and-redeem
+    kind: routes-through
+    label: ftUSD mint/redeem and composite routes
   - from: relayer-session
     to: dep-permit2
     kind: routes-through

--- a/reports/graph/flying-tulip.yaml
+++ b/reports/graph/flying-tulip.yaml
@@ -1,0 +1,431 @@
+slug: flying-tulip
+title: Flying Tulip FT Lend - Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Market / Token
+  - id: strategy
+    label: Yield Wrapper
+  - id: governance
+    label: Governance
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === Market / token layer ===
+  - id: positions-manager
+    label: PositionsManager
+    address: "0xbe4050a73a7Fb384c65E885a15C33461A4B20055"
+    category: vault
+    note: Core FT Lend engine; UUPS proxy
+  - id: ftusd
+    label: ftUSD
+    address: "0xF7D85EC4E7710f71992752eac2111312e73E9C9C"
+    category: vault
+    note: FiatToken-style stablecoin; collateral asset in FT Lend
+  - id: ft-token
+    label: FT Token
+    address: "0x5DD1A7A369e8273371d2DBf9d83356057088082c"
+    category: vault
+    note: Enabled long-tail asset; not borrowable/collateral in assessed market
+
+  # === Internal protocol infra ===
+  - id: config-registry
+    label: ConfigRegistry
+    address: "0xA8777c3D446fa7F0b0FC97a80C1Ea1d37F1ca33E"
+    category: infra
+    note: Asset configs, margins, caps, IRMs, oracle pointer
+  - id: oracle-router
+    label: OracleRouterChainlink
+    address: "0xe4372dB43D2814750a19b93950157AD81D93674A"
+    category: infra
+    note: Chainlink-anchored prices; owner can override last good price
+  - id: rfq-engine
+    label: RFQ Engines
+    address: "0xEB00B335Ca52216Fb60fdFFA361397367C39Dc32"
+    category: infra
+    note: RfqEngine plus LeverageRfqEngine for routed liquidations
+  - id: lend-circuit-breaker
+    label: Lend CircuitBreaker
+    address: "0x9676E697399581AB288844cDE5F73d0887eC18e0"
+    category: infra
+    note: Emergency flow halt; owned by the admin Safe, guardian can trip it. Wrappers can unset it (setCircuitBreaker to address zero)
+  - id: pm-wrapper
+    label: PMWrapper
+    address: "0xBDD80028c9e4b9A2D268D2cF62Fb54Ec8697C68B"
+    category: infra
+    note: Admin wrapper for PositionsManager upgrades, caps, pauses, reserves
+  - id: ftusd-core
+    label: ftUSD Core
+    address: "0x56c5892B0cF41B792217CCDD208f0FA85B178ca9"
+    category: infra
+    note: Sole ftUSD minter at assessment block
+  - id: mint-and-redeem
+    label: MintAndRedeem
+    address: "0xAa48EcBC843cF7E9A29155D112b8Cb27902bD23C"
+    category: infra
+    note: User collateral in, ftUSD out
+  - id: ftusd-usdc-wrapper
+    label: ftUSD USDC YieldWrapper
+    address: "0x6aaf84563Cdb03a22Cd92EE2553698beE87E837D"
+    category: strategy
+    note: Holds ftUSD USDC backing (2.77M); separate from the FT Lend USDC wrapper
+  - id: ftusd-usdt-wrapper
+    label: ftUSD USDT YieldWrapper
+    address: "0x28CCa8eEA2cD0498cE91A9da15772A1ce42347D6"
+    category: strategy
+    note: Holds ftUSD USDT backing (1.42M)
+  - id: delta-neutral
+    label: Delta Neutral Strategy
+    address: "0xe0E445967256EE60111e243e0F0F94DD1D351A59"
+    category: strategy
+    note: MultiCollateralDeltaNeutralStakingStrategy - deploys ftUSD backing INTO FT Lend (35.1% of TVL). Hedge leg live since ~Aug 3 - 76.5 wstETH collateral, 95.0 WETH borrowed
+  - id: relayer-session
+    label: Relayer / Sessions
+    address: "0x823a97a2c32985e0f5457fc8103F36698D1F53F4"
+    category: infra
+    note: RelayerAuth plus SessionManager and meta-action modules
+
+  # === Yield wrappers / strategies ===
+  - id: usdc-wrapper
+    label: USDC YieldWrapper
+    address: "0xD2e4A5ac4B4Da102317cF7C9A1289aDF082639E2"
+    category: strategy
+  - id: weth-wrapper
+    label: WETH YieldWrapper
+    address: "0x460494aF61BcB92B59797B4e09C26A5ADecb2da2"
+    category: strategy
+  - id: usdt-wrapper
+    label: USDT YieldWrapper
+    address: "0x28b0905d83BCe5FFA6c54651F25858828A38123B"
+    category: strategy
+  - id: wbtc-wrapper
+    label: WBTC YieldWrapper
+    address: "0x1A5730c71576D77048E9FdC79DD40e4B1E8Fe042"
+    category: strategy
+  - id: ftusd-wrapper
+    label: ftUSD YieldWrapper
+    address: "0xc67D966f761e8cf13Faa0a1E774425290c8453d9"
+    category: strategy
+    note: No strategy configured at assessment block; idle ftUSD held in wrapper
+  - id: wsteth-wrapper
+    label: wstETH YieldWrapper
+    address: "0x01980BD1B58313bD3767f6adc75Af8b6464f3db7"
+    category: strategy
+    note: No strategy configured; zero balance at assessment block
+  - id: ft-wrapper
+    label: FT YieldWrapper
+    address: "0x7127BB9d9ad0f47B8dA9087e634D67F3946F840E"
+    category: strategy
+    note: No strategy configured; circuit breaker unset (address zero)
+
+  # === Governance ===
+  - id: admin-safe
+    label: Admin Safe (3/5)
+    address: "0x1118e1c057211306a40A4d7006C040dbfE1370Cb"
+    category: governance
+    note: No timelock; root owner/masterMinter/pauser/blacklister
+  - id: guardian-safe
+    label: Guardian Safe (3/4)
+    address: "0x22246a9183cE2CE6e2c2a9973F94aEA91435017C"
+    category: governance
+    note: Signers overlap with admin Safe; pause/oracle guardian
+  - id: fee-collector
+    label: Fee Collector
+    address: "0x5cd6Abe67f8af1C0c699dF36d90a6469Eaf1958a"
+    category: governance
+    note: Receives reserves/fees and settles epochs
+  - id: wbtc-strategy-manager
+    label: WBTC Strategy Mgr Safe (3/5)
+    address: "0x5557729b169082f07d3131D560E2f2cb5e6c48f6"
+    category: governance
+    note: Third Safe with the same five signers as the admin Safe; strategyManager of the WBTC wrapper only
+  - id: yield-claimer
+    label: YieldClaimer
+    address: "0x88432bB6EA62e774cB6d87995CC5277568d01397"
+    category: governance
+    note: Holds wrapper execute() arbitrary-call and forceWithdrawToWrapper
+
+  # === External dependencies ===
+  - id: dep-aave
+    label: Aave
+    category: dependency
+    note: Idle supply venue for yield wrappers
+  - id: dep-spark
+    label: Spark
+    category: dependency
+    note: Idle supply venue for yield wrappers
+  - id: oracle-wrapper-wbtc
+    label: WBTC Oracle Wrapper
+    address: "0x183dB475d8184aA7a018ed2164e11A887afBDA55"
+    category: infra
+    note: ChainlinkLatestAnswerProxy - immutable base feed (CL BTC/USD) + Aave peg adapter; owner can pause but not repoint
+  - id: oracle-wrapper-wsteth
+    label: wstETH Oracle Wrapper
+    address: "0x000bb128a8aBCFa05B871C97CC9C5f88e7Dcf35a"
+    category: infra
+    note: ChainlinkLatestAnswerProxy - immutable base feed (CL ETH/USD) + Aave WstETHPriceCapAdapter
+  - id: oracle-wrapper-ftusd
+    label: ftUSD Oracle Wrapper
+    address: "0xA69f7a38B6c91a4bc2477f097DC8a1F16DAADFf8"
+    category: infra
+    note: FtUsdMintRedeemOracleProxy - prices ftUSD from the USDC price and cumulative mint history. Does NOT read ftUSD collateral; 0 bps deviation tolerance
+  - id: dep-chainlink
+    label: Chainlink Feeds
+    category: dependency
+    note: Canonical EACAggregatorProxy feeds for USDC, USDT and ETH
+  - id: dep-curve
+    label: Curve ftUSD/USDC
+    address: "0xafec61e7a604f8f81f7cab64ec75bfa07c542630"
+    category: dependency
+    note: StableSwap-NG ~1.87M. Only external ftUSD exit, but the liquidity is one EOA via a gauge whose manager is an admin Safe signer
+  - id: dep-morpho
+    label: Morpho
+    address: "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb"
+    category: dependency
+    note: Holds 629,675 ftUSD as collateral. Third-party acceptance and an outward propagation channel
+  - id: dep-spot-clob
+    label: FT Spot AMM / CLOB (not wired in)
+    category: dependency
+    note: Verified absent from the deployed contracts - no depth or volatility input exists in ConfigRegistry or PositionsManager, and no AMM is registered as an engine. The documented dynamic LTV is not implemented onchain
+  - id: dep-permit2
+    label: Permit2
+    address: "0xEB450d21ae68D3303Cf5775A54Cc84EE7c3fC8eC"
+    category: dependency
+
+edges:
+  # === Governance and control ===
+  - from: admin-safe
+    to: config-registry
+    kind: controls
+    label: owner - asset config, margins, IRMs
+  - from: admin-safe
+    to: oracle-router
+    kind: controls
+    label: owner - feeds and price override
+  - from: admin-safe
+    to: pm-wrapper
+    kind: controls
+    label: admin - upgrades, caps, pauses
+  - from: pm-wrapper
+    to: positions-manager
+    kind: controls
+    label: upgradePM / setCaps / pauses
+  - from: admin-safe
+    to: ftusd
+    kind: controls
+    label: owner + masterMinter + pauser + blacklister
+  - from: admin-safe
+    to: mint-and-redeem
+    kind: controls
+    label: owner
+  - from: guardian-safe
+    to: oracle-router
+    kind: holds-role
+    label: disablePrice guardian
+  - from: guardian-safe
+    to: lend-circuit-breaker
+    kind: holds-role
+    label: emergency pause
+  - from: admin-safe
+    to: lend-circuit-breaker
+    kind: controls
+    label: owner - can pause or reconfigure the breaker
+  - from: admin-safe
+    to: usdc-wrapper
+    kind: controls
+    label: owner + strategyManager - setStrategy, no delay
+  - from: admin-safe
+    to: weth-wrapper
+    kind: controls
+    label: owner + strategyManager - setStrategy, no delay
+  - from: admin-safe
+    to: usdt-wrapper
+    kind: controls
+    label: owner + strategyManager - setStrategy, no delay
+  - from: admin-safe
+    to: wbtc-wrapper
+    kind: controls
+    label: owner - upgrades wrapper proxy
+  - from: admin-safe
+    to: ftusd-wrapper
+    kind: controls
+    label: owner + strategyManager
+  - from: admin-safe
+    to: wsteth-wrapper
+    kind: controls
+    label: owner + strategyManager
+  - from: admin-safe
+    to: ft-wrapper
+    kind: controls
+    label: owner + strategyManager
+  - from: wbtc-strategy-manager
+    to: wbtc-wrapper
+    kind: controls
+    label: strategyManager - setStrategy, setCircuitBreaker
+  - from: yield-claimer
+    to: usdc-wrapper
+    kind: holds-role
+    label: yieldClaimer - execute() arbitrary call
+  - from: yield-claimer
+    to: usdt-wrapper
+    kind: holds-role
+    label: yieldClaimer - execute() arbitrary call
+  - from: yield-claimer
+    to: weth-wrapper
+    kind: holds-role
+    label: yieldClaimer - execute() arbitrary call
+  - from: yield-claimer
+    to: wbtc-wrapper
+    kind: holds-role
+    label: yieldClaimer - execute() arbitrary call
+  - from: fee-collector
+    to: positions-manager
+    kind: holds-role
+    label: collector / epoch settler
+
+  # === ftUSD mint / redeem path ===
+  - from: mint-and-redeem
+    to: ftusd-core
+    kind: routes-through
+    label: collateralized mint/redeem entry
+  - from: ftusd-core
+    to: ftusd
+    kind: mints
+    label: sole minter
+  - from: admin-safe
+    to: ftusd
+    kind: mints
+    label: masterMinter can configure arbitrary minter
+
+  # === ftUSD collateral custody and the reflexivity loop ===
+  - from: mint-and-redeem
+    to: ftusd-usdc-wrapper
+    kind: allocates-to
+    label: deposits USDC collateral on mint
+  - from: mint-and-redeem
+    to: ftusd-usdt-wrapper
+    kind: allocates-to
+    label: deposits USDT collateral on mint
+  - from: ftusd-usdc-wrapper
+    to: delta-neutral
+    kind: deposits-into
+    label: "2.77M USDC"
+  - from: ftusd-usdt-wrapper
+    to: delta-neutral
+    kind: deposits-into
+    label: "1.42M USDT"
+  - from: delta-neutral
+    to: positions-manager
+    kind: deposits-into
+    label: REFLEXIVE - ftUSD backing supplied into FT Lend (35.1% of TVL)
+  - from: admin-safe
+    to: delta-neutral
+    kind: controls
+    label: strategyManager of the ftUSD wrappers
+
+  # === Oracle wiring ===
+  - from: oracle-router
+    to: oracle-wrapper-wbtc
+    kind: routes-through
+    label: WBTC price
+  - from: oracle-router
+    to: oracle-wrapper-wsteth
+    kind: routes-through
+    label: wstETH price
+  - from: oracle-router
+    to: oracle-wrapper-ftusd
+    kind: routes-through
+    label: ftUSD price
+  - from: oracle-wrapper-wbtc
+    to: dep-chainlink
+    kind: routes-through
+    label: immutable base feed BTC/USD
+  - from: oracle-wrapper-wsteth
+    to: dep-chainlink
+    kind: routes-through
+    label: immutable base feed ETH/USD
+  - from: oracle-wrapper-ftusd
+    to: mint-and-redeem
+    kind: routes-through
+    label: reads redeem factors (USDC price + mint history), not collateral
+
+  # === Lending engine wiring ===
+  - from: oracle-router
+    to: dep-chainlink
+    kind: manages
+    label: configured price feeds
+  - from: positions-manager
+    to: rfq-engine
+    kind: routes-through
+    label: liquidations / RFQ
+  - from: positions-manager
+    to: relayer-session
+    kind: manages
+    label: meta-actions / session layer
+  - from: rfq-engine
+    to: dep-spot-clob
+    kind: routes-through
+    label: liquidation venue
+  - from: relayer-session
+    to: dep-permit2
+    kind: routes-through
+    label: token approvals
+
+  - from: ftusd
+    to: dep-curve
+    kind: routes-through
+    label: external exit + peg reference (0.30% at 500K)
+  - from: ftusd
+    to: dep-morpho
+    kind: routes-through
+    label: accepted as Morpho collateral
+
+  # === Asset supply routing ===
+  - from: positions-manager
+    to: usdc-wrapper
+    kind: allocates-to
+    label: "~25.9% TVL"
+  - from: positions-manager
+    to: weth-wrapper
+    kind: allocates-to
+    label: "~11.3% TVL"
+  - from: positions-manager
+    to: usdt-wrapper
+    kind: allocates-to
+    label: "~11.6% TVL"
+  - from: positions-manager
+    to: wbtc-wrapper
+    kind: allocates-to
+    label: "~39.5% TVL"
+  - from: usdc-wrapper
+    to: dep-spark
+    kind: deposits-into
+    label: Spark strategy
+  - from: weth-wrapper
+    to: dep-spark
+    kind: deposits-into
+    label: Spark strategy
+  - from: usdt-wrapper
+    to: dep-spark
+    kind: deposits-into
+    label: Spark strategy
+  - from: wbtc-wrapper
+    to: dep-aave
+    kind: deposits-into
+    label: Aave strategy
+  - from: positions-manager
+    to: ftusd-wrapper
+    kind: allocates-to
+    label: "~11.8% TVL"
+  - from: positions-manager
+    to: wsteth-wrapper
+    kind: allocates-to
+    label: enabled, 0 supplied
+  - from: positions-manager
+    to: ft-wrapper
+    kind: allocates-to
+    label: enabled, unpriced

--- a/reports/graph/flying-tulip.yaml
+++ b/reports/graph/flying-tulip.yaml
@@ -181,7 +181,7 @@ nodes:
     label: Curve ftUSD/USDC
     address: "0xafec61e7a604f8f81f7cab64ec75bfa07c542630"
     category: dependency
-    note: StableSwap-NG ~1.87M. Only external ftUSD exit, but the liquidity is one EOA via a gauge whose manager is an admin Safe signer
+    note: StableSwap-NG ~$249K after >85% decline. Thin ftUSD exit; gauge custody is 87.1% Convex voter proxy, 7.1% EOA, 5.6% CurveYCRVVoter
   - id: dep-morpho
     label: Morpho
     address: "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb"
@@ -378,7 +378,7 @@ edges:
   - from: ftusd
     to: dep-curve
     kind: routes-through
-    label: external exit + peg reference (0.30% at 500K)
+    label: external exit + peg reference (~0.38% at 100K)
   - from: ftusd
     to: dep-morpho
     kind: routes-through

--- a/reports/report/flying-tulip-ftusd.md
+++ b/reports/report/flying-tulip-ftusd.md
@@ -1,18 +1,18 @@
 # Asset Risk Assessment: Flying Tulip — ftUSD & Staked ftUSD (sftUSD)
 
-- **Assessment Date:** August 7, 2026
+- **Assessment Date:** August 7, 2026 (team-response update: September 4, 2026)
 - **Token:** ftUSD (stablecoin) and sftUSD (staked ftUSD)
 - **Chain:** Ethereum Mainnet
 - **Token Address:** ftUSD [`0xF7D85EC4E7710f71992752eac2111312e73E9C9C`](https://etherscan.io/address/0xF7D85EC4E7710f71992752eac2111312e73E9C9C) · sftUSD [`0xeb48218a4c35C814C7678cBcae88C6Ee037F7625`](https://etherscan.io/address/0xeb48218a4c35C814C7678cBcae88C6Ee037F7625)
 - **Final Score: 3.5/5.0**
-- **Medium Risk** — approved with enhanced monitoring. ftUSD is fully collateralized (100.05%) but that backing is **not idle cash — it is lent into Flying Tulip's own money market** by a strategy whose `operators[]` include a plain EOA with `onlyManager` rights to pre-sign hedge trades (no onchain price bound). The 3/5 admin Safe can mint unbacked ftUSD, blacklist and burn balances. Redemption is permissionless but rate-limited and capped by FT Lend's cash — ~15% of the USDT backing is not withdrawable today. The price feed is structurally blind to the backing. See [Risk Score Assessment](#risk-score-assessment).
+- **Elevated Risk** — limited approval, strict limits. ftUSD is fully collateralized (100.05%), but that backing is **not idle cash — it is lent into Flying Tulip's own money market** by a strategy whose `operators[]` include a plain EOA with `onlyManager` rights to pre-sign hedge trades (no onchain price bound). Normal minting through the current production module is collateralized; separately, the 3/5 Admin Safe retains a technically available privileged path to authorize unbacked issuance. No evidence that path has been used was found. Redemption is permissionless but first rate-limited to 10% per window; ultimate settlement depends on FT Lend cash. Curve liquidity fell by more than 85% after the initial assessment, materially weakening the secondary exit. See [Risk Score Assessment](#risk-score-assessment).
 - **Companion report:** the lending market itself is assessed in **[Flying Tulip — FT Lend](./flying-tulip.md)**.
 
-> **Scope.** This report covers **holding ftUSD** and **staking it as sftUSD**. It is a separate risk from supplying to the FT Lend market — different loss paths, different exit mechanics, different concentration profile — and the two should be sized independently. All values verified **August 6, 2026 at block `25697429`** via `cast` and Etherscan.
+> **Scope.** This report covers **holding ftUSD** and **staking it as sftUSD**. It is a separate risk from supplying to the FT Lend market — different loss paths, different exit mechanics, different concentration profile — and the two should be sized independently. Unless expressly marked as an update, values were verified **August 6, 2026 at block `25697429`** via `cast` and Etherscan. Bug-bounty scope, redemption availability, and Curve liquidity were refreshed **September 4, 2026 at block `25903824`** in response to team comments.
 
 ## Overview + Links
 
-**ftUSD** is Flying Tulip's stablecoin. Users mint 1:1 against USDC or USDT through `MintAndRedeem` and can redeem the same way, paying 7 bps each direction. It is marketed as a "delta-neutral yield stablecoin": the strategy supplies the original USDC/USDT principal to Flying Tulip's own lending market, borrows WETH from that same market, swaps the borrowed WETH for wstETH, and deposits the wstETH back into the market as leveraged collateral. Gross collateral therefore includes USDC/USDT and wstETH, offset by WETH debt; the strategy's net equity, not its gross assets, backs ftUSD.
+**ftUSD** is Flying Tulip's stablecoin. Users normally acquire it on the market or mint 1:1 against USDC or USDT through the collateralized `MintAndRedeem` module, and can redeem through the same module, paying 7 bps each direction. It is marketed as a "delta-neutral yield stablecoin": the strategy supplies the original USDC/USDT principal to Flying Tulip's own lending market, borrows WETH from that same market, swaps the borrowed WETH for wstETH, and deposits the wstETH back into the market as leveraged collateral. Gross collateral therefore includes USDC/USDT and wstETH, offset by WETH debt; the strategy's net equity, not its gross assets, backs ftUSD.
 
 **sftUSD** is the staked form — an ERC-4626-style vault at [`0xeb48218a…7625`](https://etherscan.io/address/0xeb48218a4c35C814C7678cBcae88C6Ee037F7625) holding 1,324,455 ftUSD across 107 holders. Critically, **sftUSD does not appreciate in ftUSD terms**; its yield is paid separately in FT tokens.
 
@@ -69,7 +69,7 @@ All source-verified on Etherscan, including proxy implementations.
 
 | # | Path | Mechanism | Gating | Severity |
 |---|---|---|---|---|
-| 1 | **Unbacked mint** | Safe registers a new ftUSD Core module with an arbitrary ceiling, or replaces `minter()`, issuing ftUSD with no collateral | 3/5 Safe, no timelock | Total dilution |
+| 1 | **Privileged unbacked-issuance path** | Normal minting through the current module is collateralized, but the Safe can register a new ftUSD Core module with an arbitrary ceiling or replace `minter()` | 3/5 Safe, no timelock; no evidence of use found | Total dilution |
 | 2 | **Blacklist + balance wipe** | ftUSD `blacklist` then `wipeBlacklistedAddress` freezes and **burns** a holder's balance | 3/5 Safe | Total, targeted |
 | 3 | **sftUSD balance wipe** | The staking vault has its **own** `wipeBlacklistedAddress` — a second, independent seizure layer | 3/5 Safe | Total, targeted |
 | 4 | **Contract upgrade** | ftUSD, Core, MintAndRedeem, sftUSD and both wrappers are UUPS proxies upgradeable to arbitrary code | 3/5 Safe | Total |
@@ -80,15 +80,15 @@ All source-verified on Etherscan, including proxy implementations.
 | 9 | **Rate-limited exit (sftUSD)** | 10% of TVL per window, 6h settlement, admin-settable to **7 days** | 3/5 Safe | Temporary lockup |
 | 10 | **Rewards simply stop** | FT emissions are discretionary; sftUSD's exchange rate is fixed at 1.0, so no emissions means zero yield | epoch settler | Opportunity loss |
 | 11 | **`recoverERC20` / `sweepExcess`** | Owner-callable token recovery on MintAndRedeem and sftUSD | 3/5 Safe | Partial |
-| 12 | **Curve pool flight** | The only external ftUSD exit and the only external price reference | market | Exit degradation |
+| 12 | **Curve pool flight** | The only secondary-market ftUSD exit and external price reference lost more than 85% of its liquidity after the initial review | market | Exit degradation |
 
 ## Audits and Due Diligence Disclosures
 
-The team provides gated portal access to the in-scope ftUSD, ftUSD Position Manager, Yield Claimer cotnracts audited by reputable firms.
+The team provides gated portal access to the in-scope ftUSD, ftUSD Position Manager, and YieldClaimer contracts audited by reputable firms.
 
 | Item | Status |
 |---|---|
-| Public bug bounty | **LIVE** — [Sherlock Flying Tulip Bug Bounty #248](https://audits.sherlock.xyz/bug-bounties/248?tab=scope), max reward 1,000,000 USDC; **scope is ftPUT + FT OFT**, not ftUSD / sftUSD / MintAndRedeem (see below) |
+| Public bug bounty | **LIVE** — [Sherlock Flying Tulip Bug Bounty #248](https://audits.sherlock.xyz/bug-bounties/248?tab=scope), max reward 1,000,000 USDC; the bounty's **Additional Scope** incorporates Flying Tulip's dynamic list of all deployed production contracts, including the assessed ftUSD / sftUSD stack (see below) |
 | SEAL Safe Harbor enrolment | **Not enrolled** (absent from the `security-alliance/safe-harbor` registry) |
 | Contract source verification on Etherscan | **PASS** — all contracts above verified |
 
@@ -99,20 +99,13 @@ The team provides gated portal access to the in-scope ftUSD, ftUSD Position Mana
 
 ### Bug Bounty
 
-**LIVE.** [Sherlock's Flying Tulip Bug Bounty #248](https://audits.sherlock.xyz/bug-bounties/248?tab=scope) has been live since June 18, 2026 and advertises a maximum reward of **1,000,000 USDC**. The [Scope](https://audits.sherlock.xyz/bug-bounties/248?tab=scope) tab is public: in-scope source is `flyingtulipdotcom/ftPUT` (`PutManager`, `pFT`, `ftYieldWrapper`, `CircuitBreaker`, Aave strategy, oracle/ACL) plus listed onchain deployments of that product and the FT OFT token — the same product family as [Sherlock contest #1223](https://audits.sherlock.xyz/contests/1223).
-
-**Against this report's contracts:** none of ftUSD, ftUSD Core, `MintAndRedeem`, the ftUSD oracle, the Delta-Neutral strategy, sftUSD, the staking breaker, or the ftUSD wrappers appear in that scope. Two addresses that are listed also appear here, but only as shared infrastructure / reward token — not as coverage of the assessed mint/redeem/staking path:
-
-| Address | Role in this report | In bounty scope? |
-|---|---|---|
-| [`0x88432bB6…1397`](https://etherscan.io/address/0x88432bB6EA62e774cB6d87995CC5277568d01397) | `YieldClaimer` (wrapper `execute`) | **Yes** |
-| [`0x5DD1A7A3…082c`](https://etherscan.io/address/0x5DD1A7A369e8273371d2DBf9d83356057088082c) | FT token (sftUSD emissions) | **Yes** (FT OFT) |
+**LIVE.** [Sherlock's Flying Tulip Bug Bounty #248](https://audits.sherlock.xyz/bug-bounties/248?tab=scope) has been live since June 18, 2026 and advertises a maximum reward of **1,000,000 USDC**. Its **Additional Scope** states that contracts deployed for the bounty are found either in Sherlock's static Scope section or in Flying Tulip's linked [Contract Addresses](https://docs.flyingtulip.com/contract-addresses/) directory. That directory points to Flying Tulip's Smart Search, the protocol-maintained dynamic list of all deployed production contracts. Accordingly, the live bounty covers the deployed contracts assessed here, including ftUSD, ftUSD Core, `MintAndRedeem`, the ftUSD oracle, the Delta-Neutral strategy, sftUSD, the staking breaker, the ftUSD wrappers, `YieldClaimer`, and the FT reward token, even when an address is not duplicated in Sherlock's static address table.
 
 ## Historical Track Record
 
 - **Production history:** ftUSD [deployed February 21, 2026](https://etherscan.io/tx/0x52e7d46b7e166b8e30c5d38a09d93c44537bcb77b439e5b125d8b51d5670ea21), live at the February 23 TGE — **~5.4 months**. sftUSD has settled **220 reward epochs**.
 - **Supply:** 4,196,697 ftUSD against a `maxSupply` cap of 100M (raised from 5M). Of that, **1,324,455 (31.6%) is staked** as sftUSD and 1,428,403 is supplied into FT Lend.
-- **Peg:** the protocol's oracle reads $0.9988. Independently, the Curve pool is near-balanced at 971,101 ftUSD / 903,390 USDC with `get_virtual_price()` = 1.000464 — so the peg is **externally corroborated**, not merely self-reported.
+- **Peg:** at the initial snapshot, the protocol oracle read $0.9988 and the Curve pool was near-balanced at 971,101 ftUSD / 903,390 USDC with `get_virtual_price()` = 1.000464, providing external market corroboration. That signal still exists, but its depth fell by more than 85% before the September 4 update.
 - **Incidents / depegs:** **NONE FOUND** through August 2026.
 - **Third-party acceptance, with a caveat:** [Morpho](https://etherscan.io/address/0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb) holds **629,675 ftUSD (15.0% of supply)** as collateral across two USDC markets. That is genuine external adoption for an asset this young — but Morpho does **not** independently price ftUSD; its oracle consumes Flying Tulip's own feed. See [The Morpho ftUSD markets](#the-morpho-ftusd-markets).
 - **Accounting drift resolved.** An earlier check (August 3) found `Core.totalDebt` exceeding `totalSupply` by 40,310 ftUSD. At this block the two are **exactly equal** (4,196,696.769396 both). The drift was transient.
@@ -140,8 +133,8 @@ Global gates: ftUSD `maxSupply` 100M, Core `globalDebtCeiling` 100M, `minTVLForM
 | Action | Who | Atomic? | Fees | Limits / gating |
 |---|---|:---:|---|---|
 | **Mint ftUSD** | permissionless | ✓ one tx — collateral in, `wrapper.deposit()`, `core.mint()` | 7 bps | per-collateral cap 100M; `minTVLForMint` 5M; `globalDebtCeiling` 100M; `maxSupply` 100M; mint price hardcapped at $1.00 |
-| **Redeem ftUSD** | permissionless | ✓ up to the window cap | 7 bps | **10% of wrapper capital per window, 6h settlement beyond that** (admin-settable to 7 days); total capacity capped by FT Lend's cash — USDT is ~15% short today. Priced off `min(spot, avgMint)` factors, not flat 1:1 |
-| **Sell ftUSD** | permissionless | ✓ | Curve 0.2% + slippage | ~$500K at 0.30%; USDC side exhausted above ~$900K |
+| **Redeem ftUSD** | permissionless | ✓ up to the window cap | 7 bps | **10% of wrapper capital per window, 6h settlement beyond that** (admin-settable to 7 days); ultimate capacity is capped by FT Lend cash. On September 4, USDT cash covered 89.2% of wrapper capital. Priced off `min(spot, avgMint)` factors, not flat 1:1 |
+| **Sell ftUSD** | permissionless | ✓ | Curve 0.2% + slippage | ~$100K at 0.38%; slippage rises to ~13.75% at $150K |
 | **Stake (sftUSD)** | permissionless | ✓ | none | `minDepositAmount` 0 |
 | **Unstake (sftUSD)** | permissionless | **✗ above the limit** | none | **10% of TVL per window; excess queued for 6h (`settlementDelay`), admin-settable to 7 days** |
 | **Claim FT rewards** | permissionless | ✓ | none | only if the epoch settler has funded an epoch |
@@ -308,18 +301,16 @@ MintAndRedeem  (holds ~0 collateral — only wrapper shares)
                  └─ FT Lend wrapper → Spark   (zero idle buffer)
 ```
 
-Live at block `25697429`:
+Refreshed September 4, 2026 at block `25903824`:
 
 | | USDC | USDT |
 |---|---:|---:|
-| ftUSD wrapper `capital()` | 2,781,366.71 | 1,417,609.56 |
-| ftUSD wrapper `availableToWithdraw()` | 2,781,366.71 | **1,206,351.08** |
-| **Shortfall** | 0 | **211,258.48 (14.9%)** |
-| FT Lend cash for that asset | 2,934,606.16 | **1,206,351.08** |
-| FT Lend borrowed by others | 241,017.83 | 223,541.39 |
-| Breaker instant capacity (10%) | 278,136.67 | 141,760.96 |
+| ftUSD wrapper `capital()` | 2,698,054.90 | 1,493,055.91 |
+| ftUSD wrapper `availableToWithdraw()` | 2,698,054.90 | **1,331,789.52** |
+| **Shortfall** | 0 | **161,266.39 (10.8%)** |
+| Breaker instant capacity (10%) | 269,805.49 | 149,305.59 |
 
-The USDT wrapper's `availableToWithdraw` equals FT Lend's USDT cash **to the cent** — confirming the constraint is exactly the lending market's liquidity. **About 15% of ftUSD's USDT backing is not redeemable right now**, because third parties have borrowed it inside FT Lend. This is normal operation, not stress.
+The USDT wrapper's `availableToWithdraw` confirms that the ultimate constraint is the lending market's liquidity. On September 4, cash covered **89.2%** of USDT wrapper capital. This does not constrain an ordinary immediate redemption first: the circuit breaker limits instant redemptions to 10% of wrapper capital per window, below available cash. Requests beyond the window cap queue, and their ultimate settlement still depends on FT Lend cash. The 10.8% cash gap is normal utilization, not evidence of stress or undercollateralization.
 
 **On top of that, redemption is rate-limited.** Both ftUSD backing wrappers are protected by the same `CircuitBreaker` [`0xCB210509…7355`](https://etherscan.io/address/0xCB210509F5AE2b3843B7Fb8Bb90bAFF9cE4f7355) that gates sftUSD unstaking: **10% of wrapper capital per window**, with a **6h `settlementDelay`** (admin-settable 5 min – 7 days) beyond that.
 
@@ -336,11 +327,11 @@ The asymmetry itself is conservative for solvency (appreciation retained, deprec
 
 | Size | Best route | Cost | Binding constraint |
 |---|---|---|---|
-| < ~$140K | Redeem | 7 bps, instant | none today |
-| $140K – $500K | Curve, or queued redemption | 0.22–0.30% vs 7 bps + 6h | breaker window |
-| > $500K | Split across both | — | USDT redemption ceiling ~1.21M, Curve USDC side ~903K |
+| < ~$149K | Redeem | 7 bps, instant | lower USDT breaker window |
+| $149K – $270K | Split collateral routes or queue | 7 bps + possible 6h wait | per-wrapper breaker window |
+| > ~$270K | Queued redemption | 7 bps + settlement delay | breaker window, then FT Lend cash |
 
-**Note the interaction with the oracle.** At this block the feed reports ftUSD at $0.9988 while ~15% of the USDT backing cannot be withdrawn. Reported price and actual redeemability are already decoupled under entirely normal conditions, and the oracle has no channel through which that gap could ever appear.
+**Note the interaction with the oracle.** Reported price and available redemption cash are separate quantities: the feed cannot reflect a liquidity gap because it does not read FT Lend cash. The circuit breaker's 10% window currently binds before USDT cash does, but queued settlement would still inherit any FT Lend liquidity constraint.
 
 ### The Morpho ftUSD markets
 
@@ -377,7 +368,7 @@ For an ftUSD holder this is a second-order but real exposure: 629,675 ftUSD (15.
 - **But verification takes four hops** through contracts that public documentation does not describe, and the final hop lands inside another Flying Tulip product rather than at a custodian or a liquid buffer.
 - **The price feed does not read the backing.** It is a function of the USDC price and cumulative mint history, so nothing a holder verifies about the collateral can ever reach the price the protocol uses. It also carries a 0 bps deviation tolerance, so no cross-check is attempted.
 - **No public source repository** and no public audit reports — review is limited to reading verified bytecode.
-- **The Curve pool is the only external price reference** — the only place a backing problem could surface as a price, but its liquidity is protocol-adjacent rather than independent.
+- **The Curve pool is the only external price reference** — the only place a backing problem could surface as a price, but its depth has become thin and gauge custody does not establish beneficial LP ownership.
 
 ## Liquidity Risk
 
@@ -385,7 +376,7 @@ For an ftUSD holder this is a second-order but real exposure: 629,675 ftUSD (15.
 
 | Venue | Depth | Notes |
 |---|---|---|
-| **Curve StableSwap-NG** [ftUSD/USDC](https://etherscan.io/address/0xafec61e7a604f8f81f7cab64ec75bfa07c542630) | **971,101 ftUSD / 903,390 USDC (~$1.87M)** | A=1000, fee 0.2%, near-balanced |
+| **Curve StableSwap-NG** [ftUSD/USDC](https://etherscan.io/address/0xafec61e7a604f8f81f7cab64ec75bfa07c542630) | **118,921 ftUSD / 130,034 USDC (~$249K)** | A=1000, fee 0.2%; >85% smaller than initial snapshot |
 | Curve Twocrypto [FT/ftUSD](https://etherscan.io/address/0x68102ff5406475881462880a8da3c9bc9181ad6c) | 48,838 ftUSD | thin |
 | Uniswap V3 0.05% | 0.000033 ftUSD | dust, unusable |
 | Protocol redemption | subject to FT Lend liquidity | 7 bps fee |
@@ -394,12 +385,13 @@ Measured slippage on Curve (`get_dy`, ftUSD → USDC):
 
 | Size | Out | Slippage |
 |---|---|---|
-| 10,000 | 9,979.15 USDC | 0.209% |
-| 100,000 | 99,780.80 USDC | 0.219% |
-| 250,000 | 249,398.14 USDC | 0.241% |
-| 500,000 | 498,495.41 USDC | **0.301%** |
+| 10,000 | ~9,979 USDC | ~0.21% |
+| 50,000 | 49,880.65 USDC | 0.239% |
+| 100,000 | 99,616.85 USDC | **0.383%** |
+| 120,000 | 119,098.47 USDC | 0.751% |
+| 150,000 | 129,378.67 USDC | **13.75%** |
 
-A holder can exit **$500K at 0.30%** without touching the protocol. That is a genuine, measured secondary market and the strongest single point in ftUSD's favour. Above ~$900K the pool's USDC side is exhausted and redemption becomes the only route — which then depends on FT Lend liquidity.
+A holder can still exit **$100K at about 0.38%** without touching the protocol, but depth deteriorates sharply beyond the pool's roughly $130K USDC reserve: a $150K quote incurs about **13.75%** slippage. Redemption is therefore the practical route at larger size, subject first to the breaker window and then to FT Lend cash.
 
 ### sftUSD — rate-limited
 
@@ -416,29 +408,31 @@ Unstaking passes through the staking `CircuitBreaker`:
 
 Withdrawals beyond 10% of TVL per window route to `redeemWithQueueId` / `withdrawWithQueueId` and settle after the delay. **The admin can raise that delay to 7 days in one transaction with no timelock.** There is no secondary market for sftUSD itself.
 
-### The Curve pool is protocol-adjacent liquidity
+### Curve liquidity changed materially after the initial snapshot
 
-The ~$1.87M ftUSD/USDC StableSwap-NG pool ([`0xafec61e7…2630`](https://etherscan.io/address/0xafec61e7a604f8f81f7cab64ec75bfa07c542630)) is the only external ftUSD venue and the only external ftUSD price. Inspecting who actually provides it:
+The initial August 6 snapshot was accurate: the ftUSD/USDC StableSwap-NG pool ([`0xafec61e7…2630`](https://etherscan.io/address/0xafec61e7a604f8f81f7cab64ec75bfa07c542630)) held about $1.87M and one EOA held 99.998% of gauge deposits. That address fully exited in [transaction `0x45f8…c4d`](https://etherscan.io/tx/0x45f8ae5c4968948d914e959988e5f4bd83dd22758068c0dcd1d93aa3351f3c4d) on August 28, 2026. By September 4, the pool held only **118,921 ftUSD and 130,034 USDC (~$249K)**, a decline of more than 85%.
 
 | Layer | Holder | Share |
 |---|---|---|
-| Pool LP tokens | [Curve gauge `0x8abf0a7e…7c3f`](https://etherscan.io/address/0x8abf0a7e4b59ace59cb214fcb158285cd7cf7c3f) (`LiquidityGaugeV6`) | **100.0%** |
-| Gauge deposits | EOA [`0x3ffebdc5…46ee`](https://etherscan.io/address/0x3ffebdc5130f6072a582f79f3fb61581d3d846ee) | **99.998%** |
+| Pool LP tokens | [Curve gauge `0x8abf0a7e…7c3f`](https://etherscan.io/address/0x8abf0a7e4b59ace59cb214fcb158285cd7cf7c3f) (`LiquidityGaugeV6`) | **~100.0%** |
+| Gauge deposits | [Convex voter proxy `0x989aeb4d…ad80`](https://etherscan.io/address/0x989aeb4d175e16225e39e87d0d97a3360524ad80) | **87.1%** |
+| Gauge deposits | EOA [`0x920064cf…d6a9`](https://etherscan.io/address/0x920064cf4c37238a643bebeb733e213cf19cd6a9) | **7.1%** |
+| Gauge deposits | [`CurveYCRVVoter` `0x52f54176…66b6`](https://etherscan.io/address/0x52f541764e6e90eebc5c21ff570de0e2d63766b6) | **5.6%** |
 
-**A single EOA provides essentially all of it**, and that address also holds 23,941 sftUSD. The gauge's `manager` is [`0x3c427497…1B4E`](https://etherscan.io/address/0x3c42749709BF354B3aE0Db29Fd2dd88089b21B4E) — **one of the five admin Safe signers**. A second signer, [`0xD0CA8838…6f5A`](https://etherscan.io/address/0xD0CA88388d1732594D611535314e9B6745396f5A), holds a dust gauge position.
+The current gauge custody is split, with most LP routed through a Convex aggregation contract. That proves neither a single beneficial owner nor protocol affiliation, so the earlier "protocol-adjacent EOA" characterization is withdrawn. The gauge's `manager` remains [`0x3c427497…1B4E`](https://etherscan.io/address/0x3c42749709BF354B3aE0Db29Fd2dd88089b21B4E), one of the five Admin Safe signers, but gauge management does not by itself establish ownership of the deposited LP.
 
 Pool parameters are otherwise unremarkable and healthy: `A` = 1000 with `future_A_time` = 0 (no ramp in progress), fee **0.2%**, `admin_fee` 50% of fees, `offpeg_fee_multiplier` 2.5×, `get_virtual_price` 1.000465.
 
 **This qualifies how the Curve venue should be read.** The pool is real, tradeable by anyone, and the measured slippage is genuine — but:
 
-1. **It is not a durable exit.** One EOA can withdraw it. The $500K-at-0.30% capacity is that party's continued willingness to provide liquidity, not a property of the market.
-2. **It is not independent price corroboration.** A pool made almost entirely by one protocol-adjacent party, with an admin signer as gauge manager, is closer to protocol-owned liquidity than to a third-party market. The peg is "corroborated" by a market the protocol effectively makes. That is better than no market at all — arbitrage against it is still real and permissionless — but it is not an outside check.
+1. **It is not a durable deep exit.** More than 85% of pool liquidity disappeared in one month, and a $150K sale now incurs double-digit slippage.
+2. **It remains an external price signal, but not a strong one.** Anyone can arbitrage the pool, yet its limited depth makes the signal easier to move and Convex aggregation prevents a clean inference about beneficial LP concentration.
 
-Note this is the same pattern as the Morpho finding: an external venue that looks like third-party validation but, on inspection, either consumes the protocol's own oracle (Morpho) or is provided by the protocol's own circle (Curve).
+Morpho still consumes Flying Tulip's own oracle rather than independently pricing ftUSD. Curve is genuinely market-based, but after the liquidity decline it provides only a thin independent signal.
 
 ### Holder concentration
 
-**ftUSD holders** (top balances): the largest non-protocol holders are the Curve pool (971,101), Morpho (629,675) and the FT Lend ftUSD wrapper (1,106,633). Circulating ftUSD is meaningfully absorbed by protocol-adjacent venues rather than distributed retail.
+**ftUSD holders:** the Curve pool balance fell from 971,101 ftUSD at the initial snapshot to **118,921 ftUSD** on September 4. Other holder balances in this section remain at the August 6 snapshot.
 
 **sftUSD is well distributed** — genuinely better than the lending market:
 
@@ -471,7 +465,7 @@ The same 3-of-5 Gnosis Safe [`0x1118…70Cb`](https://etherscan.io/address/0x111
 
 **Rate limits / caps:** ftUSD `maxSupply` 100M; Core `globalDebtCeiling` 100M; per-collateral cap 100M each.
 
-**Backing check at mint time:** atomic. **But** the masterMinter can register an arbitrary new module or replace the minter, issuing unbacked ftUSD — gated only by a 3-of-5 multisig with no delay.
+**Backing check at mint time:** atomic for the current production module. Separately, the masterMinter can register an arbitrary new module or replace the minter, creating a technically available path to issue unbacked ftUSD. That path is gated only by a 3-of-5 multisig with no delay; no evidence that it has been used was found.
 
 ### Programmability
 
@@ -483,7 +477,7 @@ Mint/redeem accounting, the collateral reconciliation and the sftUSD share math 
 - **Spark & Aave** — FT Lend's wrappers hold zero idle buffer, so redemption capacity ultimately depends on these venues.
 - **Lido / wstETH** — now a live component of the hedge (76.54 wstETH).
 - **Chainlink** — USDC/USD feeds the ftUSD oracle's base leg.
-- **Curve** — the only external ftUSD exit and the only external price reference. **Its liquidity is protocol-adjacent, not independent** — see below. Assessed.
+- **Curve** — the only secondary-market ftUSD exit and external price reference. Its liquidity fell by more than 85% after the initial snapshot; most gauge custody now routes through Convex, so beneficial LP ownership cannot be inferred from the gauge balance alone. Assessed.
 - **Morpho** — two USDC/ftUSD Blue markets holding 629,675 ftUSD (15.0% of supply); the live one is at 86% LLTV and 90.1% utilization. Its oracle reads Flying Tulip's own ftUSD feed, so this is an outward **propagation** channel rather than an independent price check, and pausing the FT oracle proxy would freeze these markets.
 - **CoW Protocol — not a dependency.** An earlier revision listed this after seeing `GPv2Settlement` and a `CowSwapBurner` in ftUSD transfer history and CoW-style naming (`setPreSignature`, `PreSignature`) in the engine. Both were misleading: `preSignature` is `LeverageRfqEngine`'s own `mapping(bytes32 => bool)`, the engine contains **zero** references to GPv2/CoWSwap/vaultRelayer across its 250KB of source, and neither the strategy nor the engine has any allowance to CoW's vault relayer. The `CowSwapBurner` is Curve's fee burner for the ftUSD/USDC pool. Fills go through the engine's own flash-fill path with a caller-supplied `fillTarget` and `fillData`.
 
@@ -519,7 +513,7 @@ Recommended frequency: **hourly** for peg, oracle divergence and governance; **d
 
 ### Curve liquidity
 
-- Track the gauge [`0x8abf0a7e…7c3f`](https://etherscan.io/address/0x8abf0a7e4b59ace59cb214fcb158285cd7cf7c3f) balance of [`0x3ffebdc5…46ee`](https://etherscan.io/address/0x3ffebdc5130f6072a582f79f3fb61581d3d846ee). One EOA is 99.998% of the gauge and therefore ~100% of the pool; its withdrawal removes both the exit and the price reference in a single transaction.
+- Track total pool reserves and the gauge's depositor mix. The former dominant EOA exited on August 28; 87.1% of current gauge deposits route through the Convex voter proxy, so monitor both aggregate liquidity and underlying beneficial concentration where observable.
 - Alert on pool imbalance beyond 70/30 and on `A` ramp initiation (`future_A_time` becoming non-zero) — a ramp changes slippage materially and the pool has an admin able to start one.
 
 ### Morpho exposure
@@ -585,7 +579,7 @@ Recommended frequency: **hourly** for peg, oracle divergence and governance; **d
      └─► ftftUSD wrapper 0xB44a…B87f (0 strategies, idle)
            └─► CircuitBreaker 0xCB21…7355  10%/window, 6h delay (→7d)
 
-   EXTERNAL:  Curve ftUSD/USDC ~$1.87M (only market exit + only price reference)
+   EXTERNAL:  Curve ftUSD/USDC ~$249K (thin secondary exit + external price reference)
               Morpho 629,675 ftUSD collateral
 ```
 
@@ -597,7 +591,7 @@ Recommended frequency: **hourly** for peg, oracle divergence and governance; **d
 
 - **Backing fully exists and reconciles to the wei** — 100.054% collateral ratio, verified across four hops, reproducible by anyone with `cast`.
 - **Mint is genuinely atomic and collateralized** through the only enabled module, with a per-collateral cap and a $1.00 mint price hardcap.
-- **A real external market exists**: ~$1.87M Curve pool clearing $500K at 0.30%, near-balanced. Genuinely tradeable and arbitrageable by anyone — though the liquidity is provided by a single protocol-adjacent EOA, so treat it as available rather than durable.
+- **A real external market exists**, and remains tradeable and arbitrageable by anyone. It is now thin: the Curve pool fell from ~$1.87M to ~$249K and a $150K sale incurs about 13.75% slippage.
 - **External acceptance** — 629,675 ftUSD (15.0% of supply) held as collateral in two Morpho Blue markets, the live one comfortably collateralized at ~64.5% LTV against an 86% threshold.
 - **sftUSD holder distribution is healthy** — 107 holders, largest 12.1%.
 - **Currently fully liquid**: sftUSD `availableToWithdraw` is 100% of TVL and no withdrawals are queued.
@@ -607,16 +601,16 @@ Recommended frequency: **hourly** for peg, oracle divergence and governance; **d
 
 - **The backing is lent into Flying Tulip's own money market** (100% of it, 35.1% of that market's TVL), so ftUSD cannot fail independently of FT Lend, while its price feed is blind to that backing.
 - **A plain EOA in `operators[]` can pre-sign hedge open/close/swap orders with no price or slippage bound** in either the strategy or the execution engine (`onlyManager`, not `onlyOwner`).
-- **A 3/5 Safe with no timelock can mint unbacked ftUSD**, blacklist and burn balances at both the token and vault layers, and upgrade every contract.
+- **A 3/5 Safe with no timelock retains a privileged path to unbacked issuance**, and can blacklist and burn balances at both the token and vault layers and upgrade every contract. The current production mint module is collateralized, and no evidence that the privileged issuance path has been used was found.
 - **sftUSD pays zero yield in ftUSD terms** — the rate is fixed at 1.0 and all return is discretionary FT emissions in a token with ~$28K of DEX liquidity.
 - **sftUSD's exit is rate-limited** at 10% of TVL per window with a 6h delay that the admin can extend to 7 days.
 - **Audit status is unverifiable** for every contract here, with an unconfirmed report of an open medium finding on the redemption path specifically.
 - **The price feed is structurally blind to the backing, and that blindness propagates outside the protocol.** ftUSD is priced off the USDC price and cumulative mint history — nothing in the path reads the collateral. Morpho's ftUSD markets consume that same feed rather than pricing ftUSD independently, and the FT admin Safe can freeze those markets by pausing it.
-- **Redemption capacity is bounded by FT Lend's liquidity and is already partially constrained** — ~15% of the USDT backing is not withdrawable today because third parties borrowed it, and redemption is rate-limited to 10% of wrapper capital per window with a 6h delay.
+- **Redemption is rate-limited before cash becomes the constraint.** The breaker permits 10% of wrapper capital per window with a 6h delay beyond it; current USDT cash covers 89.2% of capital, so ordinary instant redemptions fit inside available cash, while queued settlement still depends on FT Lend liquidity.
 
 ### Critical Risks
 
-- **Unbacked mint via a new Core module** — one multisig transaction, no delay, dilutes every holder.
+- **Privileged unbacked issuance via a new Core module or minter replacement** — technically available in one multisig transaction with no delay, though no evidence of use was found.
 - **Reflexive backing** — an FT Lend loss event impairs ftUSD's collateral while ftUSD is simultaneously 11.4% of that market's collateral, and its backing-blind feed would not register the impairment.
 - **Unbounded `onlyManager` trade pre-sign by an EOA** over the strategy's hedge leg (price unbounded; size still subject to PM health factor).
 
@@ -640,10 +634,10 @@ Recommended frequency: **hourly** for peg, oracle divergence and governance; **d
 #### Category 1: Audits & Historical Track Record (Weight: 20%)
 
 **Subcategory A: Audits — 2.5**
-The privately reviewed audit package provides good coverage from reputable firms, while the reports remain non-public. This asset-specific subscore remains 2.5; by contrast, the [FT Lend report](./flying-tulip.md) scores 3.0 because it applies an additional **+0.5** protocol-specific penalty for having no bounty coverage over the core lending contracts. This difference does not imply that the published bounty covers the ftUSD core: its published scope is **ftPUT / FT OFT**, not `FlyingTulipUSD`, Core, `MintAndRedeem`, sftUSD, or the Delta-Neutral strategy. No Safe Harbor enrolment was found. Complexity is high (module-gated minting, a leveraged hedging strategy, a queued staking vault).
+The privately reviewed audit package provides good coverage from reputable firms, while the reports remain non-public. The live Sherlock bounty has a maximum reward of 1,000,000 USDC and covers Flying Tulip's deployed production contracts through the dynamic contract list incorporated by the bounty's Additional Scope, including the ftUSD / sftUSD stack assessed here. The 2.5 subscore reflects strong audit and bounty coverage, with a half-point above rubric row 2 because the audit reports and finding-level details remain non-public. No Safe Harbor enrolment was found. Complexity is high (module-gated minting, a leveraged hedging strategy, and a queued staking vault).
 
 **Subcategory B: Historical — 4.0**
-ftUSD is ~5.4 months live with no depeg and no incident, which is clean but uninformative at this age. Supply is $4.2M — the `<$10M` band (4). The peg is externally corroborated, and 220 reward epochs have settled, which is a real operating record. The "delta-neutral" mechanism, however, only started working days ago, so the yield strategy itself has **no** track record.
+ftUSD is ~5.4 months live with no depeg and no incident, which is clean but uninformative at this age. Supply is $4.2M — the `<$10M` band (4). The peg has a market-based Curve reference, though current depth is thin, and 220 reward epochs have settled, which is a real operating record. The "delta-neutral" mechanism, however, only started working days before the initial snapshot, so the yield strategy itself has **no** meaningful track record.
 
 **Score: 3.25/5** — (2.5 + 4.0) / 2.
 
@@ -659,14 +653,14 @@ Worse than the lending market. Accounting is onchain and verifiable, but the bac
 Same rule as the [FT Lend report](./flying-tulip.md): **Spark, Aave, Chainlink, and Lido are not high-risk counterparties** — they are mature, heavily audited infrastructure (low individual counterparty risk).
 What elevates this subcategory is **where principal sits**:
 - **100% of ftUSD backing is a supply claim on FT Lend** (sibling product, Medium/Elevated risk profile, same admin Safe). That is the single unusual dependency — correlated failure of the stablecoin and the money market.
-- Curve is a secondary-market exit / price reference only (protocol-adjacent liquidity); primary redeem is `MintAndRedeem`. CoW is not a dependency.
+- Curve is a secondary-market exit / price reference only; primary redeem is `MintAndRedeem`. Current Curve depth is thin, and Convex aggregation obscures beneficial LP ownership. CoW is not a dependency.
 
 **Score: 4.5/5** — (5.0 + 4.5 + 4.0) / 3.
 
 #### Category 3: Funds Management (Weight: 30%)
 
 **Subcategory A: Collateralization — 3.5**
-ftUSD is 100.054% backed by the strategy's net equity, whose principal is predominantly USDC/USDT; gross collateral also includes wstETH purchased with borrowed WETH, so the portfolio must be assessed net of that WETH liability. Minting is atomic and backing is verifiable in real time onchain, but the collateral quality falls between rubric rows 3 and 4 because the backing is a leveraged position inside the newer, commonly controlled FT Lend market rather than liquid assets held independently. There is only 5 bps of excess backing, no reserve or insurance buffer, and wstETH/WETH basis risk, unwind constraints, FT Lend bad debt, or badly priced operator-authorized RFQ fills can impair the net backing.
+ftUSD is 100.054% backed by the strategy's net equity, whose principal is predominantly USDC/USDT; gross collateral also includes wstETH purchased with borrowed WETH, so the portfolio must be assessed net of that WETH liability. Minting through the current module is atomic and backing is verifiable in real time onchain, but the collateral quality falls between rubric rows 3 and 4 because the backing is a leveraged position inside the newer, commonly controlled FT Lend market rather than liquid assets held independently. The reconciliation confirms full collateralization; the ftUSD layer nevertheless has no material first-loss buffer against wstETH/WETH basis risk, unwind constraints, FT Lend bad debt, or badly priced operator-authorized RFQ fills.
 
 **Subcategory B: Provability — 1.5**
 Reserves and liabilities are fully onchain, update in real time, and reconcile exactly across ftUSD supply, Core debt, MintAndRedeem accounting, wrapper capital, and the strategy's FT Lend positions. Anyone can reproduce the reconciliation without relying on an administrator or custodian. The half-point reflects the four-contract custody chain and lack of a protocol-provided reserve dashboard, not an inability to verify the backing. The separate finding that ftUSD's price feed does not read this backing affects risk detection and liquidation behavior, but does not make the reserves themselves unprovable.
@@ -675,12 +669,12 @@ Reserves and liabilities are fully onchain, update in real time, and reconcile e
 
 #### Category 4: Liquidity Risk (Weight: 15%)
 
-- **ftUSD:** a real $1.87M Curve venue clears **$500K at 0.30%** plus permissionless 7 bps redemption. But the venue is **provided almost entirely by one EOA** through a gauge managed by an admin Safe signer, so it is withdrawable at that party's discretion rather than a durable market property.
+- **ftUSD:** the Curve venue fell from ~$1.87M to **~$249K** after the initial assessment. A $100K sale still clears at about 0.38%, but a $150K sale incurs about 13.75% slippage. Permissionless 7 bps redemption remains the practical large-exit route, subject to the 10%-per-window breaker and then FT Lend cash.
 - **sftUSD:** materially worse. Exit is **rate-limited to 10% of TVL per window with a 6h settlement delay, admin-extendable to 7 days**, and there is no secondary market for sftUSD itself. That is squarely the rubric's "withdrawal queues or restrictions" row (4).
 - Above ~$900K the Curve USDC side is exhausted and redemption becomes the only route, which depends on FT Lend and then Spark/Aave liquidity.
 - Currently no queue is active and 100% is withdrawable — the throttle is real but untested at scale.
 
-**Score: 3.5/5** — ftUSD has permissionless redemption and a measured $500K secondary-market exit at 0.30%, but redemption capacity depends on FT Lend liquidity and essentially all Curve liquidity comes from one protocol-adjacent EOA. sftUSD adds a 10%-per-window throttle and no secondary market; excess withdrawals currently wait 6 hours, while an admin can extend the delay to 7 days without a timelock. This places the combined position between the rubric's short-queue score of 3 and restricted-withdrawal score of 4.
+**Score: 4.0/5** — the combined position has withdrawal restrictions, less than $1M of secondary liquidity, and double-digit impact for an exit large enough to matter. ftUSD redemption is permissionless but rate-limited and ultimately depends on FT Lend cash. sftUSD adds the same 10%-per-window throttle and no secondary market; excess withdrawals currently wait 6 hours, while an admin can extend the delay to 7 days without a timelock.
 
 #### Category 5: Operational Risk (Weight: 5%)
 
@@ -695,11 +689,11 @@ Same team, entity and governance-transparency profile as the lending report (pub
 | Audits & Historical | 3.25 | 20% | 0.650 |
 | Centralization & Control | 4.50 | 30% | 1.350 |
 | Funds Management | 2.50 | 30% | 0.750 |
-| Liquidity Risk | 3.50 | 15% | 0.525 |
+| Liquidity Risk | 4.00 | 15% | 0.600 |
 | Operational Risk | 3.50 | 5% | 0.175 |
-| **Final Score** | | | **3.450** |
+| **Final Score** | | | **3.525** |
 
-**Final Score: 3.5** (3.45 weighted, conservatively rounded)
+**Final Score: 3.5** (3.525 weighted, displayed to one decimal)
 
 **Optional modifiers:** none apply — the asset is <1 year old and supply is far below $500M.
 
@@ -711,20 +705,20 @@ Category 1 is aligned with FT Lend. Cat 2C scores the **FT Lend backing concentr
 |------------|-----------|----------------|
 | 1.0-1.5 | Minimal Risk | Approved, high confidence |
 | 1.5-2.5 | Low Risk | Approved with standard monitoring |
-| **2.5-3.5** | **Medium Risk** | **Approved with enhanced monitoring** |
-| 3.5-4.5 | Elevated Risk | Limited approval, strict limits |
+| 2.5-3.5 | Medium Risk | Approved with enhanced monitoring |
+| **3.5-4.5** | **Elevated Risk** | **Limited approval, strict limits** |
 | 4.5-5.0 | High Risk | Not recommended |
 
-**Final Risk Tier: MEDIUM RISK — approved with enhanced monitoring.**
+**Final Risk Tier: ELEVATED RISK — limited approval, strict limits.** The unrounded 3.525 score is above the 3.5 boundary even though the displayed one-decimal score is 3.5.
 
-**This scores worse than the lending market (3.1).** FT Lend's Audits & Historical category is now higher risk (3.5 versus ftUSD's 3.25) solely because its audit subscore includes the additional no-bounty penalty; ftUSD's higher overall score is instead driven by four things a lender does not face:
+**This scores worse than the lending market (3.1).** Both reports score Audits & Historical at 3.25 after recognizing that the live Sherlock bounty covers all deployed Flying Tulip production contracts through its incorporated dynamic contract list. ftUSD's higher overall score is instead driven by four things a lender does not face:
 
 1. **Principal concentration into the reflexive asset.** Lending USDC, ftUSD is 11.4% of the collateral behind other people's loans. Holding ftUSD, 100% of principal is the reflexive asset.
 2. **An EOA in `operators[]` with unbounded hedge order pre-sign** (`approveOpenOrder` / `approveCloseOrder` / `approveSwapCollateralOrder`; no onchain price bound).
 3. **A rate-limited exit** on the staked form, admin-extendable to 7 days.
 4. **Zero intrinsic yield on sftUSD** — the rate is pinned at 1.0 and all return is discretionary emissions in an illiquid token.
 
-**The external validation is thinner than it looks.** Both of ftUSD's apparent third-party endorsements dissolve on inspection: Morpho accepts ftUSD but prices it with Flying Tulip's own feed, and the Curve pool is ~100% one protocol-adjacent EOA behind a gauge managed by an admin Safe signer. Neither is an outside check; both are extensions of the protocol's own circle.
+**The external validation is thinner than it looks.** Morpho accepts ftUSD but prices it with Flying Tulip's own feed. Curve is an independent market signal, but it lost more than 85% of its liquidity after the initial snapshot and is now easy to move at relevant size. Convex aggregation prevents a reliable inference about the beneficial owners behind most gauge deposits.
 
 ---
 
@@ -735,10 +729,10 @@ Category 1 is aligned with FT Lend. Cat 2C scores the **FT Lend backing concentr
 - **Hedge:** the leg went live around August 3–6, 2026. Reassess after 30 days of live operation, or immediately if `targetLeverageBps` is raised above 1.05×.
 - **Mint authority:** reassess on any new ftUSD Core module, `masterMinter` change, or `maxSupply`/`globalDebtCeiling` increase.
 - **Redeemability:** reassess if either wrapper's `availableToWithdraw()` falls below 75% of `capital()`, or if `settlementDelay` on the backing circuit breaker is raised.
-- **Peg:** reassess if the Curve spot price diverges >0.5% from `priceUSD(ftUSD)` for more than 24h, or if the pool goes >70/30 imbalanced or loses >50% TVL.
+- **Peg:** reassess if the Curve spot price diverges >0.5% from `priceUSD(ftUSD)` for more than 24h or the pool goes >70/30 imbalanced.
 - **Staking:** reassess if `settlementDelay` is raised, if `convertToAssets(1e6)` ever deviates from `1000000`, or if FT emissions stall for more than two epoch periods.
-- **Audit status:** reassess if any ftUSD audit is published, if the redemption finding is confirmed or refuted, or if the bounty publishes or expands ftUSD contract coverage.
-- **Curve liquidity:** reassess immediately if the sole gauge depositor [`0x3ffebdc5…46ee`](https://etherscan.io/address/0x3ffebdc5130f6072a582f79f3fb61581d3d846ee) withdraws more than 25% of its position — that is the entire external exit and the entire external price reference.
+- **Audit status:** reassess if any ftUSD audit is published, if the redemption finding is confirmed or refuted, or if Sherlock removes or narrows the dynamic production-contract coverage incorporated by the bounty's Additional Scope.
+- **Curve liquidity:** the prior >50% loss trigger has occurred. Reassess on another 25% decline from the September 4 baseline, a material change in the Convex-routed share, or a $100K quote exceeding 2% impact.
 - **Time-based:** reassess in **2 months** — the hedge strategy is new.
 
 ---
@@ -747,4 +741,5 @@ Category 1 is aligned with FT Lend. Cat 2C scores the **FT Lend backing concentr
 
 | Date | Score | Notes |
 | --- | --- | --- |
+| [September 4, 2026](https://github.com/yearn/risk-score/pull/237) | 3.5 | Liquidity reassessment after >85% Curve LP decline; bounty scope corrected |
 | [August 7, 2026](https://github.com/yearn/risk-score/pull/237) | 3.5 | Initial assessment |

--- a/reports/report/flying-tulip-ftusd.md
+++ b/reports/report/flying-tulip-ftusd.md
@@ -775,5 +775,4 @@ Category 1 is aligned with FT Lend. Cat 2C scores the **FT Lend backing concentr
 
 | Date | Score | Notes |
 | --- | --- | --- |
-| [September 4, 2026](https://github.com/yearn/risk-score/pull/237) | 3.4 | Bounty scored at rubric row 2; queued redemption and Curve liquidity refreshed; TRS added as a conditional, not-yet-credited ftUSD swap and propagation path |
-| [August 7, 2026](https://github.com/yearn/risk-score/pull/237) | 3.5 | Initial assessment |
+| [September 4, 2026](https://github.com/yearn/risk-score/pull/237) | 3.4 | Initial assessment |

--- a/reports/report/flying-tulip-ftusd.md
+++ b/reports/report/flying-tulip-ftusd.md
@@ -1,6 +1,6 @@
 # Asset Risk Assessment: Flying Tulip — ftUSD & Staked ftUSD (sftUSD)
 
-- **Assessment Date:** August 7, 2026 (team-response update: September 4, 2026)
+- **Assessment Date:** August 7, 2026 (team-response and TRS update: September 4, 2026)
 - **Token:** ftUSD (stablecoin) and sftUSD (staked ftUSD)
 - **Chain:** Ethereum Mainnet
 - **Token Address:** ftUSD [`0xF7D85EC4E7710f71992752eac2111312e73E9C9C`](https://etherscan.io/address/0xF7D85EC4E7710f71992752eac2111312e73E9C9C) · sftUSD [`0xeb48218a4c35C814C7678cBcae88C6Ee037F7625`](https://etherscan.io/address/0xeb48218a4c35C814C7678cBcae88C6Ee037F7625)
@@ -8,7 +8,7 @@
 - **Medium Risk** — approved with enhanced monitoring. ftUSD is fully collateralized (100.05%), but that backing is **not idle cash — it is lent into Flying Tulip's own money market** by a strategy whose `operators[]` include a plain EOA with `onlyManager` rights to pre-sign hedge trades (no onchain price bound). Normal minting through the current production module is collateralized; separately, the 3/5 Admin Safe retains a technically available privileged path to authorize unbacked issuance. No evidence that path has been used was found. Protocol redemption remains permissionless: sells above available instant capacity enter a six-hour queue, and ultimate settlement depends on FT Lend cash. Curve liquidity fell by more than 85% after the initial assessment, weakening the secondary exit but not removing the primary queued-redemption route. See [Risk Score Assessment](#risk-score-assessment).
 - **Companion report:** the lending market itself is assessed in **[Flying Tulip — FT Lend](./flying-tulip.md)**.
 
-> **Scope.** This report covers **holding ftUSD** and **staking it as sftUSD**. It is a separate risk from supplying to the FT Lend market — different loss paths, different exit mechanics, different concentration profile — and the two should be sized independently. Unless expressly marked as an update, values were verified **August 6, 2026 at block `25697429`** via `cast` and Etherscan. Bug-bounty scope, redemption availability, and Curve liquidity were refreshed **September 4, 2026**, with the latest breaker checks at block `25904377`, in response to team comments.
+> **Scope.** This report covers **holding ftUSD** and **staking it as sftUSD**. It is a separate risk from supplying to the FT Lend market — different loss paths, different exit mechanics, different concentration profile — and the two should be sized independently. Direct TRS position risk is out of scope; TRS is included here only as a new source of ftUSD demand, borrowing, settlement and conditional swap/exit routing. Unless expressly marked as an update, values were verified **August 6, 2026 at block `25697429`** via `cast` and Etherscan. Bug-bounty scope, redemption availability, Curve liquidity and the live Ethereum TRS configuration were refreshed **September 4, 2026**, with the latest breaker checks at block `25904377` and TRS checks through block `25904682`.
 
 ## Overview + Links
 
@@ -16,16 +16,18 @@
 
 **sftUSD** is the staked form — an ERC-4626-style vault at [`0xeb48218a…7625`](https://etherscan.io/address/0xeb48218a4c35C814C7678cBcae88C6Ee037F7625) holding 1,324,455 ftUSD across 107 holders. Critically, **sftUSD does not appreciate in ftUSD terms**; its yield is paid separately in FT tokens.
 
+**TRS** is now live and uses FT Lend for financing, RFQ/Trade for execution and ftUSD as a settlement rail. The Ethereum app exposes ftUSD as collateral and borrowable and lists WBTC-ftUSD, wstETH-ftUSD, USDC-ftUSD and WETH-ftUSD markets. This creates a new use and propagation channel for ftUSD, but not automatically a new independent redemption reserve.
+
 **Links:**
 
 - [Protocol Documentation](https://docs.flyingtulip.com/) · [Contract Addresses](https://docs.flyingtulip.com/contract-addresses/) · [Risks page](https://docs.flyingtulip.com/risks/)
-- [App](https://flyingtulip.com/) · [Blog](https://blog.flyingtulip.com/)
+- [App](https://flyingtulip.com/) · [TRS app](https://flyingtulip.com/trs/swap/) · [TRS overview](https://blog.flyingtulip.com/introducing-total-return-swaps-trs-perps-built-differently/) · [Live TRS configuration](https://api.flyingtulip.com/trs/) · [Blog](https://blog.flyingtulip.com/)
 - [GitHub org `flyingtulipdotcom`](https://github.com/flyingtulipdotcom) (ftUSD repos are **private**)
 - [DeFiLlama — Flying Tulip](https://defillama.com/protocol/flying-tulip) · [Curve ftUSD/USDC pool](https://etherscan.io/address/0xafec61e7a604f8f81f7cab64ec75bfa07c542630)
 
 ## Contract Addresses
 
-All source-verified on Etherscan, including proxy implementations.
+All core ftUSD custody/accounting contracts and the two new engine implementations are source-verified on Etherscan. The ancillary TRS permissioned executor delegates through EIP-7702 to an implementation that was not source-verified at the September 4 check; it is identified explicitly below.
 
 ### ftUSD Core
 
@@ -44,6 +46,17 @@ All source-verified on Etherscan, including proxy implementations.
 | ftUSD USDT wrapper | [`0x28CCa8eEA2cD0498cE91A9da15772A1ce42347D6`](https://etherscan.io/address/0x28CCa8eEA2cD0498cE91A9da15772A1ce42347D6) | 1,417,610 USDT |
 | **Delta-Neutral strategy** | [`0xe0E445967256EE60111e243e0F0F94DD1D351A59`](https://etherscan.io/address/0xe0E445967256EE60111e243e0F0F94DD1D351A59) | `MultiCollateralDeltaNeutralStakingStrategy` — deploys the above into FT Lend |
 | LeverageRfqEngine | [`0x8263a07504d93cB95e0a74f3627bb15faaf140e2`](https://etherscan.io/address/0x8263a07504d93cB95e0a74f3627bb15faaf140e2) | Executes the strategy's hedge orders |
+
+### TRS integration (holder-relevant dependencies)
+
+| Contract | Address | Relevance to ftUSD |
+|---|---|---|
+| LeverageRfqEngine v2 | [`0x93496075909f56d93b33302DF5D1655568Eb6e70`](https://etherscan.io/address/0x93496075909f56d93b33302DF5D1655568Eb6e70) | Executes signed TRS OPEN/CLOSE/SWAP orders; UUPS impl [`0x6595C190…8734`](https://etherscan.io/address/0x6595C1907df6cC7ae81a80C5DcaaB43FD9068734) |
+| RfqEngine v2 | [`0xc64516d58f8b83bc256448bc69d7bf2361557fdb`](https://etherscan.io/address/0xc64516d58f8b83bc256448bc69d7bf2361557fdb) | Trade/RFQ engine and additional FT Lend liquidation module |
+| SessionManager v2 | [`0x880A371CE2C5Dbb2EB47EC0023b358e8aE80071b`](https://etherscan.io/address/0x880A371CE2C5Dbb2EB47EC0023b358e8aE80071b) | Delegated TRS session permissions |
+| Permissioned executor | [`0xa505815A526f1200c17B7ffaE0067318d734b9d8`](https://etherscan.io/address/0xa505815A526f1200c17B7ffaE0067318d734b9d8) | Authorized filler; EIP-7702 delegates to unverified [`0x4428809A…a5c`](https://etherscan.io/address/0x4428809A80082E826FA336521258973Da1251a5c) |
+
+Both v2 engines are registered directly on the same `PositionsManager` that holds ftUSD backing; the new `RfqEngine` is also a liquidation module. The TRS engine requires a user/session signature and approved allowances, applies the signed minimum output, and checks health after execution. Fills are nevertheless restricted to admin-selected permissioned fillers, currently the Admin Safe and the executor above.
 
 ### Staking (sftUSD)
 
@@ -80,7 +93,7 @@ All source-verified on Etherscan, including proxy implementations.
 | 9 | **Rate-limited exit (sftUSD)** | 10% of TVL per window, 6h settlement, admin-settable to **7 days** | 3/5 Safe | Temporary lockup |
 | 10 | **Rewards simply stop** | FT emissions are discretionary; sftUSD's exchange rate is fixed at 1.0, so no emissions means zero yield | epoch settler | Opportunity loss |
 | 11 | **`recoverERC20` / `sweepExcess`** | Owner-callable token recovery on MintAndRedeem and sftUSD | 3/5 Safe | Partial |
-| 12 | **Curve pool flight** | The only secondary-market ftUSD exit and external price reference lost more than 85% of its liquidity after the initial review | market | Exit degradation |
+| 12 | **Curve pool flight** | The only independently verified secondary-market ftUSD exit and external price reference lost more than 85% of its liquidity after the initial review | market | Exit degradation |
 
 ## Audits and Due Diligence Disclosures
 
@@ -90,7 +103,7 @@ The team provides gated portal access to the in-scope ftUSD, ftUSD Position Mana
 |---|---|
 | Public bug bounty | **LIVE** — [Sherlock Flying Tulip Bug Bounty #248](https://audits.sherlock.xyz/bug-bounties/248?tab=scope), max reward 1,000,000 USDC; the bounty's **Additional Scope** incorporates Flying Tulip's dynamic list of all deployed production contracts, including the assessed ftUSD / sftUSD stack (see below) |
 | SEAL Safe Harbor enrolment | **Not enrolled** (absent from the `security-alliance/safe-harbor` registry) |
-| Contract source verification on Etherscan | **PASS** — all contracts above verified |
+| Contract source verification on Etherscan | **PASS for core ftUSD and engine contracts** — ancillary TRS executor delegation target unverified |
 
 - The docs' [Risks page](https://docs.flyingtulip.com/risks/) states a policy of "external audits before enabling capital-bearing features" and lists "Transparency. Publish parameters, addresses, **audit reports**, and incident post-mortems" as a security principle. The audit reports are not public.
 - Only two reviews are publicly confirmable, and **neither covers the assessed contracts**: the token-sale `Escrow` (PeckShield #2025-170, Oct 2025; Cantina Managed, Oct 2025) and the separate **ftPUT** product ([Sherlock contest #1223](https://audits.sherlock.xyz/contests/1223), Jan 2026).
@@ -135,12 +148,15 @@ Global gates: ftUSD `maxSupply` 100M, Core `globalDebtCeiling` 100M, `minTVLForM
 | **Mint ftUSD** | permissionless | ✓ one tx — collateral in, `wrapper.deposit()`, `core.mint()` | 7 bps | per-collateral cap 100M; `minTVLForMint` 5M; `globalDebtCeiling` 100M; `maxSupply` 100M; mint price hardcapped at $1.00 |
 | **Redeem / sell ftUSD through the app** | permissionless | queued when above available instant capacity | 7 bps | breaker has a 10% configured window capacity and 6h queue settlement (admin-settable to 7 days); at the observed frontend state, any sell above 0 ftUSD would enter the queue. Ultimate capacity is capped by FT Lend cash; USDT cash covered 89.2% of wrapper capital |
 | **Swap ftUSD on Curve** | permissionless | ✓ | Curve 0.2% + slippage | secondary exit: ~$100K at 0.38%; slippage rises to ~13.75% at $150K |
+| **Swap ftUSD inside TRS** | signed by user/session; filled by permissioned executor | conditional RFQ; atomic if filled | quoted route + protocol fee | app/config supports ftUSD collateral swaps through external aggregators, self-fill, `mintredeem`, or composite routes; no guaranteed bid or depth, and a funded ftUSD→USDC executable quote was not verified |
 | **Stake (sftUSD)** | permissionless | ✓ | none | `minDepositAmount` 0 |
 | **Unstake (sftUSD)** | permissionless | **✗ above the limit** | none | **10% of TVL per window; excess queued for 6h (`settlementDelay`), admin-settable to 7 days** |
 | **Claim FT rewards** | permissionless | ✓ | none | only if the epoch settler has funded an epoch |
 | Blacklist / burn | 3/5 Safe | ✓ | — | applies at both the ftUSD and sftUSD layers |
 
 **Redemption is permissionless even when it is not immediate.** The breaker can allow same-transaction execution from its available buffer; otherwise the sell enters a six-hour queue. At the September 4 frontend observation, the app reported that any sell above 0 ftUSD would queue. This is delayed withdrawal liquidity, not an unavailable exit. Final settlement remains bounded by FT Lend's available cash for the chosen asset (see [Redemption capacity](#redemption-capacity--the-cascade)).
+
+**TRS is a conditional swap path, not proven independent exit liquidity.** The current frontend creates leverage/collateral-swap orders with a one-hour `validTo`; the engine itself enforces only the signed expiry and has no protocol-level relative minimum or maximum lifetime. A quoted order may fill and settle in seconds, or remain unfilled until cancellation/expiry. If the selected route is `mintredeem`, it inherits ftUSD's redemption capacity and queue; an external-aggregator or self-fill route could add incremental immediate liquidity, but it should not be counted until a funded executable quote demonstrates size, output and withdrawal from the TRS account.
 
 ### Collateralization — the backing chain
 
@@ -451,7 +467,7 @@ Morpho still consumes Flying Tulip's own oracle rather than independently pricin
 
 ### Governance
 
-The same 3-of-5 Gnosis Safe [`0x1118…70Cb`](https://etherscan.io/address/0x1118e1c057211306a40A4d7006C040dbfE1370Cb) with **no timelock** owns every contract in this report. Over ftUSD specifically it is `owner` + `masterMinter` + `pauser` + `blacklister`.
+The same 3-of-5 Gnosis Safe [`0x1118…70Cb`](https://etherscan.io/address/0x1118e1c057211306a40A4d7006C040dbfE1370Cb) with **no timelock** owns every core ftUSD contract and administers the TRS engines. Over ftUSD specifically it is `owner` + `masterMinter` + `pauser` + `blacklister`; it is also an authorized TRS filler. The separate permissioned executor is not owned by the Safe onchain, but the Safe controls whether it remains authorized.
 
 ### Token Mint Authority
 
@@ -469,7 +485,7 @@ The same 3-of-5 Gnosis Safe [`0x1118…70Cb`](https://etherscan.io/address/0x111
 
 ### Programmability
 
-Mint/redeem accounting, the collateral reconciliation and the sftUSD share math are all onchain and verifiable. Against that: proxy upgrades are instant, oracle prices are admin-overridable at the router, FT emissions are entirely discretionary, and the backing strategy's `operators[]` (including a plain EOA) can pre-sign hedge orders with **no price bound** via `onlyManager`. The staking exit is a governed rate limiter, not a programmatic guarantee.
+Mint/redeem accounting, the collateral reconciliation and the sftUSD share math are all onchain and verifiable. Against that: proxy upgrades are instant, oracle prices are admin-overridable at the router, FT emissions are entirely discretionary, and the backing strategy's `operators[]` (including a plain EOA) can pre-sign hedge orders with **no price bound** via `onlyManager`. TRS adds signed session authorization and minimum-output checks, but relies on permissioned fillers and offchain route construction. The staking exit is a governed rate limiter, not a programmatic guarantee.
 
 ### External Dependencies
 
@@ -477,9 +493,10 @@ Mint/redeem accounting, the collateral reconciliation and the sftUSD share math 
 - **Spark & Aave** — FT Lend's wrappers hold zero idle buffer, so redemption capacity ultimately depends on these venues.
 - **Lido / wstETH** — now a live component of the hedge (76.54 wstETH).
 - **Chainlink** — USDC/USD feeds the ftUSD oracle's base leg.
-- **Curve** — the only secondary-market ftUSD exit and external price reference. Its liquidity fell by more than 85% after the initial snapshot; most gauge custody now routes through Convex, so beneficial LP ownership cannot be inferred from the gauge balance alone. Assessed.
+- **Curve** — the only independently verified secondary-market ftUSD exit and external price reference. Its liquidity fell by more than 85% after the initial snapshot; most gauge custody now routes through Convex, so beneficial LP ownership cannot be inferred from the gauge balance alone. Assessed.
+- **TRS / Trade** — a new ftUSD use, borrowing and conditional swap channel built on the same FT Lend account system. The live configuration can route through KyberSwap, Velora, 0x, internal self-fill, `MintAndRedeem`, and composite ftUSD routes. This can improve executable exits only when an independent route actually quotes; `mintredeem` inherits the existing breaker/queue and none of these routes changes the assets backing ftUSD.
 - **Morpho** — two USDC/ftUSD Blue markets holding 629,675 ftUSD (15.0% of supply); the live one is at 86% LLTV and 90.1% utilization. Its oracle reads Flying Tulip's own ftUSD feed, so this is an outward **propagation** channel rather than an independent price check, and pausing the FT oracle proxy would freeze these markets.
-- **CoW Protocol — not a dependency.** An earlier revision listed this after seeing `GPv2Settlement` and a `CowSwapBurner` in ftUSD transfer history and CoW-style naming (`setPreSignature`, `PreSignature`) in the engine. Both were misleading: `preSignature` is `LeverageRfqEngine`'s own `mapping(bytes32 => bool)`, the engine contains **zero** references to GPv2/CoWSwap/vaultRelayer across its 250KB of source, and neither the strategy nor the engine has any allowance to CoW's vault relayer. The `CowSwapBurner` is Curve's fee burner for the ftUSD/USDC pool. Fills go through the engine's own flash-fill path with a caller-supplied `fillTarget` and `fillData`.
+- **CoW Protocol — not a dependency.** `preSignature` is the engines' own order-authorization mapping, not GPv2; the observed `CowSwapBurner` is Curve's fee burner. Current TRS routes are the ones enumerated above, not CoW.
 
 ## Operational Risk
 
@@ -515,6 +532,14 @@ Recommended frequency: **hourly** for peg, oracle divergence and governance; **d
 
 - Track total pool reserves and the gauge's depositor mix. The former dominant EOA exited on August 28; 87.1% of current gauge deposits route through the Convex voter proxy, so monitor both aggregate liquidity and underlying beneficial concentration where observable.
 - Alert on pool imbalance beyond 70/30 and on `A` ramp initiation (`future_A_time` becoming non-zero) — a ramp changes slippage materially and the pool has an admin able to start one.
+
+### TRS / conditional swap liquidity
+
+- Poll the live Ethereum TRS configuration for changes to the engine, SessionManager, permissioned executor, aggregator codes, `minBuyAmountBps`, and `pricingFailureMode`; alert immediately on executor EIP-7702 delegation changes or unverified implementation changes.
+- Sample funded ftUSD→USDC quotes at standard notionals and record route, output, quote-to-fill latency and whether proceeds are withdrawable from the shared account. Do not add quoted TRS depth to Curve or redemption capacity unless the complete route is executable.
+- Separate `mintredeem` and composite mint/redeem fills from external-aggregator/self-fill volume. The former consumes the same breaker/redemption capacity and is not independent liquidity; the latter may be incremental.
+- Track `PermissionedFillerUpdated`, `OrderBroadcast`, `PendingOrderOpened`, `OrderCancelled`, `OrderFill`, and `LeverageFillSettled` on the v2 leverage engine. Alert on >10% expired/unfilled orders over 24h, repeated quote failures, or material execution-price divergence from external spot.
+- Track ftUSD supplied and borrowed by TRS accounts, TRS-related FT Lend utilization, and RFQ liquidations. A rise can increase redemption queue pressure because both TRS and `MintAndRedeem` draw on the same underlying lending cash.
 
 ### Morpho exposure
 
@@ -581,6 +606,12 @@ Recommended frequency: **hourly** for peg, oracle divergence and governance; **d
 
    EXTERNAL:  Curve ftUSD/USDC ~$249K (thin secondary exit + external price reference)
               Morpho 629,675 ftUSD collateral
+
+   TRS / TRADE (conditional holder exit, not counted as independent depth)
+     ftUSD in shared Lend account ─► signed SWAP ─► permissioned RFQ executor
+                                           ├─ Kyber / Velora / 0x
+                                           ├─ internal self-fill
+                                           └─ MintAndRedeem / composite route ─► same queue capacity
 ```
 
 ---
@@ -595,18 +626,19 @@ Recommended frequency: **hourly** for peg, oracle divergence and governance; **d
 - **External acceptance** — 629,675 ftUSD (15.0% of supply) held as collateral in two Morpho Blue markets, the live one comfortably collateralized at ~64.5% LTV against an 86% threshold.
 - **sftUSD holder distribution is healthy** — 107 holders, largest 12.1%.
 - **Currently fully liquid**: sftUSD `availableToWithdraw` is 100% of TVL and no withdrawals are queued.
-- All contracts source-verified; the transient `totalDebt` drift has resolved.
+- Core ftUSD custody, accounting and engine contracts are source-verified; the transient `totalDebt` drift has resolved. The ancillary TRS executor's EIP-7702 delegation target is the exception and is monitored separately.
 
 ### Key Risks
 
 - **The backing is lent into Flying Tulip's own money market** (100% of it, 35.1% of that market's TVL), so ftUSD cannot fail independently of FT Lend, while its price feed is blind to that backing.
 - **A plain EOA in `operators[]` can pre-sign hedge open/close/swap orders with no price or slippage bound** in either the strategy or the execution engine (`onlyManager`, not `onlyOwner`).
-- **A 3/5 Safe with no timelock retains a privileged path to unbacked issuance**, and can blacklist and burn balances at both the token and vault layers and upgrade every contract. The current production mint module is collateralized, and no evidence that the privileged issuance path has been used was found.
+- **A 3/5 Safe with no timelock retains a privileged path to unbacked issuance**, and can blacklist and burn balances at both the token and vault layers and upgrade every core ftUSD contract. The current production mint module is collateralized, and no evidence that the privileged issuance path has been used was found.
 - **sftUSD pays zero yield in ftUSD terms** — the rate is fixed at 1.0 and all return is discretionary FT emissions in a token with ~$28K of DEX liquidity.
 - **sftUSD's exit is rate-limited** at 10% of TVL per window with a 6h delay that the admin can extend to 7 days.
 - **Audit status is unverifiable** for every contract here, with an unconfirmed report of an open medium finding on the redemption path specifically.
 - **The price feed is structurally blind to the backing, and that blindness propagates outside the protocol.** ftUSD is priced off the USDC price and cumulative mint history — nothing in the path reads the collateral. Morpho's ftUSD markets consume that same feed rather than pricing ftUSD independently, and the FT admin Safe can freeze those markets by pausing it.
 - **Redemption remains available through the queue.** The breaker is configured around 10% of wrapper capital per window with six-hour settlement for queued sells. At the observed frontend state every non-zero sell was shown as queued, while current USDT cash covered 89.2% of capital. The restriction delays exit; it does not remove the redemption route. Queued settlement still depends on FT Lend liquidity.
+- **TRS does not yet justify liquidity credit.** It exposes conditional ftUSD swaps through permissioned RFQ execution, external aggregators, self-fill and mint/redeem adapters. No funded executable ftUSD exit was verified; mint/redeem-routed fills reuse the same breaker and queue rather than adding capacity.
 
 ### Critical Risks
 
@@ -622,7 +654,7 @@ Recommended frequency: **hourly** for peg, oracle divergence and governance; **d
 
 ### Critical Risk Gates
 
-- [ ] **Unverified contract source** — **PASS.** All contracts, including proxy implementations, are source-verified.
+- [ ] **Unverified contract source** — **PASS for the assessed ftUSD custody/accounting stack, with a reservation.** Those contracts and both new engine implementations are verified. The ancillary TRS permissioned executor delegates to unverified implementation code, but it does not mint, custody or account for ftUSD and requires signed user/session allowances.
 - [ ] **No audit** — **PASS, with material reservation.** A real audit registry exists but is access-code gated; **zero audits are independently confirmable** for any contract here. Scored down hard in Category 1 rather than gated.
 - [ ] **Unverifiable reserves** — **PASS.** Backing reconciles exactly across four hops at 100.054%.
 - [ ] **Total centralization (single EOA)** — **PASS, marginally.** Root control is a 3/5 multisig. Note however that a plain EOA holds live `onlyManager` operator rights on the Delta-Neutral strategy (hedge order pre-sign), separate from `owner`.
@@ -634,7 +666,7 @@ Recommended frequency: **hourly** for peg, oracle divergence and governance; **d
 #### Category 1: Audits & Historical Track Record (Weight: 20%)
 
 **Subcategory A: Audits — 2.0**
-The privately reviewed audit package provides good coverage from reputable firms, and the live Sherlock bounty has a maximum reward of 1,000,000 USDC and covers Flying Tulip's deployed production contracts through the dynamic contract list incorporated by the bounty's Additional Scope, including the ftUSD / sftUSD stack assessed here. This directly satisfies rubric row 2: multiple reputable reviews and a bounty above $200K. The reports and finding-level details remain non-public, Safe Harbor enrolment was not found, and complexity is high, which prevent a stronger row-1 score; they do not justify an additional half-point penalty above row 2.
+The privately reviewed audit package provides good coverage from reputable firms, and the live Sherlock bounty has a maximum reward of 1,000,000 USDC and covers Flying Tulip's deployed production contracts through the dynamic contract list incorporated by the bounty's Additional Scope, including the ftUSD / sftUSD stack and newly deployed TRS engines. This directly satisfies rubric row 2: multiple reputable reviews and a bounty above $200K. The reports and finding-level details remain non-public, Safe Harbor enrolment was not found, and complexity is high, which prevent a stronger row-1 score; they do not justify an additional half-point penalty above row 2.
 
 **Subcategory B: Historical — 4.0**
 ftUSD is ~5.4 months live with no depeg and no incident, which is clean but uninformative at this age. Supply is $4.2M — the `<$10M` band (4). The peg has a market-based Curve reference, though current depth is thin, and 220 reward epochs have settled, which is a real operating record. The "delta-neutral" mechanism, however, only started working days before the initial snapshot, so the yield strategy itself has **no** meaningful track record.
@@ -654,6 +686,7 @@ Same rule as the [FT Lend report](./flying-tulip.md): **Spark, Aave, Chainlink, 
 What elevates this subcategory is **where principal sits**:
 - **100% of ftUSD backing is a supply claim on FT Lend** (sibling product, Medium/Elevated risk profile, same admin Safe). That is the single unusual dependency — correlated failure of the stablecoin and the money market.
 - Curve is a secondary-market exit / price reference only; primary redeem is `MintAndRedeem`. Current Curve depth is thin, and Convex aggregation obscures beneficial LP ownership. CoW is not a dependency.
+- TRS adds permissioned RFQ execution and KyberSwap/Velora/0x routing to the same account system. This is a new availability and propagation dependency, but it neither changes the backing assets nor supersedes the primary redemption queue.
 
 **Score: 4.5/5** — (5.0 + 4.5 + 4.0) / 3.
 
@@ -670,10 +703,11 @@ Reserves and liabilities are fully onchain, update in real time, and reconcile e
 #### Category 4: Liquidity Risk (Weight: 15%)
 
 - **ftUSD:** permissionless 7 bps protocol redemption remains the primary exit. Amounts above available instant capacity enter a six-hour queue; at the observed frontend state, every non-zero sell was shown as queued. This is delayed withdrawal liquidity, not a missing exit. Ultimate settlement still depends on FT Lend cash. Curve is the immediate secondary route, but fell from ~$1.87M to **~$249K**; a $100K sale clears at about 0.38%, while $150K incurs about 13.75% slippage.
+- **TRS Swap:** a signed ftUSD collateral swap can settle atomically if the permissioned executor obtains a route. The current frontend uses a one-hour order expiry and supports aggregator, self-fill and mint/redeem routes, but no funded executable exit or persistent depth was verified. `mintredeem` routes reuse the existing breaker/queue, so no independent liquidity credit is assigned.
 - **sftUSD:** materially worse. Exit is **rate-limited to 10% of TVL per window with a 6h settlement delay, admin-extendable to 7 days**, and there is no secondary market for sftUSD itself. That is squarely the rubric's "withdrawal queues or restrictions" row (4).
 - Above roughly the Curve pool's $130K USDC reserve, queued protocol redemption is the practical route. At the onchain check, the breaker had no active queue; the frontend nevertheless displayed a zero instant threshold, so current execution should be assumed queued unless a live quote shows otherwise.
 
-**Score: 3.5/5** — the six-hour permissionless redemption queue materially offsets the thin Curve market: a holder can exit without accepting Curve's double-digit large-trade impact, subject to delayed settlement and FT Lend cash. The score remains between rubric rows 3 and 4 because both ftUSD and sftUSD are queue-gated at size, the secondary market is below $1M, and governance can extend settlement to seven days without a timelock.
+**Score: 3.5/5** — the six-hour permissionless redemption queue materially offsets the thin Curve market: a holder can exit without accepting Curve's double-digit large-trade impact, subject to delayed settlement and FT Lend cash. TRS is monitored as a potential additional route but does not lower the score until funded quotes demonstrate repeatable, independent capacity. The score remains between rubric rows 3 and 4 because both ftUSD and sftUSD are queue-gated at size, the verified secondary market is below $1M, and governance can extend settlement to seven days without a timelock.
 
 #### Category 5: Operational Risk (Weight: 5%)
 
@@ -696,7 +730,7 @@ Same team, entity and governance-transparency profile as the lending report (pub
 
 **Optional modifiers:** none apply — the asset is <1 year old and supply is far below $500M.
 
-Category 1 is aligned with FT Lend. Cat 2C scores the **FT Lend backing concentration**, not Spark/Aave/Chainlink as high-risk venues. The gap versus lending is driven by Programmability, FT Lend-as-backing, the leveraged collateral structure, and staked-exit liquidity.
+Category 1 is aligned with FT Lend. Cat 2C scores the **FT Lend backing concentration**, not Spark/Aave/Chainlink as high-risk venues. TRS adds an execution and propagation dependency but no score movement because it does not alter reserves and has not yet demonstrated independent exit depth. The gap versus lending is driven by Programmability, FT Lend-as-backing, the leveraged collateral structure, and staked-exit liquidity.
 
 ### Risk Tier
 
@@ -728,6 +762,7 @@ Category 1 is aligned with FT Lend. Cat 2C scores the **FT Lend backing concentr
 - **Hedge:** the leg went live around August 3–6, 2026. Reassess after 30 days of live operation, or immediately if `targetLeverageBps` is raised above 1.05×.
 - **Mint authority:** reassess on any new ftUSD Core module, `masterMinter` change, or `maxSupply`/`globalDebtCeiling` increase.
 - **Redeemability:** reassess if queued claims exceed available FT Lend cash, any claim remains unsettled beyond 6h, the frontend and onchain breaker capacity remain materially inconsistent, or `settlementDelay` is raised.
+- **TRS liquidity:** reassess after a funded ftUSD→USDC route is verified at material size, if external/self-fill becomes a repeatable independent exit, if >10% of orders expire unfilled over 24h, or after any engine/filler/executor-delegation change or failed settlement.
 - **Peg:** reassess if the Curve spot price diverges >0.5% from `priceUSD(ftUSD)` for more than 24h or the pool goes >70/30 imbalanced.
 - **Staking:** reassess if `settlementDelay` is raised, if `convertToAssets(1e6)` ever deviates from `1000000`, or if FT emissions stall for more than two epoch periods.
 - **Audit status:** reassess if any ftUSD audit is published, if the redemption finding is confirmed or refuted, or if Sherlock removes or narrows the dynamic production-contract coverage incorporated by the bounty's Additional Scope.
@@ -740,5 +775,5 @@ Category 1 is aligned with FT Lend. Cat 2C scores the **FT Lend backing concentr
 
 | Date | Score | Notes |
 | --- | --- | --- |
-| [September 4, 2026](https://github.com/yearn/risk-score/pull/237) | 3.4 | Bounty scored at rubric row 2; queued protocol redemption incorporated; Curve liquidity and bounty scope refreshed |
+| [September 4, 2026](https://github.com/yearn/risk-score/pull/237) | 3.4 | Bounty scored at rubric row 2; queued redemption and Curve liquidity refreshed; TRS added as a conditional, not-yet-credited ftUSD swap and propagation path |
 | [August 7, 2026](https://github.com/yearn/risk-score/pull/237) | 3.5 | Initial assessment |

--- a/reports/report/flying-tulip-ftusd.md
+++ b/reports/report/flying-tulip-ftusd.md
@@ -1,0 +1,750 @@
+# Asset Risk Assessment: Flying Tulip — ftUSD & Staked ftUSD (sftUSD)
+
+- **Assessment Date:** August 7, 2026
+- **Token:** ftUSD (stablecoin) and sftUSD (staked ftUSD)
+- **Chain:** Ethereum Mainnet
+- **Token Address:** ftUSD [`0xF7D85EC4E7710f71992752eac2111312e73E9C9C`](https://etherscan.io/address/0xF7D85EC4E7710f71992752eac2111312e73E9C9C) · sftUSD [`0xeb48218a4c35C814C7678cBcae88C6Ee037F7625`](https://etherscan.io/address/0xeb48218a4c35C814C7678cBcae88C6Ee037F7625)
+- **Final Score: 3.5/5.0**
+- **Medium Risk** — approved with enhanced monitoring. ftUSD is fully collateralized (100.05%) but that backing is **not idle cash — it is lent into Flying Tulip's own money market** by a strategy whose `operators[]` include a plain EOA with `onlyManager` rights to pre-sign hedge trades (no onchain price bound). The 3/5 admin Safe can mint unbacked ftUSD, blacklist and burn balances. Redemption is permissionless but rate-limited and capped by FT Lend's cash — ~15% of the USDT backing is not withdrawable today. The price feed is structurally blind to the backing. See [Risk Score Assessment](#risk-score-assessment).
+- **Companion report:** the lending market itself is assessed in **[Flying Tulip — FT Lend](./flying-tulip.md)**.
+
+> **Scope.** This report covers **holding ftUSD** and **staking it as sftUSD**. It is a separate risk from supplying to the FT Lend market — different loss paths, different exit mechanics, different concentration profile — and the two should be sized independently. All values verified **August 6, 2026 at block `25697429`** via `cast` and Etherscan.
+
+## Overview + Links
+
+**ftUSD** is Flying Tulip's stablecoin. Users mint 1:1 against USDC or USDT through `MintAndRedeem` and can redeem the same way, paying 7 bps each direction. It is marketed as a "delta-neutral yield stablecoin": the strategy supplies the original USDC/USDT principal to Flying Tulip's own lending market, borrows WETH from that same market, swaps the borrowed WETH for wstETH, and deposits the wstETH back into the market as leveraged collateral. Gross collateral therefore includes USDC/USDT and wstETH, offset by WETH debt; the strategy's net equity, not its gross assets, backs ftUSD.
+
+**sftUSD** is the staked form — an ERC-4626-style vault at [`0xeb48218a…7625`](https://etherscan.io/address/0xeb48218a4c35C814C7678cBcae88C6Ee037F7625) holding 1,324,455 ftUSD across 107 holders. Critically, **sftUSD does not appreciate in ftUSD terms**; its yield is paid separately in FT tokens.
+
+**Links:**
+
+- [Protocol Documentation](https://docs.flyingtulip.com/) · [Contract Addresses](https://docs.flyingtulip.com/contract-addresses/) · [Risks page](https://docs.flyingtulip.com/risks/)
+- [App](https://flyingtulip.com/) · [Blog](https://blog.flyingtulip.com/)
+- [GitHub org `flyingtulipdotcom`](https://github.com/flyingtulipdotcom) (ftUSD repos are **private**)
+- [DeFiLlama — Flying Tulip](https://defillama.com/protocol/flying-tulip) · [Curve ftUSD/USDC pool](https://etherscan.io/address/0xafec61e7a604f8f81f7cab64ec75bfa07c542630)
+
+## Contract Addresses
+
+All source-verified on Etherscan, including proxy implementations.
+
+### ftUSD Core
+
+| Contract | Address | Role | Implementation |
+|---|---|---|---|
+| **ftUSD** (`FlyingTulipUSD`) | [`0xF7D85EC4E7710f71992752eac2111312e73E9C9C`](https://etherscan.io/address/0xF7D85EC4E7710f71992752eac2111312e73E9C9C) | FiatToken-style stablecoin, 6 dec, UUPS | [`0xf47bb65f…1885`](https://etherscan.io/address/0xf47bb65fb0886be183db541afce555345e3e1885) |
+| ftUSD Core | [`0x56c5892B0cF41B792217CCDD208f0FA85B178ca9`](https://etherscan.io/address/0x56c5892B0cF41B792217CCDD208f0FA85B178ca9) | sole `minter()`; debt-ceiling module gate | [`0x986841b7…5440`](https://etherscan.io/address/0x986841b77f3aa934d315d48121842e3c622e5440) |
+| MintAndRedeem | [`0xAa48EcBC843cF7E9A29155D112b8Cb27902bD23C`](https://etherscan.io/address/0xAa48EcBC843cF7E9A29155D112b8Cb27902bD23C) | only enabled mint module; holds collateral accounting | [`0x8852b132…c3c6`](https://etherscan.io/address/0x8852b132b72613a16f1e3960978a3d45c0a7c3c6) |
+| ftUSD price oracle | [`0xA69f7a38B6c91a4bc2477f097DC8a1F16DAADFf8`](https://etherscan.io/address/0xA69f7a38B6c91a4bc2477f097DC8a1F16DAADFf8) | `FtUsdMintRedeemOracleProxy` — redemption-value feed | — |
+
+### Backing custody chain
+
+| Contract | Address | Holds |
+|---|---|---|
+| ftUSD USDC wrapper | [`0x6aaf84563Cdb03a22Cd92EE2553698beE87E837D`](https://etherscan.io/address/0x6aaf84563Cdb03a22Cd92EE2553698beE87E837D) | 2,781,367 USDC |
+| ftUSD USDT wrapper | [`0x28CCa8eEA2cD0498cE91A9da15772A1ce42347D6`](https://etherscan.io/address/0x28CCa8eEA2cD0498cE91A9da15772A1ce42347D6) | 1,417,610 USDT |
+| **Delta-Neutral strategy** | [`0xe0E445967256EE60111e243e0F0F94DD1D351A59`](https://etherscan.io/address/0xe0E445967256EE60111e243e0F0F94DD1D351A59) | `MultiCollateralDeltaNeutralStakingStrategy` — deploys the above into FT Lend |
+| LeverageRfqEngine | [`0x8263a07504d93cB95e0a74f3627bb15faaf140e2`](https://etherscan.io/address/0x8263a07504d93cB95e0a74f3627bb15faaf140e2) | Executes the strategy's hedge orders |
+
+### Staking (sftUSD)
+
+| Contract | Address | Role |
+|---|---|---|
+| **sftUSD** | [`0xeb48218a4c35C814C7678cBcae88C6Ee037F7625`](https://etherscan.io/address/0xeb48218a4c35C814C7678cBcae88C6Ee037F7625) | ERC-4626-style staking vault, UUPS, impl [`0xea95e463…b6da`](https://etherscan.io/address/0xea95e4636badc00881f8f73a0623b0fe8627b6da) |
+| ftftUSD wrapper | [`0xB44a9C40EFc05Eb014EfFEac3CBed6A31F8cB87f`](https://etherscan.io/address/0xb44a9c40efc05eb014effeac3cbed6a31f8cb87f) | `ftYieldWrapperV2` — holds the staked ftUSD |
+| Staking CircuitBreaker | [`0xCB210509F5AE2b3843B7Fb8Bb90bAFF9cE4f7355`](https://etherscan.io/address/0xCB210509F5AE2b3843B7Fb8Bb90bAFF9cE4f7355) | Rate-limits withdrawals |
+| Epoch settler | [`0xBAE14f050Fb8cDa4D16ab47DBEC67793c7c0b566`](https://etherscan.io/address/0xBAE14f050Fb8cDa4D16ab47DBEC67793c7c0b566) | Funds FT reward epochs |
+
+### Governance
+
+| Role | Address | Notes |
+|---|---|---|
+| **Admin Safe** | [`0x1118e1c057211306a40A4d7006C040dbfE1370Cb`](https://etherscan.io/address/0x1118e1c057211306a40A4d7006C040dbfE1370Cb) | **3 of 5, no timelock.** ftUSD `owner` + `masterMinter` + `pauser` + `blacklister`; owner of Core, MintAndRedeem, both wrappers, sftUSD, the staking breaker, and the Delta-Neutral strategy |
+| Strategy operator (Safe) | [`0x5557729b169082f07d3131D560E2f2cb5e6c48f6`](https://etherscan.io/address/0x5557729b169082f07d3131D560E2f2cb5e6c48f6) | 3/5 Safe, identical signers to admin; `operators[]` = true |
+| **Strategy operator (EOA)** | [`0x8dc8f616af6c146906b218f2acbdc2d27c9ac221`](https://etherscan.io/address/0x8dc8f616af6c146906b218f2acbdc2d27c9ac221) | **Plain EOA** (`operators[]` = true since block 25674942 / Aug 3, 2026). `onlyManager` trade/ops rights — not `owner` |
+| Staking breaker guardian | [`0xdc86aD63Ca7dB1d8b703598b0735c08d5374c7eA`](https://etherscan.io/address/0xdc86aD63Ca7dB1d8b703598b0735c08d5374c7eA) | — |
+| Staking breaker operator | [`0x765224780AD888285B03af221f528D0a6824994d`](https://etherscan.io/address/0x765224780AD888285B03af221f528D0a6824994d) | — |
+| YieldClaimer | [`0x88432bB6EA62e774cB6d87995CC5277568d01397`](https://etherscan.io/address/0x88432bB6EA62e774cB6d87995CC5277568d01397) | Holds wrapper `execute()` arbitrary-call |
+
+### Can Holders Lose Money?
+
+| # | Path | Mechanism | Gating | Severity |
+|---|---|---|---|---|
+| 1 | **Unbacked mint** | Safe registers a new ftUSD Core module with an arbitrary ceiling, or replaces `minter()`, issuing ftUSD with no collateral | 3/5 Safe, no timelock | Total dilution |
+| 2 | **Blacklist + balance wipe** | ftUSD `blacklist` then `wipeBlacklistedAddress` freezes and **burns** a holder's balance | 3/5 Safe | Total, targeted |
+| 3 | **sftUSD balance wipe** | The staking vault has its **own** `wipeBlacklistedAddress` — a second, independent seizure layer | 3/5 Safe | Total, targeted |
+| 4 | **Contract upgrade** | ftUSD, Core, MintAndRedeem, sftUSD and both wrappers are UUPS proxies upgradeable to arbitrary code | 3/5 Safe | Total |
+| 5 | **Backing impaired inside FT Lend** | The collateral is a supply position in Flying Tulip's own market. Bad debt, a pause, or an admin action there impairs ftUSD's backing | structural | Partial to total |
+| 6 | **Bad hedge execution** | Strategy `operators` pre-sign open/close/swap orders (`onlyManager`) with **no price or slippage bound**; a bad fill is a direct loss to backing | `operators[]` incl. **one EOA** | Partial |
+| 7 | **`execute()` arbitrary call** | Strategy `owner` and wrapper `yieldClaimer` can forward arbitrary calls through contracts holding the backing | 3/5 Safe / YieldClaimer | Total |
+| 8 | **Redemption capacity shortfall** | Redeeming requires FT Lend to have withdrawable liquidity, which requires Spark/Aave to have it | structural | Temporary to partial |
+| 9 | **Rate-limited exit (sftUSD)** | 10% of TVL per window, 6h settlement, admin-settable to **7 days** | 3/5 Safe | Temporary lockup |
+| 10 | **Rewards simply stop** | FT emissions are discretionary; sftUSD's exchange rate is fixed at 1.0, so no emissions means zero yield | epoch settler | Opportunity loss |
+| 11 | **`recoverERC20` / `sweepExcess`** | Owner-callable token recovery on MintAndRedeem and sftUSD | 3/5 Safe | Partial |
+| 12 | **Curve pool flight** | The only external ftUSD exit and the only external price reference | market | Exit degradation |
+
+## Audits and Due Diligence Disclosures
+
+The team provides gated portal access to the in-scope ftUSD, ftUSD Position Manager, Yield Claimer cotnracts audited by reputable firms.
+
+| Item | Status |
+|---|---|
+| Public bug bounty | **LIVE** — [Sherlock Flying Tulip Bug Bounty #248](https://audits.sherlock.xyz/bug-bounties/248?tab=scope), max reward 1,000,000 USDC; **scope is ftPUT + FT OFT**, not ftUSD / sftUSD / MintAndRedeem (see below) |
+| SEAL Safe Harbor enrolment | **Not enrolled** (absent from the `security-alliance/safe-harbor` registry) |
+| Contract source verification on Etherscan | **PASS** — all contracts above verified |
+
+- The docs' [Risks page](https://docs.flyingtulip.com/risks/) states a policy of "external audits before enabling capital-bearing features" and lists "Transparency. Publish parameters, addresses, **audit reports**, and incident post-mortems" as a security principle. The audit reports are not public.
+- Only two reviews are publicly confirmable, and **neither covers the assessed contracts**: the token-sale `Escrow` (PeckShield #2025-170, Oct 2025; Cantina Managed, Oct 2025) and the separate **ftPUT** product ([Sherlock contest #1223](https://audits.sherlock.xyz/contests/1223), Jan 2026).
+
+**Contract complexity is high:** module-gated minting on ftUSD Core, a discretionary Delta-Neutral strategy whose hedge orders carry no onchain price bound, wrapper/oracle paths into FT Lend, and a queued staking vault with an admin-extendable delay. Complexity of this order is precisely where public, finding-level audit disclosure matters most.
+
+### Bug Bounty
+
+**LIVE.** [Sherlock's Flying Tulip Bug Bounty #248](https://audits.sherlock.xyz/bug-bounties/248?tab=scope) has been live since June 18, 2026 and advertises a maximum reward of **1,000,000 USDC**. The [Scope](https://audits.sherlock.xyz/bug-bounties/248?tab=scope) tab is public: in-scope source is `flyingtulipdotcom/ftPUT` (`PutManager`, `pFT`, `ftYieldWrapper`, `CircuitBreaker`, Aave strategy, oracle/ACL) plus listed onchain deployments of that product and the FT OFT token — the same product family as [Sherlock contest #1223](https://audits.sherlock.xyz/contests/1223).
+
+**Against this report's contracts:** none of ftUSD, ftUSD Core, `MintAndRedeem`, the ftUSD oracle, the Delta-Neutral strategy, sftUSD, the staking breaker, or the ftUSD wrappers appear in that scope. Two addresses that are listed also appear here, but only as shared infrastructure / reward token — not as coverage of the assessed mint/redeem/staking path:
+
+| Address | Role in this report | In bounty scope? |
+|---|---|---|
+| [`0x88432bB6…1397`](https://etherscan.io/address/0x88432bB6EA62e774cB6d87995CC5277568d01397) | `YieldClaimer` (wrapper `execute`) | **Yes** |
+| [`0x5DD1A7A3…082c`](https://etherscan.io/address/0x5DD1A7A369e8273371d2DBf9d83356057088082c) | FT token (sftUSD emissions) | **Yes** (FT OFT) |
+
+## Historical Track Record
+
+- **Production history:** ftUSD [deployed February 21, 2026](https://etherscan.io/tx/0x52e7d46b7e166b8e30c5d38a09d93c44537bcb77b439e5b125d8b51d5670ea21), live at the February 23 TGE — **~5.4 months**. sftUSD has settled **220 reward epochs**.
+- **Supply:** 4,196,697 ftUSD against a `maxSupply` cap of 100M (raised from 5M). Of that, **1,324,455 (31.6%) is staked** as sftUSD and 1,428,403 is supplied into FT Lend.
+- **Peg:** the protocol's oracle reads $0.9988. Independently, the Curve pool is near-balanced at 971,101 ftUSD / 903,390 USDC with `get_virtual_price()` = 1.000464 — so the peg is **externally corroborated**, not merely self-reported.
+- **Incidents / depegs:** **NONE FOUND** through August 2026.
+- **Third-party acceptance, with a caveat:** [Morpho](https://etherscan.io/address/0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb) holds **629,675 ftUSD (15.0% of supply)** as collateral across two USDC markets. That is genuine external adoption for an asset this young — but Morpho does **not** independently price ftUSD; its oracle consumes Flying Tulip's own feed. See [The Morpho ftUSD markets](#the-morpho-ftusd-markets).
+- **Accounting drift resolved.** An earlier check (August 3) found `Core.totalDebt` exceeding `totalSupply` by 40,310 ftUSD. At this block the two are **exactly equal** (4,196,696.769396 both). The drift was transient.
+
+## Funds Management
+
+### Minting and redemption
+
+`MintAndRedeem` is the only enabled module on ftUSD Core. Mint is atomic: collateral transfers in, `wrapper.deposit()` is called, then `core.mint()` issues ftUSD — all in one transaction.
+
+| Parameter | USDC | USDT |
+|---|---|---|
+| Enabled | ✓ | ✓ |
+| `mintFeeBps` / `redeemFeeBps` | 7 / 7 | 7 / 7 |
+| `maxValueFtUSD` (per-collateral cap) | 100M | 100M |
+| `mintPriceHardcapWad` | 1.0 — collateral never valued above $1 | 1.0 |
+| Accounted collateral | 2,781,367 | 1,417,610 |
+
+Global gates: ftUSD `maxSupply` 100M, Core `globalDebtCeiling` 100M, `minTVLForMint` 5,000,000. Accrued fees: 6,575.28 ftUSD held on `MintAndRedeem`, sweepable by the owner via `sweepFees`.
+
+**Redemption pricing is not a flat 1:1.** `redeemPriceBreakdown` returns a decomposition of `spotFactorWad`, `avgMintFactorWad` and `effectiveRedeemFactorWad` — redemptions are priced against a historical average mint factor, not purely spot. This is the mechanism the unverified audit finding referenced above concerns, and it is the single most important thing to model before sizing a large ftUSD position.
+
+### Accessibility
+
+| Action | Who | Atomic? | Fees | Limits / gating |
+|---|---|:---:|---|---|
+| **Mint ftUSD** | permissionless | ✓ one tx — collateral in, `wrapper.deposit()`, `core.mint()` | 7 bps | per-collateral cap 100M; `minTVLForMint` 5M; `globalDebtCeiling` 100M; `maxSupply` 100M; mint price hardcapped at $1.00 |
+| **Redeem ftUSD** | permissionless | ✓ up to the window cap | 7 bps | **10% of wrapper capital per window, 6h settlement beyond that** (admin-settable to 7 days); total capacity capped by FT Lend's cash — USDT is ~15% short today. Priced off `min(spot, avgMint)` factors, not flat 1:1 |
+| **Sell ftUSD** | permissionless | ✓ | Curve 0.2% + slippage | ~$500K at 0.30%; USDC side exhausted above ~$900K |
+| **Stake (sftUSD)** | permissionless | ✓ | none | `minDepositAmount` 0 |
+| **Unstake (sftUSD)** | permissionless | **✗ above the limit** | none | **10% of TVL per window; excess queued for 6h (`settlementDelay`), admin-settable to 7 days** |
+| **Claim FT rewards** | permissionless | ✓ | none | only if the epoch settler has funded an epoch |
+| Blacklist / burn | 3/5 Safe | ✓ | — | applies at both the ftUSD and sftUSD layers |
+
+**Redemption is permissionless and same-transaction up to the window cap.** Beyond ~10% of wrapper capital it queues for 6 hours, and total redeemable size is bounded by FT Lend's available cash for that asset — a constraint that is **already binding on USDT** (see [Redemption capacity](#redemption-capacity--the-cascade)). "Atomic" is a property of the transaction, not a guarantee of capacity.
+
+### Collateralization — the backing chain
+
+Complete reconciliation at block `25697429`:
+
+```
+User mints ftUSD with USDC/USDT
+   └─► MintAndRedeem  0xAa48EcBC…D23C     (holds ~0 collateral — custody is NOT here)
+         └─► wrapper.deposit()
+               ftUSD-USDC wrapper 0x6aaf8456…837D   capital 2,781,366.71 USDC
+               ftUSD-USDT wrapper 0x28CCa8eE…47D6   capital 1,417,609.56 USDT
+                     └─► MultiCollateralDeltaNeutralStakingStrategy 0xe0E44596…1A59
+                           ├─► FT Lend: 2,780,139.26 USDC supplied
+                           ├─► FT Lend: 1,417,609.56 USDT supplied
+                           ├─► FT Lend: 76.54 wstETH supplied (bought with borrowed WETH)
+                           ├─► FT Lend: 95.01 WETH borrowed (matching hedge liability)
+                           └─► Aave: 1,227.45 USDC residual
+```
+
+| Check | Value |
+|---|---|
+| ftUSD `totalSupply()` | 4,196,696.77 |
+| ftUSD Core `totalDebt()` | 4,196,696.77 ✓ |
+| `accountedCollateralTvl()` | 4,198,976.27 |
+| — USDC / USDT components | 2,781,366.71 / 1,417,609.56 ✓ |
+| Located in wrappers | 2,781,366.71 / 1,417,609.56 ✓ |
+| **Collateral ratio** | **100.054%** |
+
+**The backing genuinely exists and reconciles to the wei.** That is a real strength and better than many larger stablecoins. The risk is not that the collateral is missing — it is *where* the collateral is.
+
+**This is a leveraged portfolio, not a vault holding only stablecoins.** The original ftUSD principal remains predominantly supplied as USDC/USDT, while the strategy adds a long wstETH position financed by WETH debt. Ordinary ETH/USD moves should largely offset across those two ETH-denominated legs, but wstETH/ETH basis risk, borrowing costs, unwind liquidity, and execution losses remain. If wstETH cannot be sold and the WETH debt repaid promptly, redemptions can lose capacity; if wstETH is impaired relative to WETH, the unmatched loss reduces ftUSD backing.
+
+### The backing is lent into Flying Tulip's own market
+
+ftUSD's collateral is not idle cash. It is a **supplier position in FT Lend**, the protocol's own money market, worth **$4.38M = 35.1% of that market's entire TVL**.
+
+Consequences for an ftUSD holder:
+
+1. **You are a lender in FT Lend whether you intended to be or not.** Every risk in the [FT Lend report](./flying-tulip.md) — bad debt with no backstop, admin upgrade, oracle override, Spark/Aave dependency with zero idle buffer for your ftUSD. Most of the time it's not a problem, because Spark and Aave have big TVL and no liquidity rarely occurs.
+2. **The circle closes.** ftUSD is *also* an accepted collateral in that market (11.4% of its TVL) and *also* borrowable there. A shock propagates in a loop rather than being absorbed.
+3. **Your price feed does not read your backing.** `FtUsdMintRedeemOracleProxy` prices ftUSD from Chainlink USDC/USD and the `MintAndRedeem` redeem factor, which is derived from cumulative mint history rather than the accounted collateral deployed inside FT Lend. A genuine impairment would not surface in that feed. The Curve pool is the only external market signal.
+4. **Redemption capacity is not independent.** Redeeming at size requires FT Lend to have withdrawable liquidity, which requires Spark/Aave to have it.
+
+### The hedge, and who runs it
+
+The "delta-neutral" leg is now live. It was **not running as recently as August 3** (0 wstETH, 0.34 WETH debt); by August 6 it holds 76.54 wstETH as collateral and owes 95.01 WETH — 99.6% of all WETH debt in FT Lend. `targetLeverageBps` = 10500 (1.05×), `borrowAsset` = WETH, `stakingAsset` = wstETH. The WETH is borrowed from FT Lend itself: external WETH suppliers economically fund the loan, while the same Flying Tulip 3/5 Safe controls both the borrower strategy and FT Lend's administrative configuration. These are therefore related, vertically controlled components rather than independent counterparties.
+
+**Losses can propagate in both directions.** A hedge loss reduces the net equity backing ftUSD; if it also leaves unrecoverable WETH debt, FT Lend's WETH suppliers can absorb bad debt. Conversely, FT Lend illiquidity or an administrative restriction can prevent the strategy from withdrawing stablecoins or unwinding wstETH, reducing ftUSD redemption capacity even before a permanent accounting loss occurs.
+
+**Control is split between `owner` and `operators`:**
+
+| Layer | Who | Gate | Powers |
+|---|---|---|---|
+| `owner()` | 3/5 Admin Safe (was deployer EOA [`0x92c3eb78…61f4`](https://etherscan.io/address/0x92c3eb785069f58657bfcaa116d9ce7d56e361f4) until block 25302049) | `onlyOwner` | Config: `setOperator`, `setLeverageEngine`, `setCollateralWrapper(s)`, `setftYieldWrapper`; also **`execute(address,uint256,bytes)`** |
+| `operators` | [`0x5557729b…48f6`](https://etherscan.io/address/0x5557729b169082f07d3131D560E2f2cb5e6c48f6) — 3/5 Safe, identical signers | `onlyManager` | See operator action list below |
+| `operators` | **[`0x8dc8f616…c221`](https://etherscan.io/address/0x8dc8f616af6c146906b218f2acbdc2d27c9ac221) — plain EOA** (codesize 0; `OperatorSet` at block [`25674942`](https://etherscan.io/tx/0x4f642f298395d44d0fdfe90126d24ab5f58f3fae5f86d9a915b98e777b5db198)) | `onlyManager` | Same operator action list |
+
+`onlyManager` = `msg.sender == owner() || operators[msg.sender]`. Operators share **trade/ops** rights with the owner under that modifier. They cannot change the operator set or call the strategy's separate arbitrary-call `execute(address,uint256,bytes)` function, which are both `onlyOwner`; this restriction does not apply to filling pre-signed RFQ orders.
+
+**Operator (`onlyManager`) actions:**
+
+| Function | What it does |
+|---|---|
+| `approveOpenOrder` | Pre-signs an open hedge order via `LeverageRfqEngine` (borrow WETH / buy wstETH path) |
+| `approveCloseOrder` | Pre-signs a close hedge order |
+| `approveSwapCollateralOrder` | Pre-signs a collateral-swap order |
+| `revokeOrder` / `revokeOrderByDigest` | Revokes a pending pre-signed order |
+| `cancelOrder` | Cancels an order |
+| `setTargetLeverageBps` | Sets the strategy's target leverage parameter |
+| `claimStakingYield` | Claims staking yield on the hedge leg |
+
+Those `approve*Order` calls invoke `pm.approveBorrow` / `pm.approveEngine` and pre-sign through `LeverageRfqEngine` — that is the path that moves hedge risk on the backing.
+
+**Order validation carries no price bound.** `_validateCommonOrder` checks only that `order.user == address(this)`, that the order has not expired, and that both amounts are non-zero. `_validateOpenOrder` adds a direction check (sell WETH, buy wstETH). There is **no price check, no slippage bound**, and `targetLeverageBps` is not enforced in validation — it is used for previews. `LeverageRfqEngine.broadcastOrder` only checks `order.user == msg.sender` and pre-signs; the engine source contains no oracle reference at all.
+
+**Net: a single EOA with `operators[] = true` can pre-sign hedge open/close/swap orders on the strategy at an arbitrary execution price.** It cannot change the operator set or call the strategy's separate arbitrary-call `execute(address,uint256,bytes)` function; those administrative powers are `onlyOwner`. However, once the EOA pre-signs an RFQ order, anyone—including that EOA or an accomplice—can fill it through the public `LeverageRfqEngine` fill functions. The only onchain backstop on fills is the `PositionsManager` health-factor check, which does not enforce an oracle-relative price or slippage limit. This is the most acute finding in this report.
+
+**Live example (Aug 12, 2026) — authorise ≠ execute:**
+
+1. **Pre-sign** — operator EOA [`0x8dC8…c221`](https://etherscan.io/address/0x8dC8f616Af6C146906B218f2acbdc2D27C9ac221) called `approveOpenOrder` on the strategy ([tx `0x0d9e6a…dab9`](https://etherscan.io/tx/0x0d9e6a543935e31ef8323ccadc624329a8f10274c3e5a8adec3e6d2d1ae0dab9), block `25738326`): OPEN **10 WETH → min 8.048 wstETH**, `feeAmount` 0, ~20 min `validTo`. Events: PM `borrowAllowance` for the leverage engine (+10 WETH), engine `PreSignature` + `OrderBroadcast` (digest `0x13e44b…8d92`). **No tokens moved.**
+2. **Fill** — five blocks later, a separate filler [`0xa505…b9d8`](https://etherscan.io/address/0xa505815A526f1200c17B7ffaE0067318d734b9d8) called `openLeverageFlash` on `LeverageRfqEngine` ([tx `0x1b0ea2…aefe`](https://etherscan.io/tx/0x1b0ea29d9fa6dbf1776225dca3f7d63081858288b9157d086ee74ec8fbe2aefe), block `25738331`) and completed the borrow/swap/deposit. `filledDigests[digest] = true`.
+
+Implied rate on that order (~1.2425 WETH/wstETH) was ~0.09% under fair `stEthPerToken` at the pre-sign block — normal ops sizing, not a bad fill. It still demonstrates the split: the EOA alone locks the limit price; any filler can take it; PM only gates size via HF.
+
+### Staked ftUSD (sftUSD)
+
+| Property | Value |
+|---|---|
+| `totalAssets` / `totalSupply` | 1,324,454.74 / 1,324,454.74 |
+| **`convertToAssets(1e6)`** | **exactly `1000000`** |
+| Underlying wrapper strategies | **0 configured**, `deployed()` = 0 — the ftUSD sits idle |
+| Reward token | **FT**, 139,602.48 pending in the vault (~$13.9K) |
+| Epochs settled | 220 |
+| Holders | 107 |
+| Paused | false |
+
+**sftUSD never appreciates in ftUSD terms.** The exchange rate is fixed at 1.000000 and the underlying wrapper has no strategy, so 100% of the return is FT token emissions, claimed separately via `claim()`. Those emissions are funded by the epoch settler at its discretion — nothing obliges it. On the lending side of the protocol the same mechanism has paid **zero** emissions to WBTC and ftUSD suppliers for the market's entire life, so "emissions may simply not arrive" is a demonstrated behaviour, not a hypothetical.
+
+The reward token itself is close to unsellable at size: aggregate FT quote-side DEX liquidity is roughly **$28K**.
+
+### How ftUSD is priced
+
+Every venue that prices ftUSD — FT Lend's liquidation engine and both Morpho markets — reads the same contract: `FtUsdMintRedeemOracleProxy` [`0xA69f7a38B6c91a4bc2477f097DC8a1F16DAADFf8`](https://etherscan.io/address/0xA69f7a38B6c91a4bc2477f097DC8a1F16DAADFf8). It is a Chainlink-shaped `AggregatorV3Interface` wrapper, 8 decimals, **owned by the 3/5 admin Safe**, with `baseFeed`, `mintRedeem` and `usdc` set `immutable` at construction.
+
+**Step 1 — read Chainlink USDC/USD and validate it.** `baseFeed` is canonical Chainlink USDC/USD. The wrapper reverts if `paused`, if the round is incomplete (`answeredInRound < roundId`, `updatedAt == 0`, or a future timestamp), if the round is older than `maxStaleness` (currently **86,400s / 24h**), or if the answer is non-positive.
+
+**Step 2 — derive ftUSD from the mint/redeem engine.** `_quoteAnswer` queries `MintAndRedeem` twice and takes the **lower** of two estimates:
+
+```
+mintOut   = previewMint(USDC, 1e6)      // ftUSD received for 1.000000 USDC
+redeemOut = previewRedeem(USDC, 1e6)    // USDC received for 1.000000 ftUSD
+
+mintImplied = usdcUsd × 1e6 / mintOut       // what it costs to create 1 ftUSD
+redeemValue = redeemOut × usdcUsd / 1e6     // what 1 ftUSD returns on exit
+
+answer = min(mintImplied, redeemValue)
+```
+
+Live at block `25697429`: `mintOut` = 999,067 and `redeemOut` = 999,050, with USDC/USD at $0.99989 →
+
+| Leg | Value |
+|---|---|
+| mint-implied price | $1.000827 |
+| redeem value | $0.998944 |
+| **`answer` = min(...)** | **$0.998944** |
+
+**Step 3 — what those previews are actually made of.** This is the part that matters. `previewRedeem` resolves through `_redeemFactorWad` → `_redeemFactorDecomposition` (`MintAndRedeem` line 1722), which builds the `RedeemFactorDecomposition` struct returned publicly by `redeemPriceBreakdown(address)`:
+
+```
+spotFactorWad    = _redeemFactorFromPriceWad( oracle.priceUSD(USDC) )
+avgMintFactorWad = f( cinfo.totalFtUSDMinted / cinfo.totalIn )   // cumulative counters
+effectiveRedeemFactorWad = min(spotFactorWad, avgMintFactorWad)
+```
+
+`oracle` on `MintAndRedeem` is the FT Lend `OracleRouterChainlink` [`0xe4372dB4…674A`](https://etherscan.io/address/0xe4372dB43D2814750a19b93950157AD81D93674A), and `priceUSD(USDC)` resolves to canonical Chainlink USDC/USD. `_redeemFactorFromPriceWad` is a clamp — returns the price if ≤ 1.0, else `1e18²/price` — so the factor can never exceed 1.
+
+Live: `spotFactorWad` 0.99976752, `avgMintFactorWad` 0.99975037, `effectiveRedeemFactorWad` 0.99975037.
+
+**Neither input measures the collateral.** `spotFactor` is a function of the **USDC price**. `avgMintFactor` is a function of **cumulative mint history** — counters that move only on mint/redeem, never on a change in collateral value. `_quoteRedeemExactOutput` (line 1449) consults only the factor and the fee. Nothing in the path reads `accountedCollateralTvl`, wrapper `capital()`, or the strategy's position.
+
+> **The oracle is structurally blind to the state of ftUSD's backing.** If the collateral were impaired or gone, `previewRedeem(USDC, 1e6)` would still return ~999,050 and the feed would still report ~$0.9989. There is no lag to measure, because there is no propagation path at all.
+
+**This is not circularity.** Tracing the call graph — `OracleRouter.priceUSD(ftUSD)` → this proxy → `MintAndRedeem.preview*` → `OracleRouter.priceUSD(USDC)` → Chainlink — the router is touched twice but with *different assets*, so there is no cycle and no recursion. The accurate description is simpler and worse than circularity: **ftUSD is priced as ≈ USDC, adjusted only by fees and historical mint ratios.** A circular feed would at least track the backing with lag; this one does not track it at all.
+
+**What the design does protect against.** Every guard in the path is aimed at the collateral *changing price*: the clamp caps the factor at 1.0 whether USDC trades above or below a dollar, and `min(spot, avgMint)` ensures a redeemer can never extract more than the cheaper of {current price, historical average mint price}. That is coherent and deliberately conservative. It is simply aimed at a different risk than the one this system carries — the collateral here is a lending position, and the design is silent on whether it is still there.
+
+**A pause here is a cross-protocol denial-of-service.** `setPaused(true)` on this proxy makes `latestRoundData` revert. That does not just stop FT Lend pricing ftUSD — it also breaks the Morpho oracle that consumes it (below), freezing borrows and liquidations in a third-party protocol. The 3/5 admin Safe holds that lever.
+
+### Redemption capacity — the cascade
+
+Redemption is **real and permissionless**: `redeem`, `redeemExact`, `redeemTo` and the session variants are all public, 7 bps, atomic in code. ftUSD is not swap-only. But "atomic" describes the transaction, not the capacity — and the capacity is a four-hop unwind:
+
+```
+MintAndRedeem  (holds ~0 collateral — only wrapper shares)
+  └─ wrapper.withdraw
+       └─ Delta-Neutral strategy
+            └─ withdraw from FT Lend   ← capped by FT Lend's available CASH
+                 └─ FT Lend wrapper → Spark   (zero idle buffer)
+```
+
+Live at block `25697429`:
+
+| | USDC | USDT |
+|---|---:|---:|
+| ftUSD wrapper `capital()` | 2,781,366.71 | 1,417,609.56 |
+| ftUSD wrapper `availableToWithdraw()` | 2,781,366.71 | **1,206,351.08** |
+| **Shortfall** | 0 | **211,258.48 (14.9%)** |
+| FT Lend cash for that asset | 2,934,606.16 | **1,206,351.08** |
+| FT Lend borrowed by others | 241,017.83 | 223,541.39 |
+| Breaker instant capacity (10%) | 278,136.67 | 141,760.96 |
+
+The USDT wrapper's `availableToWithdraw` equals FT Lend's USDT cash **to the cent** — confirming the constraint is exactly the lending market's liquidity. **About 15% of ftUSD's USDT backing is not redeemable right now**, because third parties have borrowed it inside FT Lend. This is normal operation, not stress.
+
+**On top of that, redemption is rate-limited.** Both ftUSD backing wrappers are protected by the same `CircuitBreaker` [`0xCB210509…7355`](https://etherscan.io/address/0xCB210509F5AE2b3843B7Fb8Bb90bAFF9cE4f7355) that gates sftUSD unstaking: **10% of wrapper capital per window**, with a **6h `settlementDelay`** (admin-settable 5 min – 7 days) beyond that.
+
+**How the redeem factor behaves over time.** `avgMintFactorWad` is derived from `cinfo.totalFtUSDMinted / cinfo.totalIn`. Both are **cumulative mint-side counters that only ever increase** (`+=` at `MintAndRedeem` lines 1581–1582); redemptions increment separate counters (`totalOut`, `totalFtUSDBurned`) that do not enter the calculation. Live for USDC: `totalIn` 4,218,502 and `totalFtUSDMinted` 4,217,456 → ratio 0.999752, matching the observed factor.
+
+Two consequences:
+
+- **It is a lifetime average, and it gets stickier with age.** Each new mint moves it by a shrinking fraction as `totalIn` grows. Early mints anchor it permanently. Over time `avgMintFactorWad` asymptotes to a constant and stops responding to anything at all.
+- **`effective = min(spot, avgMint)` therefore degenerates.** Once the average is effectively frozen, the redeem factor is `min(USDC-price factor, constant)` — which reinforces the backing-blindness above. This is the answer to "how does redemption behave under a moving mint factor": it increasingly doesn't move.
+
+The asymmetry itself is conservative for solvency (appreciation retained, depreciation passed through), so this is not an insolvency mechanism in the direction the unverified audit finding suggests. But it does mean the redeem factor carries progressively less information as the protocol matures.
+
+**Practical exit menu for a holder:**
+
+| Size | Best route | Cost | Binding constraint |
+|---|---|---|---|
+| < ~$140K | Redeem | 7 bps, instant | none today |
+| $140K – $500K | Curve, or queued redemption | 0.22–0.30% vs 7 bps + 6h | breaker window |
+| > $500K | Split across both | — | USDT redemption ceiling ~1.21M, Curve USDC side ~903K |
+
+**Note the interaction with the oracle.** At this block the feed reports ftUSD at $0.9988 while ~15% of the USDT backing cannot be withdrawn. Reported price and actual redeemability are already decoupled under entirely normal conditions, and the oracle has no channel through which that gap could ever appear.
+
+### The Morpho ftUSD markets
+
+ftUSD is live collateral in **two Morpho Blue markets**, both lending USDC, both created in June 2026:
+
+| Market ID | Loan | Collateral | LLTV | Supplied | Borrowed | Util |
+|---|---|---|---|---:|---:|---:|
+| [`0x88ab06d4…8acf`](https://etherscan.io/address/0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb) | USDC | ftUSD | **86.0%** | 450,213 USDC | 405,868 USDC | **90.1%** |
+| [`0x5497d843…d2ac`](https://etherscan.io/address/0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb) | USDC | ftUSD | 91.5% | 1.00 USDC | 0 | — |
+
+Both use `AdaptiveCurveIrm` [`0x870ac11d…00bc`](https://etherscan.io/address/0x870ac11d48b15db9a138cf899d20f13f79ba00bc), Morpho's standard rate model. Morpho holds **629,675 ftUSD** of posted collateral in total, against 405,868 USDC of debt — a blended LTV of roughly **64.5%** against an 86% liquidation threshold, so the live market is currently healthy with meaningful headroom.
+
+**The oracle is the important part.** The markets price ftUSD through `MorphoChainlinkOracleV2` [`0x7887afbe7581eb01b3d91d80c198b0275feab779`](https://etherscan.io/address/0x7887afbe7581eb01b3d91d80c198b0275feab779), configured as:
+
+| Parameter | Value |
+|---|---|
+| `BASE_FEED_1` | [`0xA69f7a38…DFf8`](https://etherscan.io/address/0xA69f7a38B6c91a4bc2477f097DC8a1F16DAADFf8) — **Flying Tulip's own `FtUsdMintRedeemOracleProxy`** |
+| `QUOTE_FEED_1` | [`0x37be050e…8cAa`](https://etherscan.io/address/0x37be050e75C7F0a80F0E8abBFC2c4Ff826728cAa) — canonical Chainlink USDC/USD |
+| `BASE_VAULT` / `QUOTE_VAULT` | none |
+| `SCALE_FACTOR` | 1e36 |
+| `price()` | 998,924,165,380,579,646,955,586,648,201,499,387 → **0.998924 USDC per ftUSD** |
+
+**This materially qualifies the "third-party validation" reading.** Morpho *accepts* ftUSD as collateral, which is genuine external adoption. But Morpho does **not independently price it** — it consumes Flying Tulip's redemption-factor feed. Three consequences:
+
+1. **The backing-blindness propagates outward.** Morpho's ftUSD price is Flying Tulip's feed, which is a function of the USDC price and mint history — not of the collateral. An impairment of ftUSD's backing would never reach Morpho's liquidation engine through this path, so Morpho lenders could be under-collateralized with no onchain signal at all.
+2. **The Flying Tulip admin Safe holds a DoS lever over a third-party protocol.** Pausing the ftUSD oracle proxy makes `price()` revert, freezing borrows and liquidations in these Morpho markets.
+3. **The 86% LLTV market is 90.1% utilized.** Exit liquidity for Morpho lenders is thin in the same conditions that would stress ftUSD, and ftUSD collateral posted there is not available to support the ftUSD peg.
+
+For an ftUSD holder this is a second-order but real exposure: 629,675 ftUSD (15.0% of supply) is locked as Morpho collateral and would need to be unwound through the same Curve pool or redemption path that everyone else uses.
+
+### Provability
+
+- **Reserves reconcile exactly** (table above) and every hop is readable onchain by anyone. Genuine strength.
+- **But verification takes four hops** through contracts that public documentation does not describe, and the final hop lands inside another Flying Tulip product rather than at a custodian or a liquid buffer.
+- **The price feed does not read the backing.** It is a function of the USDC price and cumulative mint history, so nothing a holder verifies about the collateral can ever reach the price the protocol uses. It also carries a 0 bps deviation tolerance, so no cross-check is attempted.
+- **No public source repository** and no public audit reports — review is limited to reading verified bytecode.
+- **The Curve pool is the only external price reference** — the only place a backing problem could surface as a price, but its liquidity is protocol-adjacent rather than independent.
+
+## Liquidity Risk
+
+### ftUSD
+
+| Venue | Depth | Notes |
+|---|---|---|
+| **Curve StableSwap-NG** [ftUSD/USDC](https://etherscan.io/address/0xafec61e7a604f8f81f7cab64ec75bfa07c542630) | **971,101 ftUSD / 903,390 USDC (~$1.87M)** | A=1000, fee 0.2%, near-balanced |
+| Curve Twocrypto [FT/ftUSD](https://etherscan.io/address/0x68102ff5406475881462880a8da3c9bc9181ad6c) | 48,838 ftUSD | thin |
+| Uniswap V3 0.05% | 0.000033 ftUSD | dust, unusable |
+| Protocol redemption | subject to FT Lend liquidity | 7 bps fee |
+
+Measured slippage on Curve (`get_dy`, ftUSD → USDC):
+
+| Size | Out | Slippage |
+|---|---|---|
+| 10,000 | 9,979.15 USDC | 0.209% |
+| 100,000 | 99,780.80 USDC | 0.219% |
+| 250,000 | 249,398.14 USDC | 0.241% |
+| 500,000 | 498,495.41 USDC | **0.301%** |
+
+A holder can exit **$500K at 0.30%** without touching the protocol. That is a genuine, measured secondary market and the strongest single point in ftUSD's favour. Above ~$900K the pool's USDC side is exhausted and redemption becomes the only route — which then depends on FT Lend liquidity.
+
+### sftUSD — rate-limited
+
+Unstaking passes through the staking `CircuitBreaker`:
+
+| Parameter | Value |
+|---|---|
+| `withdrawalCapacity(ftUSD, TVL)` | **132,445 = exactly 10% of staked TVL** |
+| `settlementDelay` | **21,600s = 6 hours** |
+| Admin-settable range | `MIN_DELAY` 300s → **`MAX_DELAY` 604,800s = 7 days** |
+| Queue used historically | `nextQueueId` = 11 (~10 queued withdrawals) |
+| Currently queued | `activeQueueCount` = 0 |
+| Currently available | `availableToWithdraw` = 100% of TVL |
+
+Withdrawals beyond 10% of TVL per window route to `redeemWithQueueId` / `withdrawWithQueueId` and settle after the delay. **The admin can raise that delay to 7 days in one transaction with no timelock.** There is no secondary market for sftUSD itself.
+
+### The Curve pool is protocol-adjacent liquidity
+
+The ~$1.87M ftUSD/USDC StableSwap-NG pool ([`0xafec61e7…2630`](https://etherscan.io/address/0xafec61e7a604f8f81f7cab64ec75bfa07c542630)) is the only external ftUSD venue and the only external ftUSD price. Inspecting who actually provides it:
+
+| Layer | Holder | Share |
+|---|---|---|
+| Pool LP tokens | [Curve gauge `0x8abf0a7e…7c3f`](https://etherscan.io/address/0x8abf0a7e4b59ace59cb214fcb158285cd7cf7c3f) (`LiquidityGaugeV6`) | **100.0%** |
+| Gauge deposits | EOA [`0x3ffebdc5…46ee`](https://etherscan.io/address/0x3ffebdc5130f6072a582f79f3fb61581d3d846ee) | **99.998%** |
+
+**A single EOA provides essentially all of it**, and that address also holds 23,941 sftUSD. The gauge's `manager` is [`0x3c427497…1B4E`](https://etherscan.io/address/0x3c42749709BF354B3aE0Db29Fd2dd88089b21B4E) — **one of the five admin Safe signers**. A second signer, [`0xD0CA8838…6f5A`](https://etherscan.io/address/0xD0CA88388d1732594D611535314e9B6745396f5A), holds a dust gauge position.
+
+Pool parameters are otherwise unremarkable and healthy: `A` = 1000 with `future_A_time` = 0 (no ramp in progress), fee **0.2%**, `admin_fee` 50% of fees, `offpeg_fee_multiplier` 2.5×, `get_virtual_price` 1.000465.
+
+**This qualifies how the Curve venue should be read.** The pool is real, tradeable by anyone, and the measured slippage is genuine — but:
+
+1. **It is not a durable exit.** One EOA can withdraw it. The $500K-at-0.30% capacity is that party's continued willingness to provide liquidity, not a property of the market.
+2. **It is not independent price corroboration.** A pool made almost entirely by one protocol-adjacent party, with an admin signer as gauge manager, is closer to protocol-owned liquidity than to a third-party market. The peg is "corroborated" by a market the protocol effectively makes. That is better than no market at all — arbitrage against it is still real and permissionless — but it is not an outside check.
+
+Note this is the same pattern as the Morpho finding: an external venue that looks like third-party validation but, on inspection, either consumes the protocol's own oracle (Morpho) or is provided by the protocol's own circle (Curve).
+
+### Holder concentration
+
+**ftUSD holders** (top balances): the largest non-protocol holders are the Curve pool (971,101), Morpho (629,675) and the FT Lend ftUSD wrapper (1,106,633). Circulating ftUSD is meaningfully absorbed by protocol-adjacent venues rather than distributed retail.
+
+**sftUSD is well distributed** — genuinely better than the lending market:
+
+| # | Holder | Balance | Share | Cumulative |
+|---|---|---|---|---|
+| 1 | [`0x5786c96f…a088`](https://etherscan.io/address/0x5786c96f80ad6a00de474b85bb83dc537d8aa088) | 160,440 | 12.1% | 12.1% |
+| 2 | [`0x73bdf9f0…f124`](https://etherscan.io/address/0x73bdf9f02f5f093fde140fb6e4fbbc8fc4d0f124) | 159,723 | 12.1% | 24.2% |
+| 3 | [`0x80d0d540…9ee8`](https://etherscan.io/address/0x80d0d54050c15971b21e877d95441800f5aa9ee8) | 115,145 | 8.7% | 32.9% |
+| 4 | [`0xe5dab7ec…eb6a`](https://etherscan.io/address/0xe5dab7ec38f91f97c34f9f35eee683150a15eb6a) | 109,673 | 8.3% | 41.1% |
+| 5 | [`0x9a4a20fc…7317`](https://etherscan.io/address/0x9a4a20fc422f849caa37fd32a873223e23077317) | 99,881 | 7.5% | 48.7% |
+| … | 102 others | | | 100% |
+
+107 holders, top-1 at 12.1%, top-10 at 66.9%. Note holder #8 [`0xb7b54333…08bc8`](https://etherscan.io/address/0xB7B543337539219A5a1326aCB71dBa8Bba408bc8) (49,923, 3.8%) is **an admin Safe signer**.
+
+## Centralization & Control Risks
+
+### Governance
+
+The same 3-of-5 Gnosis Safe [`0x1118…70Cb`](https://etherscan.io/address/0x1118e1c057211306a40A4d7006C040dbfE1370Cb) with **no timelock** owns every contract in this report. Over ftUSD specifically it is `owner` + `masterMinter` + `pauser` + `blacklister`.
+
+### Token Mint Authority
+
+**Mint mechanism:** single role-gated `minter()` fronted by a debt-ceiling module system. **Mint requires backing** for the one enabled module.
+
+| Address | Can Mint | Can Burn | Role / Mechanism | Notes |
+|---------|:--------:|:--------:|------------------|-------|
+| [`0x56c5892B…8ca9`](https://etherscan.io/address/0x56c5892B0cF41B792217CCDD208f0FA85B178ca9) | ✓ | ✓ | sole `minter()`, allowance ≈ 2²⁵⁶−1 | **ftUSD Core** — mints only for enabled modules within their ceilings |
+| [`0xAa48EcBC…D23C`](https://etherscan.io/address/0xAa48EcBC843cF7E9A29155D112b8Cb27902bD23C) | ✓ (via Core) | ✓ | enabled module, ceiling **100M**, `moduleDebt` 4,196,696.77 | **MintAndRedeem** — the only enabled module; collateralized |
+| [`0x1118e1c0…70Cb`](https://etherscan.io/address/0x1118e1c057211306a40A4d7006C040dbfE1370Cb) | **indirectly, unbacked** | ✓ | `owner` + `masterMinter` + `pauser` + `blacklister` | **3/5 Safe** — `configureMinter` / `removeMinter` / `updateMasterMinter`, enable an arbitrary new Core module, `setMaxSupply`, `pause`, **`blacklist` / `wipeBlacklistedAddress`**, `upgradeToAndCall` |
+
+**Rate limits / caps:** ftUSD `maxSupply` 100M; Core `globalDebtCeiling` 100M; per-collateral cap 100M each.
+
+**Backing check at mint time:** atomic. **But** the masterMinter can register an arbitrary new module or replace the minter, issuing unbacked ftUSD — gated only by a 3-of-5 multisig with no delay.
+
+### Programmability
+
+Mint/redeem accounting, the collateral reconciliation and the sftUSD share math are all onchain and verifiable. Against that: proxy upgrades are instant, oracle prices are admin-overridable at the router, FT emissions are entirely discretionary, and the backing strategy's `operators[]` (including a plain EOA) can pre-sign hedge orders with **no price bound** via `onlyManager`. The staking exit is a governed rate limiter, not a programmatic guarantee.
+
+### External Dependencies
+
+- **FT Lend** — where the stablecoin principal, wstETH hedge collateral, and WETH hedge debt are recorded in one strategy account. The same Admin Safe controls the ftUSD strategy and FT Lend's administrative configuration; external suppliers provide the borrowed WETH. See the [companion report](./flying-tulip.md). **Critical.**
+- **Spark & Aave** — FT Lend's wrappers hold zero idle buffer, so redemption capacity ultimately depends on these venues.
+- **Lido / wstETH** — now a live component of the hedge (76.54 wstETH).
+- **Chainlink** — USDC/USD feeds the ftUSD oracle's base leg.
+- **Curve** — the only external ftUSD exit and the only external price reference. **Its liquidity is protocol-adjacent, not independent** — see below. Assessed.
+- **Morpho** — two USDC/ftUSD Blue markets holding 629,675 ftUSD (15.0% of supply); the live one is at 86% LLTV and 90.1% utilization. Its oracle reads Flying Tulip's own ftUSD feed, so this is an outward **propagation** channel rather than an independent price check, and pausing the FT oracle proxy would freeze these markets.
+- **CoW Protocol — not a dependency.** An earlier revision listed this after seeing `GPv2Settlement` and a `CowSwapBurner` in ftUSD transfer history and CoW-style naming (`setPreSignature`, `PreSignature`) in the engine. Both were misleading: `preSignature` is `LeverageRfqEngine`'s own `mapping(bytes32 => bool)`, the engine contains **zero** references to GPv2/CoWSwap/vaultRelayer across its 250KB of source, and neither the strategy nor the engine has any allowance to CoW's vault relayer. The `CowSwapBurner` is Curve's fee burner for the ftUSD/USDC pool. Fills go through the engine's own flash-fill path with a caller-supplied `fillTarget` and `fillData`.
+
+## Operational Risk
+
+Identical team, entity and disclosure profile to the lending report: public founder (Andre Cronje) with a mixed track record, ~15 anonymous team members, **no disclosed legal entity or jurisdiction**, no DAO or forum, undisclosed multisig signers, no public incident-response runbook despite the docs claiming one.
+
+Two disclosure gaps specific to this report:
+
+1. **The docs do not disclose that ftUSD's backing is lent into FT Lend.** A holder reading the public material would reasonably believe the collateral is held in a conventional custody or yield arrangement.
+2. **The "delta-neutral" description was inaccurate until three days ago.** The strategy held no hedge at all until ~August 3–6, 2026, while being marketed as delta-neutral since launch.
+
+## Monitoring
+
+Recommended frequency: **hourly** for peg, oracle divergence and governance; **daily** for backing reconciliation and cap headroom.
+
+### Backing and solvency
+
+- Reconcile `ftUSD.totalSupply()` vs `Core.totalDebt()` vs `MintAndRedeem.accountedCollateralTvl()` vs the sum of both wrappers' `capital()`. Alert on **>0.5% divergence** or on any reappearance of the debt-vs-supply drift.
+- Track the Delta-Neutral strategy's FT Lend positions and its **WETH debt and health factor** — it is 99.6% of all WETH borrows, so its liquidation would be FT Lend's first at size and a direct hit to backing.
+- Alert if `deployed()` on either ftUSD wrapper moves to a new strategy, or if `MintAndRedeem.collateralInfo(token).yieldWrapper` changes.
+
+### Peg and oracle
+
+- **Compare the Curve spot price against `priceUSD(ftUSD)` from the router.** This is the only external market signal on a feed that cannot see the backing. Alert on >0.5% divergence.
+- Alert on `PausedSet` / `AnswerBoundsSet` / `MaxStalenessSet` on the ftUSD oracle proxy, and on any `setLastGoodPrice(ftUSD, …)` at the router.
+- Alert if the Curve pool becomes >70/30 imbalanced or loses >50% of its TVL — that removes the only external market signal.
+- Poll `previewMint(USDC, 1e6)` and `previewRedeem(USDC, 1e6)` directly — these are the oracle's two inputs, and they propagate to FT Lend *and* Morpho.
+- Alert on `redeemPriceBreakdown(USDC)` when `spotFactorWad` falls below `avgMintFactorWad` — the point at which redeemers start absorbing collateral depreciation.
+- **Do not rely on the oracle to detect a backing problem.** It reads the USDC price and mint history, not the collateral, so it will report par through an impairment. The reconciliation below and the Curve comparison are the only signals that would move.
+- **Poll `availableToWithdraw()` vs `capital()` on both ftUSD wrappers.** This is the live measure of redeemability and it is already short on USDT. Alert if the gap exceeds 25% on either asset, or if it appears on USDC (currently zero).
+- **Alert on `setPaused` on the ftUSD oracle proxy.** It halts pricing in FT Lend and simultaneously freezes both Morpho markets.
+
+### Curve liquidity
+
+- Track the gauge [`0x8abf0a7e…7c3f`](https://etherscan.io/address/0x8abf0a7e4b59ace59cb214fcb158285cd7cf7c3f) balance of [`0x3ffebdc5…46ee`](https://etherscan.io/address/0x3ffebdc5130f6072a582f79f3fb61581d3d846ee). One EOA is 99.998% of the gauge and therefore ~100% of the pool; its withdrawal removes both the exit and the price reference in a single transaction.
+- Alert on pool imbalance beyond 70/30 and on `A` ramp initiation (`future_A_time` becoming non-zero) — a ramp changes slippage materially and the pool has an admin able to start one.
+
+### Morpho exposure
+
+- Track market [`0x88ab06d4…8acf`](https://etherscan.io/address/0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb) (86% LLTV): `totalSupplyAssets`, `totalBorrowAssets` and posted ftUSD collateral. It is currently 90.1% utilized, so Morpho lenders have thin exit capacity in exactly the conditions that would stress ftUSD.
+- Alert if the blended LTV there rises above ~75% (currently ~64.5% against an 86% threshold), or if `MorphoChainlinkOracleV2.price()` starts reverting — the latter means the FT oracle proxy has been paused or has gone stale.
+- Alert on any new Morpho market created with ftUSD as loan or collateral asset, and on `BASE_FEED_1` remaining pointed at Flying Tulip's own feed if a curated alternative appears.
+
+### Mint authority — immediate alert
+
+- `MinterConfigured`, `MinterRemoved`, `MasterMinterChanged` on ftUSD.
+- **Any new module enablement on ftUSD Core** — this is the unbacked-mint path.
+- `setMaxSupply`, `globalDebtCeiling` changes, `Blacklisted`, `wipeBlacklistedAddress`.
+- `Upgraded` on ftUSD, Core, MintAndRedeem, sftUSD, and both wrappers.
+
+### Strategy operations
+
+- **`OperatorSet` on the Delta-Neutral strategy** — the set currently includes a plain EOA; any addition is material.
+- **Owner-only (`onlyOwner`):** `setOperator`, `setLeverageEngine`, `setCollateralWrapper(s)`, `setftYieldWrapper`, any `execute()` call.
+- **Operator (`onlyManager`, incl. the EOA):** `approveOpenOrder` / `approveCloseOrder` / `approveSwapCollateralOrder`, `revokeOrder` / `revokeOrderByDigest` / `cancelOrder`, `setTargetLeverageBps`, `claimStakingYield`.
+- Monitor open/close order digests via `OrderBroadcast` on `LeverageRfqEngine` and compare realised fills against Chainlink at execution time — since no price bound exists in-contract, **this is the only detection mechanism for a bad fill**.
+
+### Staking
+
+- `settlementDelay` changes on the staking breaker (admin can go to 7 days), `activeQueueCount`, and `paused` on the sftUSD vault.
+- `convertToAssets(1e6)` — if it ever deviates from `1000000`, the vault's economics have changed.
+- FT balance in the vault and epoch cadence: a stall in `settleEpoch` means yield has stopped.
+
+## Appendix: Contract Architecture
+
+```
+                      Admin Safe 3/5  0x1118…70Cb   (no timelock)
+                      owner of EVERY contract below; ftUSD masterMinter/pauser/blacklister
+                                    │
+        ┌───────────────────────────┼────────────────────────────┐
+        ▼                           ▼                            ▼
+   ftUSD (UUPS)             MintAndRedeem  ──► ftUSD Core ──► mint (module ceiling 100M)
+   blacklist + wipe             │ 7bps in/out       ▲
+        ▲                       │                   └── only enabled module
+        │                       ▼
+        │            ftUSD-USDC wrapper  2,781,367 USDC
+        │            ftUSD-USDT wrapper  1,417,610 USDT
+        │                       │
+        │                       ▼
+        │      MultiCollateralDeltaNeutralStakingStrategy  0xe0E4…1A59
+        │        owner = Admin Safe │ operators = 3/5 Safe + PLAIN EOA
+        │        orders have NO price/slippage bound
+        │                       │
+        │                       ▼
+        │            ┌──────────────────────────┐
+        │            │  FT LEND (companion report ) │  35.1% of its TVL
+        │            │  2.78M USDC + 1.42M USDT │
+        │            │  + 76.5 wstETH collateral│ bought with borrowed WETH
+        │            │  − 95.0 WETH debt        │ supplied by FT Lend lenders
+        │            └──────────────────────────┘
+        │                       │ Spark / Aave (zero idle buffer)
+        │                       ▼
+        │            ftUSD price oracle ◄── f(USDC px, mint history) — BLIND to backing
+        │
+        ▼
+   sftUSD vault 0xeb48…7625  (UUPS, own wipeBlacklistedAddress)
+     rate 1.000000 fixed ── yield = FT emissions only (discretionary)
+     └─► ftftUSD wrapper 0xB44a…B87f (0 strategies, idle)
+           └─► CircuitBreaker 0xCB21…7355  10%/window, 6h delay (→7d)
+
+   EXTERNAL:  Curve ftUSD/USDC ~$1.87M (only market exit + only price reference)
+              Morpho 629,675 ftUSD collateral
+```
+
+---
+
+## Risk Summary
+
+### Key Strengths
+
+- **Backing fully exists and reconciles to the wei** — 100.054% collateral ratio, verified across four hops, reproducible by anyone with `cast`.
+- **Mint is genuinely atomic and collateralized** through the only enabled module, with a per-collateral cap and a $1.00 mint price hardcap.
+- **A real external market exists**: ~$1.87M Curve pool clearing $500K at 0.30%, near-balanced. Genuinely tradeable and arbitrageable by anyone — though the liquidity is provided by a single protocol-adjacent EOA, so treat it as available rather than durable.
+- **External acceptance** — 629,675 ftUSD (15.0% of supply) held as collateral in two Morpho Blue markets, the live one comfortably collateralized at ~64.5% LTV against an 86% threshold.
+- **sftUSD holder distribution is healthy** — 107 holders, largest 12.1%.
+- **Currently fully liquid**: sftUSD `availableToWithdraw` is 100% of TVL and no withdrawals are queued.
+- All contracts source-verified; the transient `totalDebt` drift has resolved.
+
+### Key Risks
+
+- **The backing is lent into Flying Tulip's own money market** (100% of it, 35.1% of that market's TVL), so ftUSD cannot fail independently of FT Lend, while its price feed is blind to that backing.
+- **A plain EOA in `operators[]` can pre-sign hedge open/close/swap orders with no price or slippage bound** in either the strategy or the execution engine (`onlyManager`, not `onlyOwner`).
+- **A 3/5 Safe with no timelock can mint unbacked ftUSD**, blacklist and burn balances at both the token and vault layers, and upgrade every contract.
+- **sftUSD pays zero yield in ftUSD terms** — the rate is fixed at 1.0 and all return is discretionary FT emissions in a token with ~$28K of DEX liquidity.
+- **sftUSD's exit is rate-limited** at 10% of TVL per window with a 6h delay that the admin can extend to 7 days.
+- **Audit status is unverifiable** for every contract here, with an unconfirmed report of an open medium finding on the redemption path specifically.
+- **The price feed is structurally blind to the backing, and that blindness propagates outside the protocol.** ftUSD is priced off the USDC price and cumulative mint history — nothing in the path reads the collateral. Morpho's ftUSD markets consume that same feed rather than pricing ftUSD independently, and the FT admin Safe can freeze those markets by pausing it.
+- **Redemption capacity is bounded by FT Lend's liquidity and is already partially constrained** — ~15% of the USDT backing is not withdrawable today because third parties borrowed it, and redemption is rate-limited to 10% of wrapper capital per window with a 6h delay.
+
+### Critical Risks
+
+- **Unbacked mint via a new Core module** — one multisig transaction, no delay, dilutes every holder.
+- **Reflexive backing** — an FT Lend loss event impairs ftUSD's collateral while ftUSD is simultaneously 11.4% of that market's collateral, and its backing-blind feed would not register the impairment.
+- **Unbounded `onlyManager` trade pre-sign by an EOA** over the strategy's hedge leg (price unbounded; size still subject to PM health factor).
+
+---
+
+## Risk Score Assessment
+
+**Scoring guidelines applied:** conservative rounding, decimals where a subcategory falls between bands, onchain evidence over documentation.
+
+### Critical Risk Gates
+
+- [ ] **Unverified contract source** — **PASS.** All contracts, including proxy implementations, are source-verified.
+- [ ] **No audit** — **PASS, with material reservation.** A real audit registry exists but is access-code gated; **zero audits are independently confirmable** for any contract here. Scored down hard in Category 1 rather than gated.
+- [ ] **Unverifiable reserves** — **PASS.** Backing reconciles exactly across four hops at 100.054%.
+- [ ] **Total centralization (single EOA)** — **PASS, marginally.** Root control is a 3/5 multisig. Note however that a plain EOA holds live `onlyManager` operator rights on the Delta-Neutral strategy (hedge order pre-sign), separate from `owner`.
+
+**No critical gate is triggered.**
+
+### Category Scores
+
+#### Category 1: Audits & Historical Track Record (Weight: 20%)
+
+**Subcategory A: Audits — 2.5**
+The privately reviewed audit package provides good coverage from reputable firms, while the reports remain non-public. This asset-specific subscore remains 2.5; by contrast, the [FT Lend report](./flying-tulip.md) scores 3.0 because it applies an additional **+0.5** protocol-specific penalty for having no bounty coverage over the core lending contracts. This difference does not imply that the published bounty covers the ftUSD core: its published scope is **ftPUT / FT OFT**, not `FlyingTulipUSD`, Core, `MintAndRedeem`, sftUSD, or the Delta-Neutral strategy. No Safe Harbor enrolment was found. Complexity is high (module-gated minting, a leveraged hedging strategy, a queued staking vault).
+
+**Subcategory B: Historical — 4.0**
+ftUSD is ~5.4 months live with no depeg and no incident, which is clean but uninformative at this age. Supply is $4.2M — the `<$10M` band (4). The peg is externally corroborated, and 220 reward epochs have settled, which is a real operating record. The "delta-neutral" mechanism, however, only started working days ago, so the yield strategy itself has **no** track record.
+
+**Score: 3.25/5** — (2.5 + 4.0) / 2.
+
+#### Category 2: Centralization & Control Risks (Weight: 30%)
+
+**Subcategory A: Governance — 5.0**
+Same 3/5 Safe, no timelock, UUPS everywhere. For ftUSD specifically it adds an **unbacked-mint path** (register an arbitrary Core module) and **two independent seizure layers** (`wipeBlacklistedAddress` on both the token and the staking vault). Signers undisclosed; the guardian and strategy-operator Safes share the same signer set.
+
+**Subcategory B: Programmability — 4.5**
+Worse than the lending market. Accounting is onchain and verifiable, but the backing sits in a discretionary strategy whose **`operators[]` set includes a plain EOA** with `onlyManager` rights to pre-sign hedge orders (`approveOpenOrder` / `approveCloseOrder` / `approveSwapCollateralOrder`), revoke/cancel orders, set `targetLeverageBps`, and `claimStakingYield` — **with no onchain price or slippage bound** on those orders. (Config/`execute` remain `onlyOwner` / Admin Safe.) Yield on sftUSD is 100% discretionary FT emissions, and the staking exit is a governed rate limiter with an admin-settable delay.
+
+**Subcategory C: External Dependencies — 4.0**
+Same rule as the [FT Lend report](./flying-tulip.md): **Spark, Aave, Chainlink, and Lido are not high-risk counterparties** — they are mature, heavily audited infrastructure (low individual counterparty risk).
+What elevates this subcategory is **where principal sits**:
+- **100% of ftUSD backing is a supply claim on FT Lend** (sibling product, Medium/Elevated risk profile, same admin Safe). That is the single unusual dependency — correlated failure of the stablecoin and the money market.
+- Curve is a secondary-market exit / price reference only (protocol-adjacent liquidity); primary redeem is `MintAndRedeem`. CoW is not a dependency.
+
+**Score: 4.5/5** — (5.0 + 4.5 + 4.0) / 3.
+
+#### Category 3: Funds Management (Weight: 30%)
+
+**Subcategory A: Collateralization — 3.5**
+ftUSD is 100.054% backed by the strategy's net equity, whose principal is predominantly USDC/USDT; gross collateral also includes wstETH purchased with borrowed WETH, so the portfolio must be assessed net of that WETH liability. Minting is atomic and backing is verifiable in real time onchain, but the collateral quality falls between rubric rows 3 and 4 because the backing is a leveraged position inside the newer, commonly controlled FT Lend market rather than liquid assets held independently. There is only 5 bps of excess backing, no reserve or insurance buffer, and wstETH/WETH basis risk, unwind constraints, FT Lend bad debt, or badly priced operator-authorized RFQ fills can impair the net backing.
+
+**Subcategory B: Provability — 1.5**
+Reserves and liabilities are fully onchain, update in real time, and reconcile exactly across ftUSD supply, Core debt, MintAndRedeem accounting, wrapper capital, and the strategy's FT Lend positions. Anyone can reproduce the reconciliation without relying on an administrator or custodian. The half-point reflects the four-contract custody chain and lack of a protocol-provided reserve dashboard, not an inability to verify the backing. The separate finding that ftUSD's price feed does not read this backing affects risk detection and liquidation behavior, but does not make the reserves themselves unprovable.
+
+**Score: 2.5/5** — (3.5 + 1.5) / 2.
+
+#### Category 4: Liquidity Risk (Weight: 15%)
+
+- **ftUSD:** a real $1.87M Curve venue clears **$500K at 0.30%** plus permissionless 7 bps redemption. But the venue is **provided almost entirely by one EOA** through a gauge managed by an admin Safe signer, so it is withdrawable at that party's discretion rather than a durable market property.
+- **sftUSD:** materially worse. Exit is **rate-limited to 10% of TVL per window with a 6h settlement delay, admin-extendable to 7 days**, and there is no secondary market for sftUSD itself. That is squarely the rubric's "withdrawal queues or restrictions" row (4).
+- Above ~$900K the Curve USDC side is exhausted and redemption becomes the only route, which depends on FT Lend and then Spark/Aave liquidity.
+- Currently no queue is active and 100% is withdrawable — the throttle is real but untested at scale.
+
+**Score: 3.5/5** — ftUSD has permissionless redemption and a measured $500K secondary-market exit at 0.30%, but redemption capacity depends on FT Lend liquidity and essentially all Curve liquidity comes from one protocol-adjacent EOA. sftUSD adds a 10%-per-window throttle and no secondary market; excess withdrawals currently wait 6 hours, while an admin can extend the delay to 7 days without a timelock. This places the combined position between the rubric's short-queue score of 3 and restricted-withdrawal score of 4.
+
+#### Category 5: Operational Risk (Weight: 5%)
+
+Same team, entity and governance-transparency profile as the lending report (public founder with mixed record, anonymous team, no legal entity, no DAO or forum, no public incident runbook).
+
+**Score: 3.5/5**
+
+### Final Score Calculation
+
+| Category | Score | Weight | Weighted |
+|----------|-------|--------|----------|
+| Audits & Historical | 3.25 | 20% | 0.650 |
+| Centralization & Control | 4.50 | 30% | 1.350 |
+| Funds Management | 2.50 | 30% | 0.750 |
+| Liquidity Risk | 3.50 | 15% | 0.525 |
+| Operational Risk | 3.50 | 5% | 0.175 |
+| **Final Score** | | | **3.450** |
+
+**Final Score: 3.5** (3.45 weighted, conservatively rounded)
+
+**Optional modifiers:** none apply — the asset is <1 year old and supply is far below $500M.
+
+Category 1 is aligned with FT Lend. Cat 2C scores the **FT Lend backing concentration**, not Spark/Aave/Chainlink as high-risk venues. The gap versus lending is driven by Programmability, FT Lend-as-backing, the leveraged collateral structure, and staked-exit liquidity.
+
+### Risk Tier
+
+| Final Score | Risk Tier | Recommendation |
+|------------|-----------|----------------|
+| 1.0-1.5 | Minimal Risk | Approved, high confidence |
+| 1.5-2.5 | Low Risk | Approved with standard monitoring |
+| **2.5-3.5** | **Medium Risk** | **Approved with enhanced monitoring** |
+| 3.5-4.5 | Elevated Risk | Limited approval, strict limits |
+| 4.5-5.0 | High Risk | Not recommended |
+
+**Final Risk Tier: MEDIUM RISK — approved with enhanced monitoring.**
+
+**This scores worse than the lending market (3.1).** FT Lend's Audits & Historical category is now higher risk (3.5 versus ftUSD's 3.25) solely because its audit subscore includes the additional no-bounty penalty; ftUSD's higher overall score is instead driven by four things a lender does not face:
+
+1. **Principal concentration into the reflexive asset.** Lending USDC, ftUSD is 11.4% of the collateral behind other people's loans. Holding ftUSD, 100% of principal is the reflexive asset.
+2. **An EOA in `operators[]` with unbounded hedge order pre-sign** (`approveOpenOrder` / `approveCloseOrder` / `approveSwapCollateralOrder`; no onchain price bound).
+3. **A rate-limited exit** on the staked form, admin-extendable to 7 days.
+4. **Zero intrinsic yield on sftUSD** — the rate is pinned at 1.0 and all return is discretionary emissions in an illiquid token.
+
+**The external validation is thinner than it looks.** Both of ftUSD's apparent third-party endorsements dissolve on inspection: Morpho accepts ftUSD but prices it with Flying Tulip's own feed, and the Curve pool is ~100% one protocol-adjacent EOA behind a gauge managed by an admin Safe signer. Neither is an outside check; both are extensions of the protocol's own circle.
+
+---
+
+## Reassessment Triggers
+
+- **Backing location:** reassess immediately if ftUSD's backing moves to a different venue, or if the Delta-Neutral strategy's share of FT Lend TVL exceeds 45% or falls below 10%.
+- **Operator model:** reassess on any `OperatorSet` event, and immediately if a price or slippage bound is *not* added to order validation within the next review cycle.
+- **Hedge:** the leg went live around August 3–6, 2026. Reassess after 30 days of live operation, or immediately if `targetLeverageBps` is raised above 1.05×.
+- **Mint authority:** reassess on any new ftUSD Core module, `masterMinter` change, or `maxSupply`/`globalDebtCeiling` increase.
+- **Redeemability:** reassess if either wrapper's `availableToWithdraw()` falls below 75% of `capital()`, or if `settlementDelay` on the backing circuit breaker is raised.
+- **Peg:** reassess if the Curve spot price diverges >0.5% from `priceUSD(ftUSD)` for more than 24h, or if the pool goes >70/30 imbalanced or loses >50% TVL.
+- **Staking:** reassess if `settlementDelay` is raised, if `convertToAssets(1e6)` ever deviates from `1000000`, or if FT emissions stall for more than two epoch periods.
+- **Audit status:** reassess if any ftUSD audit is published, if the redemption finding is confirmed or refuted, or if the bounty publishes or expands ftUSD contract coverage.
+- **Curve liquidity:** reassess immediately if the sole gauge depositor [`0x3ffebdc5…46ee`](https://etherscan.io/address/0x3ffebdc5130f6072a582f79f3fb61581d3d846ee) withdraws more than 25% of its position — that is the entire external exit and the entire external price reference.
+- **Time-based:** reassess in **2 months** — the hedge strategy is new.
+
+---
+
+## Assessment History
+
+| Date | Score | Notes |
+| --- | --- | --- |
+| [August 7, 2026](https://github.com/yearn/risk-score/pull/237) | 3.5 | Initial assessment |

--- a/reports/report/flying-tulip-ftusd.md
+++ b/reports/report/flying-tulip-ftusd.md
@@ -4,11 +4,11 @@
 - **Token:** ftUSD (stablecoin) and sftUSD (staked ftUSD)
 - **Chain:** Ethereum Mainnet
 - **Token Address:** ftUSD [`0xF7D85EC4E7710f71992752eac2111312e73E9C9C`](https://etherscan.io/address/0xF7D85EC4E7710f71992752eac2111312e73E9C9C) · sftUSD [`0xeb48218a4c35C814C7678cBcae88C6Ee037F7625`](https://etherscan.io/address/0xeb48218a4c35C814C7678cBcae88C6Ee037F7625)
-- **Final Score: 3.5/5.0**
-- **Elevated Risk** — limited approval, strict limits. ftUSD is fully collateralized (100.05%), but that backing is **not idle cash — it is lent into Flying Tulip's own money market** by a strategy whose `operators[]` include a plain EOA with `onlyManager` rights to pre-sign hedge trades (no onchain price bound). Normal minting through the current production module is collateralized; separately, the 3/5 Admin Safe retains a technically available privileged path to authorize unbacked issuance. No evidence that path has been used was found. Redemption is permissionless but first rate-limited to 10% per window; ultimate settlement depends on FT Lend cash. Curve liquidity fell by more than 85% after the initial assessment, materially weakening the secondary exit. See [Risk Score Assessment](#risk-score-assessment).
+- **Final Score: 3.4/5.0**
+- **Medium Risk** — approved with enhanced monitoring. ftUSD is fully collateralized (100.05%), but that backing is **not idle cash — it is lent into Flying Tulip's own money market** by a strategy whose `operators[]` include a plain EOA with `onlyManager` rights to pre-sign hedge trades (no onchain price bound). Normal minting through the current production module is collateralized; separately, the 3/5 Admin Safe retains a technically available privileged path to authorize unbacked issuance. No evidence that path has been used was found. Protocol redemption remains permissionless: sells above available instant capacity enter a six-hour queue, and ultimate settlement depends on FT Lend cash. Curve liquidity fell by more than 85% after the initial assessment, weakening the secondary exit but not removing the primary queued-redemption route. See [Risk Score Assessment](#risk-score-assessment).
 - **Companion report:** the lending market itself is assessed in **[Flying Tulip — FT Lend](./flying-tulip.md)**.
 
-> **Scope.** This report covers **holding ftUSD** and **staking it as sftUSD**. It is a separate risk from supplying to the FT Lend market — different loss paths, different exit mechanics, different concentration profile — and the two should be sized independently. Unless expressly marked as an update, values were verified **August 6, 2026 at block `25697429`** via `cast` and Etherscan. Bug-bounty scope, redemption availability, and Curve liquidity were refreshed **September 4, 2026 at block `25903824`** in response to team comments.
+> **Scope.** This report covers **holding ftUSD** and **staking it as sftUSD**. It is a separate risk from supplying to the FT Lend market — different loss paths, different exit mechanics, different concentration profile — and the two should be sized independently. Unless expressly marked as an update, values were verified **August 6, 2026 at block `25697429`** via `cast` and Etherscan. Bug-bounty scope, redemption availability, and Curve liquidity were refreshed **September 4, 2026**, with the latest breaker checks at block `25904377`, in response to team comments.
 
 ## Overview + Links
 
@@ -133,14 +133,14 @@ Global gates: ftUSD `maxSupply` 100M, Core `globalDebtCeiling` 100M, `minTVLForM
 | Action | Who | Atomic? | Fees | Limits / gating |
 |---|---|:---:|---|---|
 | **Mint ftUSD** | permissionless | ✓ one tx — collateral in, `wrapper.deposit()`, `core.mint()` | 7 bps | per-collateral cap 100M; `minTVLForMint` 5M; `globalDebtCeiling` 100M; `maxSupply` 100M; mint price hardcapped at $1.00 |
-| **Redeem ftUSD** | permissionless | ✓ up to the window cap | 7 bps | **10% of wrapper capital per window, 6h settlement beyond that** (admin-settable to 7 days); ultimate capacity is capped by FT Lend cash. On September 4, USDT cash covered 89.2% of wrapper capital. Priced off `min(spot, avgMint)` factors, not flat 1:1 |
-| **Sell ftUSD** | permissionless | ✓ | Curve 0.2% + slippage | ~$100K at 0.38%; slippage rises to ~13.75% at $150K |
+| **Redeem / sell ftUSD through the app** | permissionless | queued when above available instant capacity | 7 bps | breaker has a 10% configured window capacity and 6h queue settlement (admin-settable to 7 days); at the observed frontend state, any sell above 0 ftUSD would enter the queue. Ultimate capacity is capped by FT Lend cash; USDT cash covered 89.2% of wrapper capital |
+| **Swap ftUSD on Curve** | permissionless | ✓ | Curve 0.2% + slippage | secondary exit: ~$100K at 0.38%; slippage rises to ~13.75% at $150K |
 | **Stake (sftUSD)** | permissionless | ✓ | none | `minDepositAmount` 0 |
 | **Unstake (sftUSD)** | permissionless | **✗ above the limit** | none | **10% of TVL per window; excess queued for 6h (`settlementDelay`), admin-settable to 7 days** |
 | **Claim FT rewards** | permissionless | ✓ | none | only if the epoch settler has funded an epoch |
 | Blacklist / burn | 3/5 Safe | ✓ | — | applies at both the ftUSD and sftUSD layers |
 
-**Redemption is permissionless and same-transaction up to the window cap.** Beyond ~10% of wrapper capital it queues for 6 hours, and total redeemable size is bounded by FT Lend's available cash for that asset — a constraint that is **already binding on USDT** (see [Redemption capacity](#redemption-capacity--the-cascade)). "Atomic" is a property of the transaction, not a guarantee of capacity.
+**Redemption is permissionless even when it is not immediate.** The breaker can allow same-transaction execution from its available buffer; otherwise the sell enters a six-hour queue. At the September 4 frontend observation, the app reported that any sell above 0 ftUSD would queue. This is delayed withdrawal liquidity, not an unavailable exit. Final settlement remains bounded by FT Lend's available cash for the chosen asset (see [Redemption capacity](#redemption-capacity--the-cascade)).
 
 ### Collateralization — the backing chain
 
@@ -301,18 +301,18 @@ MintAndRedeem  (holds ~0 collateral — only wrapper shares)
                  └─ FT Lend wrapper → Spark   (zero idle buffer)
 ```
 
-Refreshed September 4, 2026 at block `25903824`:
+Refreshed September 4, 2026, with breaker state checked at block `25904377`:
 
 | | USDC | USDT |
 |---|---:|---:|
-| ftUSD wrapper `capital()` | 2,698,054.90 | 1,493,055.91 |
-| ftUSD wrapper `availableToWithdraw()` | 2,698,054.90 | **1,331,789.52** |
+| ftUSD wrapper `capital()` | 2,695,057.68 | 1,493,055.91 |
+| ftUSD wrapper `availableToWithdraw()` | 2,695,057.68 | **1,331,789.52** |
 | **Shortfall** | 0 | **161,266.39 (10.8%)** |
-| Breaker instant capacity (10%) | 269,805.49 | 149,305.59 |
+| Breaker `withdrawalCapacity(asset, capital)` | 269,505.77 | 149,305.59 |
 
-The USDT wrapper's `availableToWithdraw` confirms that the ultimate constraint is the lending market's liquidity. On September 4, cash covered **89.2%** of USDT wrapper capital. This does not constrain an ordinary immediate redemption first: the circuit breaker limits instant redemptions to 10% of wrapper capital per window, below available cash. Requests beyond the window cap queue, and their ultimate settlement still depends on FT Lend cash. The 10.8% cash gap is normal utilization, not evidence of stress or undercollateralization.
+The USDT wrapper's `availableToWithdraw` confirms that the ultimate constraint is the lending market's liquidity. On September 4, cash covered **89.2%** of USDT wrapper capital. The contract's per-asset `withdrawalCapacity` read returned 10% of capital and the shared breaker had no active queue, while the frontend reported a 0 ftUSD instant threshold and routed every non-zero sell to the six-hour queue. These are different layers of the route and should be monitored together rather than treating the configured 10% value as a guaranteed user-facing instant quote. The 10.8% cash gap is normal utilization, not evidence of stress or undercollateralization.
 
-**On top of that, redemption is rate-limited.** Both ftUSD backing wrappers are protected by the same `CircuitBreaker` [`0xCB210509…7355`](https://etherscan.io/address/0xCB210509F5AE2b3843B7Fb8Bb90bAFF9cE4f7355) that gates sftUSD unstaking: **10% of wrapper capital per window**, with a **6h `settlementDelay`** (admin-settable 5 min – 7 days) beyond that.
+**Redemption is rate-limited, but the queue remains a valid exit.** Both ftUSD backing wrappers are protected by the same `CircuitBreaker` [`0xCB210509…7355`](https://etherscan.io/address/0xCB210509F5AE2b3843B7Fb8Bb90bAFF9cE4f7355) that gates sftUSD unstaking: **10% configured capacity per window**, with a **6h `settlementDelay`** (admin-settable 5 min – 7 days) for queued sells.
 
 **How the redeem factor behaves over time.** `avgMintFactorWad` is derived from `cinfo.totalFtUSDMinted / cinfo.totalIn`. Both are **cumulative mint-side counters that only ever increase** (`+=` at `MintAndRedeem` lines 1581–1582); redemptions increment separate counters (`totalOut`, `totalFtUSDBurned`) that do not enter the calculation. Live for USDC: `totalIn` 4,218,502 and `totalFtUSDMinted` 4,217,456 → ratio 0.999752, matching the observed factor.
 
@@ -327,11 +327,11 @@ The asymmetry itself is conservative for solvency (appreciation retained, deprec
 
 | Size | Best route | Cost | Binding constraint |
 |---|---|---|---|
-| < ~$149K | Redeem | 7 bps, instant | lower USDT breaker window |
-| $149K – $270K | Split collateral routes or queue | 7 bps + possible 6h wait | per-wrapper breaker window |
-| > ~$270K | Queued redemption | 7 bps + settlement delay | breaker window, then FT Lend cash |
+| Any size within available frontend capacity | Redeem | 7 bps, same transaction | live breaker buffer and chosen collateral route |
+| Above available frontend capacity | Queued redemption | 7 bps + 6h settlement delay | breaker queue, then FT Lend cash |
+| Secondary immediate exit | Curve | 0.2% + slippage | ~$100K at 0.38%; depth deteriorates sharply by $150K |
 
-**Note the interaction with the oracle.** Reported price and available redemption cash are separate quantities: the feed cannot reflect a liquidity gap because it does not read FT Lend cash. The circuit breaker's 10% window currently binds before USDT cash does, but queued settlement would still inherit any FT Lend liquidity constraint.
+**Note the interaction with the oracle.** Reported price, current instant breaker capacity, queue state, and available redemption cash are separate quantities. The feed cannot reflect a liquidity or queue constraint because it does not read any of them. Queued settlement still inherits any FT Lend liquidity constraint.
 
 ### The Morpho ftUSD markets
 
@@ -504,11 +504,11 @@ Recommended frequency: **hourly** for peg, oracle divergence and governance; **d
 
 - **Compare the Curve spot price against `priceUSD(ftUSD)` from the router.** This is the only external market signal on a feed that cannot see the backing. Alert on >0.5% divergence.
 - Alert on `PausedSet` / `AnswerBoundsSet` / `MaxStalenessSet` on the ftUSD oracle proxy, and on any `setLastGoodPrice(ftUSD, …)` at the router.
-- Alert if the Curve pool becomes >70/30 imbalanced or loses >50% of its TVL — that removes the only external market signal.
+- Alert if the Curve pool becomes >70/30 imbalanced, loses another 25% from the September 4 baseline, or a $100K quote exceeds 2% impact.
 - Poll `previewMint(USDC, 1e6)` and `previewRedeem(USDC, 1e6)` directly — these are the oracle's two inputs, and they propagate to FT Lend *and* Morpho.
 - Alert on `redeemPriceBreakdown(USDC)` when `spotFactorWad` falls below `avgMintFactorWad` — the point at which redeemers start absorbing collateral depreciation.
 - **Do not rely on the oracle to detect a backing problem.** It reads the USDC price and mint history, not the collateral, so it will report par through an impairment. The reconciliation below and the Curve comparison are the only signals that would move.
-- **Poll `availableToWithdraw()` vs `capital()` on both ftUSD wrappers.** This is the live measure of redeemability and it is already short on USDT. Alert if the gap exceeds 25% on either asset, or if it appears on USDC (currently zero).
+- **Poll the complete redemption path:** frontend instant-sell threshold, breaker `withdrawalCapacity` / `getAssetHealth`, `activeQueueCount`, queued notional and age, and each wrapper's `availableToWithdraw()` vs `capital()`. Alert if a queue remains unsettled past 6h, if the frontend and contract capacity disagree materially, or if available FT Lend cash falls below queued claims.
 - **Alert on `setPaused` on the ftUSD oracle proxy.** It halts pricing in FT Lend and simultaneously freezes both Morpho markets.
 
 ### Curve liquidity
@@ -525,7 +525,7 @@ Recommended frequency: **hourly** for peg, oracle divergence and governance; **d
 ### Mint authority — immediate alert
 
 - `MinterConfigured`, `MinterRemoved`, `MasterMinterChanged` on ftUSD.
-- **Any new module enablement on ftUSD Core** — this is the unbacked-mint path.
+- **Any new module enablement on ftUSD Core** — investigate immediately whether the module independently enforces collateral before minting.
 - `setMaxSupply`, `globalDebtCeiling` changes, `Blacklisted`, `wipeBlacklistedAddress`.
 - `Upgraded` on ftUSD, Core, MintAndRedeem, sftUSD, and both wrappers.
 
@@ -606,7 +606,7 @@ Recommended frequency: **hourly** for peg, oracle divergence and governance; **d
 - **sftUSD's exit is rate-limited** at 10% of TVL per window with a 6h delay that the admin can extend to 7 days.
 - **Audit status is unverifiable** for every contract here, with an unconfirmed report of an open medium finding on the redemption path specifically.
 - **The price feed is structurally blind to the backing, and that blindness propagates outside the protocol.** ftUSD is priced off the USDC price and cumulative mint history — nothing in the path reads the collateral. Morpho's ftUSD markets consume that same feed rather than pricing ftUSD independently, and the FT admin Safe can freeze those markets by pausing it.
-- **Redemption is rate-limited before cash becomes the constraint.** The breaker permits 10% of wrapper capital per window with a 6h delay beyond it; current USDT cash covers 89.2% of capital, so ordinary instant redemptions fit inside available cash, while queued settlement still depends on FT Lend liquidity.
+- **Redemption remains available through the queue.** The breaker is configured around 10% of wrapper capital per window with six-hour settlement for queued sells. At the observed frontend state every non-zero sell was shown as queued, while current USDT cash covered 89.2% of capital. The restriction delays exit; it does not remove the redemption route. Queued settlement still depends on FT Lend liquidity.
 
 ### Critical Risks
 
@@ -633,13 +633,13 @@ Recommended frequency: **hourly** for peg, oracle divergence and governance; **d
 
 #### Category 1: Audits & Historical Track Record (Weight: 20%)
 
-**Subcategory A: Audits — 2.5**
-The privately reviewed audit package provides good coverage from reputable firms, while the reports remain non-public. The live Sherlock bounty has a maximum reward of 1,000,000 USDC and covers Flying Tulip's deployed production contracts through the dynamic contract list incorporated by the bounty's Additional Scope, including the ftUSD / sftUSD stack assessed here. The 2.5 subscore reflects strong audit and bounty coverage, with a half-point above rubric row 2 because the audit reports and finding-level details remain non-public. No Safe Harbor enrolment was found. Complexity is high (module-gated minting, a leveraged hedging strategy, and a queued staking vault).
+**Subcategory A: Audits — 2.0**
+The privately reviewed audit package provides good coverage from reputable firms, and the live Sherlock bounty has a maximum reward of 1,000,000 USDC and covers Flying Tulip's deployed production contracts through the dynamic contract list incorporated by the bounty's Additional Scope, including the ftUSD / sftUSD stack assessed here. This directly satisfies rubric row 2: multiple reputable reviews and a bounty above $200K. The reports and finding-level details remain non-public, Safe Harbor enrolment was not found, and complexity is high, which prevent a stronger row-1 score; they do not justify an additional half-point penalty above row 2.
 
 **Subcategory B: Historical — 4.0**
 ftUSD is ~5.4 months live with no depeg and no incident, which is clean but uninformative at this age. Supply is $4.2M — the `<$10M` band (4). The peg has a market-based Curve reference, though current depth is thin, and 220 reward epochs have settled, which is a real operating record. The "delta-neutral" mechanism, however, only started working days before the initial snapshot, so the yield strategy itself has **no** meaningful track record.
 
-**Score: 3.25/5** — (2.5 + 4.0) / 2.
+**Score: 3.0/5** — (2.0 + 4.0) / 2.
 
 #### Category 2: Centralization & Control Risks (Weight: 30%)
 
@@ -669,12 +669,11 @@ Reserves and liabilities are fully onchain, update in real time, and reconcile e
 
 #### Category 4: Liquidity Risk (Weight: 15%)
 
-- **ftUSD:** the Curve venue fell from ~$1.87M to **~$249K** after the initial assessment. A $100K sale still clears at about 0.38%, but a $150K sale incurs about 13.75% slippage. Permissionless 7 bps redemption remains the practical large-exit route, subject to the 10%-per-window breaker and then FT Lend cash.
+- **ftUSD:** permissionless 7 bps protocol redemption remains the primary exit. Amounts above available instant capacity enter a six-hour queue; at the observed frontend state, every non-zero sell was shown as queued. This is delayed withdrawal liquidity, not a missing exit. Ultimate settlement still depends on FT Lend cash. Curve is the immediate secondary route, but fell from ~$1.87M to **~$249K**; a $100K sale clears at about 0.38%, while $150K incurs about 13.75% slippage.
 - **sftUSD:** materially worse. Exit is **rate-limited to 10% of TVL per window with a 6h settlement delay, admin-extendable to 7 days**, and there is no secondary market for sftUSD itself. That is squarely the rubric's "withdrawal queues or restrictions" row (4).
-- Above ~$900K the Curve USDC side is exhausted and redemption becomes the only route, which depends on FT Lend and then Spark/Aave liquidity.
-- Currently no queue is active and 100% is withdrawable — the throttle is real but untested at scale.
+- Above roughly the Curve pool's $130K USDC reserve, queued protocol redemption is the practical route. At the onchain check, the breaker had no active queue; the frontend nevertheless displayed a zero instant threshold, so current execution should be assumed queued unless a live quote shows otherwise.
 
-**Score: 4.0/5** — the combined position has withdrawal restrictions, less than $1M of secondary liquidity, and double-digit impact for an exit large enough to matter. ftUSD redemption is permissionless but rate-limited and ultimately depends on FT Lend cash. sftUSD adds the same 10%-per-window throttle and no secondary market; excess withdrawals currently wait 6 hours, while an admin can extend the delay to 7 days without a timelock.
+**Score: 3.5/5** — the six-hour permissionless redemption queue materially offsets the thin Curve market: a holder can exit without accepting Curve's double-digit large-trade impact, subject to delayed settlement and FT Lend cash. The score remains between rubric rows 3 and 4 because both ftUSD and sftUSD are queue-gated at size, the secondary market is below $1M, and governance can extend settlement to seven days without a timelock.
 
 #### Category 5: Operational Risk (Weight: 5%)
 
@@ -686,14 +685,14 @@ Same team, entity and governance-transparency profile as the lending report (pub
 
 | Category | Score | Weight | Weighted |
 |----------|-------|--------|----------|
-| Audits & Historical | 3.25 | 20% | 0.650 |
+| Audits & Historical | 3.00 | 20% | 0.600 |
 | Centralization & Control | 4.50 | 30% | 1.350 |
 | Funds Management | 2.50 | 30% | 0.750 |
-| Liquidity Risk | 4.00 | 15% | 0.600 |
+| Liquidity Risk | 3.50 | 15% | 0.525 |
 | Operational Risk | 3.50 | 5% | 0.175 |
-| **Final Score** | | | **3.525** |
+| **Final Score** | | | **3.400** |
 
-**Final Score: 3.5** (3.525 weighted, displayed to one decimal)
+**Final Score: 3.4** (3.400 weighted)
 
 **Optional modifiers:** none apply — the asset is <1 year old and supply is far below $500M.
 
@@ -705,13 +704,13 @@ Category 1 is aligned with FT Lend. Cat 2C scores the **FT Lend backing concentr
 |------------|-----------|----------------|
 | 1.0-1.5 | Minimal Risk | Approved, high confidence |
 | 1.5-2.5 | Low Risk | Approved with standard monitoring |
-| 2.5-3.5 | Medium Risk | Approved with enhanced monitoring |
-| **3.5-4.5** | **Elevated Risk** | **Limited approval, strict limits** |
+| **2.5-3.5** | **Medium Risk** | **Approved with enhanced monitoring** |
+| 3.5-4.5 | Elevated Risk | Limited approval, strict limits |
 | 4.5-5.0 | High Risk | Not recommended |
 
-**Final Risk Tier: ELEVATED RISK — limited approval, strict limits.** The unrounded 3.525 score is above the 3.5 boundary even though the displayed one-decimal score is 3.5.
+**Final Risk Tier: MEDIUM RISK — approved with enhanced monitoring.**
 
-**This scores worse than the lending market (3.1).** Both reports score Audits & Historical at 3.25 after recognizing that the live Sherlock bounty covers all deployed Flying Tulip production contracts through its incorporated dynamic contract list. ftUSD's higher overall score is instead driven by four things a lender does not face:
+**This scores worse than the lending market (3.0).** Both reports score Audits & Historical at 3.0 after recognizing that the live Sherlock bounty covers all deployed Flying Tulip production contracts through its incorporated dynamic contract list. ftUSD's higher overall score is instead driven by four things a lender does not face:
 
 1. **Principal concentration into the reflexive asset.** Lending USDC, ftUSD is 11.4% of the collateral behind other people's loans. Holding ftUSD, 100% of principal is the reflexive asset.
 2. **An EOA in `operators[]` with unbounded hedge order pre-sign** (`approveOpenOrder` / `approveCloseOrder` / `approveSwapCollateralOrder`; no onchain price bound).
@@ -728,7 +727,7 @@ Category 1 is aligned with FT Lend. Cat 2C scores the **FT Lend backing concentr
 - **Operator model:** reassess on any `OperatorSet` event, and immediately if a price or slippage bound is *not* added to order validation within the next review cycle.
 - **Hedge:** the leg went live around August 3–6, 2026. Reassess after 30 days of live operation, or immediately if `targetLeverageBps` is raised above 1.05×.
 - **Mint authority:** reassess on any new ftUSD Core module, `masterMinter` change, or `maxSupply`/`globalDebtCeiling` increase.
-- **Redeemability:** reassess if either wrapper's `availableToWithdraw()` falls below 75% of `capital()`, or if `settlementDelay` on the backing circuit breaker is raised.
+- **Redeemability:** reassess if queued claims exceed available FT Lend cash, any claim remains unsettled beyond 6h, the frontend and onchain breaker capacity remain materially inconsistent, or `settlementDelay` is raised.
 - **Peg:** reassess if the Curve spot price diverges >0.5% from `priceUSD(ftUSD)` for more than 24h or the pool goes >70/30 imbalanced.
 - **Staking:** reassess if `settlementDelay` is raised, if `convertToAssets(1e6)` ever deviates from `1000000`, or if FT emissions stall for more than two epoch periods.
 - **Audit status:** reassess if any ftUSD audit is published, if the redemption finding is confirmed or refuted, or if Sherlock removes or narrows the dynamic production-contract coverage incorporated by the bounty's Additional Scope.
@@ -741,5 +740,5 @@ Category 1 is aligned with FT Lend. Cat 2C scores the **FT Lend backing concentr
 
 | Date | Score | Notes |
 | --- | --- | --- |
-| [September 4, 2026](https://github.com/yearn/risk-score/pull/237) | 3.5 | Liquidity reassessment after >85% Curve LP decline; bounty scope corrected |
+| [September 4, 2026](https://github.com/yearn/risk-score/pull/237) | 3.4 | Bounty scored at rubric row 2; queued protocol redemption incorporated; Curve liquidity and bounty scope refreshed |
 | [August 7, 2026](https://github.com/yearn/risk-score/pull/237) | 3.5 | Initial assessment |

--- a/reports/report/flying-tulip.md
+++ b/reports/report/flying-tulip.md
@@ -1,14 +1,14 @@
 # Protocol Risk Assessment: Flying Tulip — FT Lend (ftDNMM)
 
-- **Assessment Date:** August 7, 2026
+- **Assessment Date:** August 7, 2026 (team-response update: September 4, 2026)
 - **Token:** FT Lend market — supply / borrow positions (internal balances, not tokenised)
 - **Chain:** Ethereum Mainnet
 - **Core Contract:** PositionsManager [`0xbe4050a73a7Fb384c65E885a15C33461A4B20055`](https://etherscan.io/address/0xbe4050a73a7Fb384c65E885a15C33461A4B20055)
 - **Final Score: 3.1/5.0**
-- **Medium Risk** — approved with enhanced monitoring. A 3-of-5 Safe with no timelock can upgrade every contract and override every price. **35.1% of the market's TVL is the protocol's own ftUSD backing collateral supplied back into itself**, and only three genuinely third-party addresses hold 96% of the remainder. The audit package was privately reviewed and is strong, but the reports remain non-public and FT Lend has no in-scope bug bounty. See [Risk Score Assessment](#risk-score-assessment). (Also deployed on Sonic; this report covers Ethereum.)
+- **Medium Risk** — approved with enhanced monitoring. A 3-of-5 Safe with no timelock can upgrade every contract and override every price. **35.1% of the market's TVL is the protocol's own ftUSD backing collateral supplied back into itself**, and only three genuinely third-party addresses hold 96% of the remainder. The audit package was privately reviewed and is strong but remains non-public; a live $1M Sherlock bounty covers deployed Flying Tulip contracts through the dynamic production-contract list incorporated by its Additional Scope. See [Risk Score Assessment](#risk-score-assessment). (Also deployed on Sonic; this report covers Ethereum.)
 - **Companion report:** ftUSD and staked ftUSD are assessed separately in **[Flying Tulip — ftUSD & Staked ftUSD](./flying-tulip-ftusd.md)**.
 
-> **Scope.** Yearn's interest (issue [yearn/risk-score#234](https://github.com/yearn/risk-score/issues/234)) is the risk of supplying ("just lend") and/or borrowing in the **FT Lend** market. This report covers the lending engine and the assets it touches. **Holding ftUSD and staking ftUSD are out of scope** and are assessed in the companion report [Flying Tulip — ftUSD & Staked ftUSD](./flying-tulip-ftusd.md). ftUSD appears here only as an accepted collateral asset and because the contract holding its backing is this market's largest supplier. Nothing in this report should be used to size an ftUSD or sftUSD position. The unrelated `tulip.garden` protocol on Solana is **not** Flying Tulip and is excluded. Original values were verified **June 7, 2026 at block `25264957`**; this revision re-verified everything on **August 6, 2026 at block `25697429`** via `cast` and Etherscan against an Ethereum mainnet RPC.
+> **Scope.** Yearn's interest (issue [yearn/risk-score#234](https://github.com/yearn/risk-score/issues/234)) is the risk of supplying ("just lend") and/or borrowing in the **FT Lend** market. This report covers the lending engine and the assets it touches. **Holding ftUSD and staking ftUSD are out of scope** and are assessed in the companion report [Flying Tulip — ftUSD & Staked ftUSD](./flying-tulip-ftusd.md). ftUSD appears here only as an accepted collateral asset and because the contract holding its backing is this market's largest supplier. Nothing in this report should be used to size an ftUSD or sftUSD position. The unrelated `tulip.garden` protocol on Solana is **not** Flying Tulip and is excluded. Original values were verified **June 7, 2026 at block `25264957`**; this revision re-verified everything on **August 6, 2026 at block `25697429`** via `cast` and Etherscan. Bug-bounty scope and Curve context were refreshed **September 4, 2026 at block `25903824`** in response to team comments.
 
 ## Overview + Links
 
@@ -116,7 +116,7 @@ Enumerated loss paths for a Yearn deposit into FT Lend, ordered by how directly 
 | 4 | **`YieldClaimer` arbitrary call** | `wrapper.execute(strategy, to, value, data)` forwards an arbitrary call through the strategy contract | YieldClaimer contract | Total loss |
 | 5 | **Unbacked ftUSD mint** | Safe registers a new ftUSD Core module (or replaces `minter()`) and issues ftUSD with no collateral; ftUSD is collateral in FT Lend | 3/5 Safe | Severe — dilutes ftUSD collateral |
 | 6 | **ftUSD blacklist / balance wipe** | `blacklist` + `wipeBlacklistedAddress` freezes and burns a holder's ftUSD, including a Yearn position | 3/5 Safe | Severe |
-| 7 | **Bad debt from a failed liquidation** | The novel time-sliced/RFQ liquidation path fails to clear a position; the insolvency exception in `liquidateFlash` explicitly permits seizing all collateral and leaving debt. No backstop; reserves are negligible | permissionless caller via `RfqEngine` | Partial, socialized |
+| 7 | **Bad debt from a failed liquidation** | The novel time-sliced/RFQ liquidation path fails to clear a position; the insolvency exception in `liquidateFlash` explicitly permits seizing all collateral and leaving debt. Blue-chip collateral and a 1.25 target health factor mitigate likelihood, but reserves are negligible | permissionless caller via `RfqEngine` | Partial, socialized |
 | 8 | **Reflexive ftUSD impairment** | ftUSD's backing *is* a supply position in FT Lend; a loss here impairs ftUSD, which is 11.8% of the market's collateral and is priced by a feed blind to that backing | structural | Partial |
 | 9 | **Spark or Aave exit shortfall** | Wrappers hold **zero idle buffer** (`deployed() == capital()`); a freeze or cash shortfall at either *otherwise low-risk* venue blocks or impairs exits | external (concentrated exposure) | Partial to total per-asset |
 | 10 | **Withdrawal pause / breaker** | `setWithdrawPaused`, `CircuitBreaker`, or flipping `marginRestrictWithdrawToSettlement` / `marginWithdrawRequiresNoDebt` to `true` traps funds | 3/5 Safe / guardian | Temporary lockup |
@@ -132,7 +132,7 @@ An investor-relations portal does host a structured **Audits** registry — its 
 
 | Item | Status |
 |---|---|
-| Public bug bounty | **LIVE** — [Sherlock Flying Tulip Bug Bounty #248](https://audits.sherlock.xyz/bug-bounties/248?tab=scope), max reward 1,000,000 USDC; **scope is ftPUT + FT OFT**, not FT Lend / ftUSD (see below) |
+| Public bug bounty | **LIVE** — [Sherlock Flying Tulip Bug Bounty #248](https://audits.sherlock.xyz/bug-bounties/248?tab=scope), max reward 1,000,000 USDC; the bounty's **Additional Scope** incorporates Flying Tulip's dynamic list of all deployed production contracts, including FT Lend (see below) |
 | SEAL Safe Harbor enrolment | **Not enrolled** (absent from the `security-alliance/safe-harbor` registry) |
 | Contract source verification on Etherscan | **PASS** — all 20 contracts checked are verified (see Appendix B) |
 
@@ -144,16 +144,7 @@ An investor-relations portal does host a structured **Audits** registry — its 
 
 ### Bug Bounty
 
-**LIVE.** [Sherlock's Flying Tulip Bug Bounty #248](https://audits.sherlock.xyz/bug-bounties/248?tab=scope) has been live since June 18, 2026 and advertises a maximum reward of **1,000,000 USDC**. The [Scope](https://audits.sherlock.xyz/bug-bounties/248?tab=scope) tab is public: in-scope source is `flyingtulipdotcom/ftPUT` (`PutManager`, `pFT`, `ftYieldWrapper`, `CircuitBreaker`, Aave strategy, oracle/ACL) plus listed onchain deployments of that product and the FT OFT token — the same product family as [Sherlock contest #1223](https://audits.sherlock.xyz/contests/1223).
-
-**Against this report's contracts:** none of `PositionsManager`, `ConfigRegistry`, the RFQ engines, the IRMs, or the ftUSD mint/redeem/staking stack appear in that scope. Two addresses that *are* listed also appear here, but only as shared infrastructure / reward token — not as coverage of the assessed lending path:
-
-| Address | Role in this report | In bounty scope? |
-|---|---|---|
-| [`0x88432bB6…1397`](https://etherscan.io/address/0x88432bB6EA62e774cB6d87995CC5277568d01397) | `YieldClaimer` (wrapper `execute`) | **Yes** |
-| [`0x5DD1A7A3…082c`](https://etherscan.io/address/0x5DD1A7A369e8273371d2DBf9d83356057088082c) | FT token (supplier emissions) | **Yes** (FT OFT) |
-
-So the bounty is a real disclosure channel for adjacent Flying Tulip code, but it does **not** establish bounty coverage for supplying or borrowing in FT Lend.
+**LIVE.** [Sherlock's Flying Tulip Bug Bounty #248](https://audits.sherlock.xyz/bug-bounties/248?tab=scope) has been live since June 18, 2026 and advertises a maximum reward of **1,000,000 USDC**. Its **Additional Scope** states that contracts deployed for the bounty are found either in Sherlock's static Scope section or in Flying Tulip's linked [Contract Addresses](https://docs.flyingtulip.com/contract-addresses/) directory. That directory points to Flying Tulip's Smart Search, the protocol-maintained dynamic list of all deployed production contracts. Accordingly, the live bounty covers the deployed contracts assessed here, including `PositionsManager`, `ConfigRegistry`, the RFQ engines, the IRMs, the wrappers and strategies, and the related ftUSD contracts, even when an address is not duplicated in Sherlock's static address table.
 
 > **Scoring note.** This does **not** trigger the "No audit" critical gate — a real audit registry demonstrably exists, so asserting "no audit" would be false. Audits can be access with team permission.
 
@@ -241,7 +232,7 @@ A lender calls `deposit(asset, amount)` on the `PositionsManager`. Un-borrowed l
 | Lending protocol reserves | `astate.reserves` | 7.72 USDC · 13.16 USDT · 303.01 ftUSD · 0.0000257 WETH · **0 WBTC** | accrued from interest |
 | Reserve withdrawal | `PMWrapper.withdrawReserves` | unrestricted | Admin Safe |
 
-**Protocol reserves are negligible** — a few hundred dollars in total against a $12.48M book. There is no meaningful buffer between a bad-debt event and supplier principal; bad debt is socialized to suppliers of the affected asset. ftUSD mint/redeem fees are covered in the ftUSD report.
+**Protocol reserves are negligible** — a few hundred dollars in total against a $12.48M book. The current book uses blue-chip collateral and a 1.25 target health factor, which reduce expected bad-debt risk. Reserves nevertheless provide no meaningful buffer against any residual loss; bad debt would be borne by suppliers of the affected asset. ftUSD mint/redeem fees are covered in the ftUSD report.
 
 ### Supplier rewards are discretionary FT emissions
 
@@ -379,7 +370,7 @@ Lender-exit frame: a supplier leaves via `withdraw` against available (un-borrow
 
 | Venue | Pool | ftUSD side | Quote side | Notes |
 |---|---|---|---|---|
-| **Curve StableSwap-NG** | [`0xafec61e7…2630`](https://etherscan.io/address/0xafec61e7a604f8f81f7cab64ec75bfa07c542630) | **971,101 ftUSD** | **903,390 USDC** | ~$1.87M, A=1000, fee 0.2%, near-balanced |
+| **Curve StableSwap-NG** | [`0xafec61e7…2630`](https://etherscan.io/address/0xafec61e7a604f8f81f7cab64ec75bfa07c542630) | **118,921 ftUSD** | **130,034 USDC** | ~$249K, A=1000, fee 0.2%; >85% smaller than initial snapshot |
 | Curve Twocrypto | [`0x68102ff5…ad6c`](https://etherscan.io/address/0x68102ff5406475881462880a8da3c9bc9181ad6c) | 48,838 ftUSD | FT | FT/ftUSD pair |
 | Uniswap V3 0.05% | [`0x99986c44…bf2c`](https://etherscan.io/address/0x99986c4473e3C8fF3b31FA8a92fB582d19BdBf2c) | 0.000033 ftUSD | 0.00064 USDC | dust — not a usable venue |
 | Uniswap V3/V2 (other tiers) | — | no pool deployed | — | — |
@@ -388,12 +379,12 @@ Lender-exit frame: a supplier leaves via `withdraw` against available (un-borrow
 
 | Size | Out | Slippage |
 |---|---|---|
-| 10,000 ftUSD | 9,979.15 USDC | 0.209% |
-| 100,000 ftUSD | 99,780.80 USDC | 0.219% |
-| 250,000 ftUSD | 249,398.14 USDC | 0.241% |
-| 500,000 ftUSD | 498,495.41 USDC | 0.301% |
+| 10,000 ftUSD | ~9,979 USDC | ~0.21% |
+| 50,000 ftUSD | 49,880.65 USDC | 0.239% |
+| 100,000 ftUSD | 99,616.85 USDC | 0.383% |
+| 150,000 ftUSD | 129,378.67 USDC | **13.75%** |
 
-  **$500K exits at 0.30% slippage** — better execution than the FT Lend ftUSD market itself could absorb (1.11M ftUSD of wrapper liquidity, but only against protocol redemption). The pool is near-balanced (971K/903K) and `get_virtual_price()` = 1.000464, so **the ftUSD peg is externally corroborated**, not merely self-reported by the protocol's own redemption oracle. ftUSD also circulates as collateral in [Morpho](https://etherscan.io/address/0xbbbbbbbbbb9cc5e90e3b3af64bdaf62c37eeffcb) (629,675 ftUSD), which is independent third-party acceptance of the asset.
+  The initial August 6 snapshot supported a $500K exit at 0.30%, but the dominant LP exited on August 28 and the pool fell from ~$1.87M to ~$249K. On September 4, **$100K exits at about 0.38%, while $150K incurs about 13.75% slippage**. The pool remains an external price signal and exit for ftUSD, but no longer provides deep corroboration. This does not change the FT Lend supplier liquidity score because Curve cannot exit a USDC/WETH/WBTC lending position. ftUSD also circulates as collateral in [Morpho](https://etherscan.io/address/0xbbbbbbbbbb9cc5e90e3b3af64bdaf62c37eeffcb) (629,675 ftUSD), which is independent third-party acceptance of the asset.
 
 - The supply receipts themselves have no secondary market which is normal for lending protocols. A lender's FT Lend position is an internal balance, not a transferable token, so exit is redemption-only against wrapper liquidity — which is a Spark/Aave withdrawal. The Curve venue above is an exit for *ftUSD holders*, not for USDC/WETH/WBTC lenders. This distinction matters: it improves the ftUSD collateral leg and the ftUSD-supplier leg, and does nothing for the other 88% of the market.
 
@@ -412,7 +403,7 @@ Lender-exit frame: a supplier leaves via `withdraw` against available (un-borrow
 - **WBTC strategy-manager Safe:** [`0x5557729b169082f07d3131D560E2f2cb5e6c48f6`](https://etherscan.io/address/0x5557729b169082f07d3131D560E2f2cb5e6c48f6) — a **third** Safe, **3 of 5**, with the *identical five signers* as the admin Safe. `strategyManager` of the WBTC wrapper only. Separate address, zero added independence.
 - **Upgradeability:** every core contract is an OpenZeppelin **UUPS proxy** (EIP-1967 admin slot empty; upgrade gated by `owner()`/`admin()`). `PositionsManager.admin()` is `PMWrapper` [`0xBDD80028…C68B`](https://etherscan.io/address/0xBDD80028c9e4b9A2D268D2cF62Fb54Ec8697C68B), whose `admin()` is the same 3/5 Safe and which can `upgradePM`, `setCaps`, pause, and `withdrawReserves`.
 
-With **no delay**, the 3/5 Safe can: upgrade any contract to arbitrary code, change which assets/caps/margins apply, write an arbitrary oracle price, pause user funds, redirect where lender capital is deployed, and (for ftUSD) mint unbacked supply, blacklist, and burn balances. There is **no timelock, no DAO, and no independent guardian.**
+With **no delay**, the 3/5 Safe can: upgrade any contract to arbitrary code, change which assets/caps/margins apply, write an arbitrary oracle price, pause user funds, redirect where lender capital is deployed, and (for ftUSD) authorize a new issuance path that need not enforce collateral, blacklist, and burn balances. The current production mint module is collateralized and no evidence of privileged unbacked issuance was found. There is **no timelock, no DAO, and no independent guardian.**
 
 ### Admin powers over FT Lend (verified onchain)
 
@@ -451,16 +442,16 @@ Lending accounting (supply/borrow indices, health factors) is onchain and the or
 - **Aave price adapters** — `CLSynchronicityPriceAdapterPegToBase` (WBTC) and `WstETHPriceCapAdapter` (wstETH) sit in the pricing path for 39.5% of TVL; sound, audited construction.
 - **FT Lend itself (reflexive)** — ftUSD's backing (~$4.38M) is supplied into this market by the Delta-Neutral strategy, and ftUSD is also accepted as collateral here, so the stablecoin and the money market cannot fail independently. See [Reflexive supply](#reflexive-supply-ftusd-backing-lent-into-ft-lend). This is the unusual dependency — not Spark/Aave/Chainlink.
 - **The Spot AMM / CLOB — verified absent from the deployed contracts.** The docs describe dynamic LTV "snapshotted from AMM depth and volatility," and earlier revisions of this report carried that as an unverified critical dependency. It is not wired in. `ConfigRegistry`'s entire risk surface is `assetCfg` (IRM, `mmBps`, enabled/borrowable/collateral flags, wrapper), the three margin thresholds and the oracle pointer — **no depth input, no volatility input, no LTV machinery**. The `PositionsManager` contains no AMM or order-book reference beyond a comment on the `engines` mapping (`// PositionsManager, RFQ, ftLP, OrderBook, AMM, etc`), and all four registered engines are RFQ/meta-action contracts. The `RfqEngine`'s only "Uniswap" string is an MIT licence header on a copied math library. *Caveat: the lending repos are private, so this is established from deployed ABIs, source and event logs, not from the team's source of truth.*
-- **Lido / stETH** — referenced by the Delta-Neutral strategy design but **not currently held** (0 balance).
-- **Curve** — a StableSwap-NG [ftUSD/USDC pool](https://etherscan.io/address/0xafec61e7a604f8f81f7cab64ec75bfa07c542630) (~$1.87M) is the **only secondary-market** exit and the only external ftUSD price reference. Primary exit is protocol redeem via [`MintAndRedeem`](https://etherscan.io/address/0xAa48EcBC843cF7E9A29155D112b8Cb27902bD23C) (permissionless, 7 bps, capacity-capped by FT Lend cash). **Curve liquidity is highly concentrated:** 100% of the LP supply sits in a [Curve gauge](https://etherscan.io/address/0x8abf0a7e4b59ace59cb214fcb158285cd7cf7c3f) whose `manager` is [`0x3c427497…1B4E`](https://etherscan.io/address/0x3c42749709BF354B3aE0Db29Fd2dd88089b21B4E) — **an admin Safe signer** — and 99.998% of the gauge is held by a single EOA. `A` = 1000 with no ramp in progress; fee 0.2%; `offpeg_fee_multiplier` 2.5×. Full analysis in the [ftUSD report](./flying-tulip-ftusd.md).
+- **Lido / wstETH** — a live component of the Delta-Neutral strategy's hedge at the August 6 snapshot (76.54 wstETH financed by 95.01 WETH debt).
+- **Curve** — a StableSwap-NG [ftUSD/USDC pool](https://etherscan.io/address/0xafec61e7a604f8f81f7cab64ec75bfa07c542630) is the **only secondary-market** exit and external ftUSD price reference. Primary exit is protocol redemption. After the former dominant EOA exited on August 28, pool liquidity fell by more than 85% to ~$249K. Current gauge custody is 87.1% through the Convex voter proxy, 7.1% through an EOA, and 5.6% through `CurveYCRVVoter`; Convex aggregation does not establish beneficial ownership. Full analysis in the [ftUSD report](./flying-tulip-ftusd.md).
 
 ## Operational Risk
 
 - **Team:** Founder **Andre Cronje** (public; founded Yearn, Keep3r, co-founded Sonic/Fantom) strong founder, but mixed reputation on other projects.
 - **Legal entity / jurisdiction:** **NOT FOUND** / undisclosed (docs reference a "Foundation" with no domicile). CoinList sale excluded the US, Canada and ~21 other jurisdictions.
 - **Funding:** ~$200M seed (Sep 2025, $1B FDV), ~$25.5M Series A (Jan 2026), public sale; the official sale-update blog reports total raised ≈ **$184M** (below the "$200M seed" headline — a reconciliation gap). FT token (Aug 3, 2026): max supply 10B, mainnet `totalSupply()` **1,197,190,528**, circulating ~547M, price ~**$0.0994**, **market cap ~$54.5M**, FDV ~$119M ([CoinGecko](https://www.coingecko.com/en/coins/flying-tulip)). FT is an OFT, so mainnet supply is not the cross-chain total.
-- **Documentation vs. reality gap.** Beyond the usual omissions (oracle design, risk parameters, multisig setup), two deployed behaviours are not disclosed publicly: that **ftUSD's backing is lent into FT Lend**, and that the **"delta-neutral" strategy currently runs no hedge**. The docs' own transparency principle commits to publishing audit reports, which has not happened.
-- **Incident response:** the docs claim "continuous monitoring and formal incident runbooks" and list "incident post-mortems" as a published artefact. **No runbook, no post-mortem, and no security contact are public**, and there have been no incidents to test the claim. Onchain emergency capability genuinely exists and is broad — per-asset pause, the `CircuitBreaker`, guardian `disablePrice`, ftUSD `pause` and `blacklist`. The live Sherlock bounty provides a public reporting channel for **ftPUT**, but Safe Harbor enrolment remains absent and the bounty scope does not cover the assessed FT Lend / ftUSD contracts.
+- **Documentation vs. reality gap.** Beyond the usual omissions (oracle design, risk parameters, multisig setup), the public material does not clearly disclose that **ftUSD's backing is lent into FT Lend**. The hedge was inactive at the June snapshot and active by August 6, showing that strategy state can change materially between reviews. The docs' own transparency principle commits to publishing audit reports, which has not happened.
+- **Incident response:** the docs claim "continuous monitoring and formal incident runbooks" and list "incident post-mortems" as a published artefact. **No runbook, no post-mortem, and no security contact are public**, and there have been no incidents to test the claim. Onchain emergency capability genuinely exists and is broad — per-asset pause, the `CircuitBreaker`, guardian `disablePrice`, ftUSD `pause` and `blacklist`. The live Sherlock bounty provides a public reporting channel covering deployed Flying Tulip production contracts through the dynamic contract list incorporated by its Additional Scope; Safe Harbor enrolment remains absent.
 - **Other deployments:** Flying Tulip also runs on **Sonic**, which DeFiLlama puts at **$0.52M — 3.8%** of protocol TVL against Ethereum's $12.99M ([API](https://api.llama.fi/protocol/flying-tulip)). It is a separate deployment: none of the contracts assessed here exists on Sonic, so **nothing in this report transfers to it**, and no Ethereum position is exposed to it. Deliberately out of scope rather than pending — a Sonic allocation would need its own assessment, and at 3.8% of a $13M protocol that is not currently worth the effort.
 - **Governance transparency:** no DAO, no forum/Snapshot, multisig signer identities undisclosed.
 
@@ -613,21 +604,21 @@ All contracts in the trust surface were checked via Etherscan `getsourcecode` on
 - **Genuine onchain over-collateralization with blue-chip collateral** (WETH, WBTC, wstETH, USDC, USDT) and enforced health factors.
 - **Oracle construction is more careful than it first appears** — canonical Chainlink for USDC/USDT/ETH, plus Aave's audited peg and cap adapters for WBTC and wstETH, all wired **immutably** so the owner cannot repoint them.
 - **No privilege drift since launch.** All four engines, both meta-modules and the sole liquidation module were set in the deployment block and have never changed.
-- **ftUSD has a genuine external market.** A ~$1.87M Curve StableSwap-NG pool clears $500K at 0.30% slippage and sits near-balanced, which both provides a real exit for the ftUSD leg and corroborates the peg independently of the protocol's own oracle. ftUSD is separately accepted as Morpho collateral.
+- **ftUSD has a genuine external market**, but it is now thin: the Curve pool fell from ~$1.87M to ~$249K after the initial review. It remains a market-based price signal and exit for the ftUSD leg; ftUSD is separately accepted as Morpho collateral.
 - **Conservative caps and a small footprint** limit blast radius today.
 
 ### Key Risks
 
 - **34.5% of TVL is the protocol lending to itself.** ftUSD's backing is deployed into FT Lend, so ftUSD and the lending market cannot fail independently, and ftUSD's own price feed cannot register an impairment of that collateral at all.
-- **Single 3/5 multisig controls everything with no timelock** — instant upgrade of any contract, arbitrary oracle price override, pause of user funds, unbacked ftUSD mint, blacklist and seizure. Two further Safes share the identical signer set, so apparent separation of duties is cosmetic.
+- **Single 3/5 multisig controls everything with no timelock** — instant upgrade of any contract, arbitrary oracle price override, pause of user funds, and a privileged path to authorize unbacked ftUSD issuance, plus blacklist and seizure. The current ftUSD mint module is collateralized and no evidence that the privileged issuance path has been used was found. Two further Safes share the identical signer set, so apparent separation of duties is cosmetic.
 - **Extreme lender and borrower concentration:** 25 suppliers total; three third-party addresses are 96.1% of third-party TVL; one EOA is 38% of all supply and 73% of all debt.
-- **Audit quality is good but non-public, and FT Lend has no in-scope bounty** — the private package was reviewed for this assessment, while firm/date/scope/finding details remain unavailable to public depositors. The live $1M Sherlock bounty covers **ftPUT / FT OFT**, not the lending core.
-- **Very new** (engine ~3.2 months) with **no stress history**, an untested novel liquidation engine, and **no loss backstop** (reserves are negligible).
+- **Audit quality is good but non-public** — the private package was reviewed for this assessment, while firm/date/scope/finding details remain unavailable to public depositors. A live $1M Sherlock bounty covers FT Lend and the other deployed production contracts through the dynamic contract list incorporated by its Additional Scope.
+- **Very new** (engine ~3.2 months) with **no stress history**, an untested novel liquidation engine, and negligible reserves. The current book's blue-chip collateral and 1.25 target health factor reduce expected bad-debt risk, but any residual bad debt would be borne by suppliers.
 - **Reflexive collateral.** A loss event in FT Lend impairs ftUSD's backing, which impairs ftUSD, which is 11.8% of FT Lend's collateral; the backing-blind feed would not register that impairment.
 
 ### Critical Risks
 
-- **Unilateral, instant admin control.** A 3/5 multisig — effectively one party, given the identical signer set across all three Safes — can upgrade the engine, rewrite the oracle price via `setLastGoodPrice`, redirect lender capital through a zero-delay `setStrategy`, or mint unbacked ftUSD, with no delay and no independent check. Deployed invariants must be treated as mutable, not durable.
+- **Unilateral, instant admin control.** A 3/5 multisig — effectively one party, given the identical signer set across all three Safes — can upgrade the engine, rewrite the oracle price via `setLastGoodPrice`, redirect lender capital through a zero-delay `setStrategy`, or authorize a new unbacked ftUSD issuance path, with no delay and no independent check. Normal ftUSD minting remains collateralized and no evidence that this path has been used was found. Deployed invariants must be treated as mutable, not durable.
 
 ---
 
@@ -648,10 +639,10 @@ All contracts in the trust surface were checked via Etherscan `getsourcecode` on
 
 #### Category 1: Audits & Historical Track Record (Weight: 20%)
 
-**Subcategory A: Audits & Security Reviews — 3.0**
+**Subcategory A: Audits & Security Reviews — 2.5**
 - The privately reviewed audit package provides good in-scope coverage from reputable firms including ChainSecurity, MixBytes, and Cantina; the audit quality itself maps to rubric row 2.
 - **+0.5** because the reports and finding-level detail remain behind an access-code wall rather than being publicly inspectable.
-- **+0.5 because FT Lend is not covered by the bug bounty.** The live $1M Sherlock program covers ftPUT / FT OFT, not `PositionsManager`, `ConfigRegistry`, the IRMs, or the RFQ engines. This is the explicit reason FT Lend scores worse than ftUSD's 2.5 audit subscore; it is not a negative judgment on the audit quality.
+- The live Sherlock bounty has a maximum reward of 1,000,000 USDC and covers Flying Tulip's deployed production contracts through the dynamic contract list incorporated by the bounty's Additional Scope, including `PositionsManager`, `ConfigRegistry`, the IRMs, and the RFQ engines.
 - The only two publicly confirmable reviews cover the token-sale `Escrow` and the separate ftPUT product — **neither touches `PositionsManager`, `ConfigRegistry`, the IRMs, the RFQ engines, ftUSD, ftUSD Core, or `MintAndRedeem`.**
 - Contract surface is large and novel: dynamic snapshot LTV, RFQ/relayer/session layer, flash liquidation, epoch settlement, cross-product shared collateral, and a discretionary backing strategy. The rubric notes simple surfaces score better than complex ones.
 
@@ -661,7 +652,7 @@ All contracts in the trust surface were checked via Etherscan `getsourcecode` on
 - No incidents, exploits, or depegs — but also no stress event of any kind, no drawdown, and no liquidation cascade. The clean record carries little information at this age and size.
 - Both columns land on 4. **4.0.**
 
-**Score: 3.5/5** — (3.0 + 4.0) / 2 = 3.5. The audit work is good, but FT Lend lacks in-scope bounty coverage and the market is young and small.
+**Score: 3.25/5** — (2.5 + 4.0) / 2 = 3.25. The audit work and bounty coverage are good, while the non-public reports and the market's limited age and scale keep the category above the low-risk bands.
 
 #### Category 2: Centralization & Control Risks (Weight: 30%)
 
@@ -693,7 +684,7 @@ All contracts in the trust surface were checked via Etherscan `getsourcecode` on
 - The direct lending book is strong: 100% onchain, over-collateralized, blue-chip collateral, health factors enforced in-contract (`marginHfSafeBps` 1.50 / `marginHfTargetBps` 1.25 / $250 min equity).
 - Dragging it down: **ftUSD (11.4% of TVL) is collateral whose own backing is a claim on this same market**, at a nominal 101.03% CR with no independent buffer.
 - **Maintenance margins on stables are 1.5%, and there is nothing beneath them.** The dynamic-LTV haircut the docs describe is **not implemented in the deployed contracts** — no depth or volatility input exists in `ConfigRegistry` or the `PositionsManager`. With `mmBps` = 150 and a 1.25 target HF, the contract permits roughly **50× leverage** on a stable position. This is an admin-set constant, not a risk engine, and it is the only thing standing between a borrower and the collateral.
-- **No loss backstop.** Protocol reserves are 7.72 USDC / 13.16 USDT / 303.01 ftUSD / ~0 WETH / 0 WBTC — negligible against $12.13M. Bad debt would be socialized to suppliers.
+- **Limited loss backstop.** Protocol reserves are 7.72 USDC / 13.16 USDT / 303.01 ftUSD / ~0 WETH / 0 WBTC — negligible against $12.13M. Blue-chip collateral and the 1.25 target health factor reduce expected loss probability, but any residual bad debt would be socialized to suppliers.
 - Liquidation engine is novel, module-gated via permissionless `rfqFill(Flash)`, and has never run at scale. **The `PositionsManager` defines no liquidation bonus and no close factor** — the seize/repay split is set by the swappable `RfqEngine`, and the insolvency exception explicitly permits leaving bad debt.
 - **Supplier yield is partly discretionary FT emissions** paid via admin-only `settleEpoch`. WBTC and ftUSD suppliers (51.3% of TVL combined) have received **zero** emissions to date.
 - Admin can override the price that determines whether a position is solvent at all.
@@ -723,7 +714,7 @@ Framed for an **FT Lend supplier**. Exit is protocol `withdraw` against availabl
 
 - **Team:** founder is public and well known (Andre Cronje — Yearn, Keep3r, Sonic/Fantom), which is a genuine positive. His track record is mixed, with a documented history of abandoned or incomplete launches. The remaining ~15 team members are anonymous.
 - **Legal:** **no disclosed legal entity or jurisdiction** — docs reference a "Foundation" with no domicile.
-- **Documentation:** conceptually reasonable, but omits oracle design, risk parameters and the multisig setup. The docs do not disclose that ftUSD's backing is lent into FT Lend, and the "delta-neutral" strategy holds no hedge. The docs' own transparency principle promises published audit reports that do not exist.
+- **Documentation:** conceptually reasonable, but omits oracle design, risk parameters and the multisig setup. The docs do not clearly disclose that ftUSD's backing is lent into FT Lend. The strategy's hedge was inactive at the June snapshot and active by August 6. The docs' own transparency principle promises published audit reports that do not exist.
 - **Governance transparency:** no DAO, no forum, no Snapshot, signers undisclosed.
 - **Incident response:** docs reference "formal incident runbooks"; none is public. Emergency capability exists onchain (pause, circuit breaker, `disablePrice`) and has never been exercised.
 
@@ -733,14 +724,14 @@ Framed for an **FT Lend supplier**. Exit is protocol `withdraw` against availabl
 
 | Category | Score | Weight | Weighted |
 |----------|-------|--------|----------|
-| Audits & Historical | 3.50 | 20% | 0.700 |
+| Audits & Historical | 3.25 | 20% | 0.650 |
 | Centralization & Control | 3.50 | 30% | 1.050 |
 | Funds Management | 3.00 | 30% | 0.900 |
 | Liquidity Risk | 2.00 | 15% | 0.300 |
 | Operational Risk | 3.50 | 5% | 0.175 |
-| **Final Score** | | | **3.125** |
+| **Final Score** | | | **3.075** |
 
-**Final Score: 3.1**
+**Final Score: 3.1** (3.075 weighted)
 
 **Optional modifiers:** none apply. Protocol is <1 year old (no −0.5 for >2 years incident-free) and TVL is far below $500M (no −0.5 for scale).
 
@@ -758,12 +749,12 @@ Framed for an **FT Lend supplier**. Exit is protocol `withdraw` against availabl
 
 The composite is 3.1, in the Medium band. The determining factors are:
 
-- **Governance is the dominant term** (Category 2A at 5.0, carrying 10% of the total weight on its own). A 3/5 Safe with no timelock, holding upgrade authority over every contract, arbitrary oracle-price authority, and an unbacked-mint path on ftUSD, means no invariant in this report survives an adverse governance action. Three Safes with one signer set provide no meaningful separation.
+- **Governance is the dominant term** (Category 2A at 5.0, carrying 10% of the total weight on its own). A 3/5 Safe with no timelock holds upgrade authority over every contract, arbitrary oracle-price authority, and a privileged path to authorize an ftUSD issuance module that need not enforce collateral. The current production mint path is collateralized and no evidence of privileged unbacked issuance was found, but no invariant survives an adverse governance action. Three Safes with one signer set provide no meaningful separation.
 - **Reflexive collateral.** 35.1% of TVL is the protocol's own ftUSD backing; ftUSD is 11.4% of this market's collateral; and ftUSD's price feed is blind to that backing, so an impairment would not surface in liquidation pricing. FT Lend and ftUSD cannot fail independently.
 - **Concentration.** Three third-party addresses are 96.1% of third-party TVL; one EOA is 38% of supply and 73% of debt.
 - **Lender exit is utilization-bound**, with a second gate at Spark/Aave because wrappers hold zero idle buffer. Liquidity score is not driven by Curve — that venue is for ftUSD holders, not FT Lend suppliers.
-- **Audit evidence is not inspectable** for any in-scope contract, with no bounty and no Safe Harbor.
-- **No loss backstop** and a novel, untested liquidation engine.
+- **Audit evidence is not publicly inspectable** for any in-scope contract. A live $1M Sherlock bounty covers deployed production contracts, but there is no Safe Harbor enrolment.
+- **Negligible loss reserves** and a novel, untested liquidation engine; blue-chip collateral and the 1.25 target health factor mitigate expected bad-debt risk but do not absorb residual losses.
 
 Offsetting these, and the reason this is not High Risk: the accounting is honest and fully reconcilable onchain, the collateral is genuinely blue-chip and over-collateralized, the oracle construction uses canonical Chainlink plus audited Aave adapters wired immutably, privileges have not drifted since deployment, every contract is source-verified, and current utilization leaves ample cash for same-block lender exits.
 
@@ -773,13 +764,13 @@ Offsetting these, and the reason this is not High Risk: the accounting is honest
 
 ## Reassessment Triggers
 
-- **Audit status:** reassess if any in-scope audit report is published with firm, date and scope, if the bounty publishes or expands assessed-contract coverage, or if the protocol enrols in SEAL Safe Harbor.
+- **Audit status:** reassess if any in-scope audit report is published with firm, date and scope, if Sherlock removes or narrows the dynamic production-contract coverage incorporated by the bounty's Additional Scope, or if the protocol enrols in SEAL Safe Harbor.
 - **Governance hardening:** reassess if a timelock is added, if the admin Safe threshold or signer independence materially improves, or if the three Safes are given genuinely distinct signer sets.
-- **Reflexivity:** reassess if the Delta-Neutral strategy's share of FT Lend TVL exceeds 40% or falls below 10%, if ftUSD backing is redeployed to a venue outside FT Lend, or if the hedge leg (stETH/WETH) is actually activated at size.
+- **Reflexivity:** reassess if the Delta-Neutral strategy's share of FT Lend TVL exceeds 40% or falls below 10%, if ftUSD backing is redeployed to a venue outside FT Lend, or if the hedge target or position changes materially.
 - **Dynamic LTV:** reassess if an AMM or order-book contract is ever registered via `EngineSet`, or if `ConfigRegistry` gains a depth/volatility input — that would introduce the risk engine the docs already describe and change the collateralization analysis.
 - **Time-based:** reassess in **2 months**. Shortened from 3: the hedge leg activating mid-assessment showed this market's state can move materially in days on one actor's decision.
 - **TVL/usage-based:** using the August 3 baseline of $7.95M *third-party* lending TVL, reassess if it grows above ~$24M, falls below ~$2.6M, or if any of the three dominant third-party suppliers exits.
-- **ftUSD market-based:** reassess if the Curve ftUSD/USDC pool loses >50% of its TVL, becomes materially imbalanced (>70/30), or if its spot price diverges >0.5% from the protocol's `priceUSD(ftUSD)` — that pool is the only external check on the ftUSD feed.
+- **ftUSD market-based:** the prior >50% Curve-liquidity trigger has occurred. For the ftUSD companion report, reassess on another 25% decline from the September 4 baseline, material imbalance (>70/30), or spot divergence >0.5% from `priceUSD(ftUSD)`. This remains context only for most FT Lend suppliers.
 - **Cap-based:** reassess if `supplyCap` is materially raised on any asset — ftUSD is already 95% subscribed against a 1.5M cap.
 - **Concentration:** reassess if the dominant EOA's share of supply or debt moves by more than 15 percentage points in either direction.
 - **Incident-based:** reassess after any exploit, bad-debt event, oracle override (`setLastGoodPrice`), oracle-wrapper pause, proxy upgrade, ftUSD depeg or unbacked mint, new ftUSD Core module enablement, or any Spark/Aave incident affecting a configured strategy.
@@ -790,4 +781,5 @@ Offsetting these, and the reason this is not High Risk: the accounting is honest
 
 | Date | Score | Notes |
 | --- | --- | --- |
+| [September 4, 2026](https://github.com/yearn/risk-score/pull/237) | 3.1 | Bounty scope corrected; team-response wording and ftUSD Curve context refreshed; score unchanged |
 | [August 7, 2026](https://github.com/yearn/risk-score/pull/237) | 3.1 | Initial assessment |

--- a/reports/report/flying-tulip.md
+++ b/reports/report/flying-tulip.md
@@ -831,5 +831,4 @@ Offsetting these, and the reason this is not High Risk: the accounting is honest
 
 | Date | Score | Notes |
 | --- | --- | --- |
-| [September 4, 2026](https://github.com/yearn/risk-score/pull/237) | 3.0 | $1M all-production-contract bounty scored at rubric row 2; team-response wording, ftUSD context, and live TRS/Trade engines, execution dependencies and monitoring incorporated |
-| [August 7, 2026](https://github.com/yearn/risk-score/pull/237) | 3.1 | Initial assessment |
+| [September 4, 2026](https://github.com/yearn/risk-score/pull/237) | 3.0 | Initial assessment |

--- a/reports/report/flying-tulip.md
+++ b/reports/report/flying-tulip.md
@@ -1,0 +1,793 @@
+# Protocol Risk Assessment: Flying Tulip — FT Lend (ftDNMM)
+
+- **Assessment Date:** August 7, 2026
+- **Token:** FT Lend market — supply / borrow positions (internal balances, not tokenised)
+- **Chain:** Ethereum Mainnet
+- **Core Contract:** PositionsManager [`0xbe4050a73a7Fb384c65E885a15C33461A4B20055`](https://etherscan.io/address/0xbe4050a73a7Fb384c65E885a15C33461A4B20055)
+- **Final Score: 3.1/5.0**
+- **Medium Risk** — approved with enhanced monitoring. A 3-of-5 Safe with no timelock can upgrade every contract and override every price. **35.1% of the market's TVL is the protocol's own ftUSD backing collateral supplied back into itself**, and only three genuinely third-party addresses hold 96% of the remainder. The audit package was privately reviewed and is strong, but the reports remain non-public and FT Lend has no in-scope bug bounty. See [Risk Score Assessment](#risk-score-assessment). (Also deployed on Sonic; this report covers Ethereum.)
+- **Companion report:** ftUSD and staked ftUSD are assessed separately in **[Flying Tulip — ftUSD & Staked ftUSD](./flying-tulip-ftusd.md)**.
+
+> **Scope.** Yearn's interest (issue [yearn/risk-score#234](https://github.com/yearn/risk-score/issues/234)) is the risk of supplying ("just lend") and/or borrowing in the **FT Lend** market. This report covers the lending engine and the assets it touches. **Holding ftUSD and staking ftUSD are out of scope** and are assessed in the companion report [Flying Tulip — ftUSD & Staked ftUSD](./flying-tulip-ftusd.md). ftUSD appears here only as an accepted collateral asset and because the contract holding its backing is this market's largest supplier. Nothing in this report should be used to size an ftUSD or sftUSD position. The unrelated `tulip.garden` protocol on Solana is **not** Flying Tulip and is excluded. Original values were verified **June 7, 2026 at block `25264957`**; this revision re-verified everything on **August 6, 2026 at block `25697429`** via `cast` and Etherscan against an Ethereum mainnet RPC.
+
+## Overview + Links
+
+**Flying Tulip** is Andre Cronje's "on-chain financial system that standardizes pricing, credit, and risk across a suite of products" — a hybrid AMM-CLOB spot exchange, a lending market (FT Lend), perpetual futures, and a yield stablecoin (ftUSD). The products share collateral and pricing so "a single deposit can back a loan, serve as collateral for a limit order, and support a future position simultaneously."
+
+**FT Lend** (the contract suite is labelled **ftDNMM** in the protocol's address registry) works as follows:
+
+- **Markets.** Two models: (1) *permissionless* pair markets auto-created for any Spot pool, and (2) a curated *permissioned* cross-collateral pool. On Ethereum today the live set is the curated pool (7 enabled assets, 6 priced).
+- **Supply side.** A lender calls `deposit(asset, amount)` on the `PositionsManager`. Un-borrowed liquidity is held by the asset's `ftYieldWrapper`, which deploys it to an external strategy. Suppliers earn borrower interest plus strategy yield through the supply index.
+- **Borrow side.** Borrowers post collateral and borrow against it. **LTV is dynamic and snapshotted** at position open based on AMM depth and multi-timeframe volatility. Onchain, each asset carries a **maintenance-margin rate (`mmBps`)** in the `ConfigRegistry`, and account health is enforced against `marginHfTargetBps`/`marginHfSafeBps`.
+- **Pricing.** An onchain `OracleRouterChainlink` — Chainlink-anchored, with Aave-style adapters for WBTC and wstETH, and a protocol-internal redemption oracle for ftUSD.
+- **Liquidations.** Module-gated through `RfqEngine` (`rfqFill` / `rfqFillFlash` → `liquidateFlash`), designed as time-sliced / RFQ-routed soft liquidations. Anyone can liquidate using partial liquidation.
+
+**Links:**
+
+- [Protocol Documentation](https://docs.flyingtulip.com/) · [FT Lend docs](https://docs.flyingtulip.com/product-suite/ft-lend/) · [Contract Addresses](https://docs.flyingtulip.com/contract-addresses/) · [Risks page](https://docs.flyingtulip.com/risks/)
+- [App](https://flyingtulip.com/) · [Lend dashboard](https://flyingtulip.com/lend/dashboard/) · [Blog](https://blog.flyingtulip.com/)
+- [GitHub org `flyingtulipdotcom`](https://github.com/flyingtulipdotcom) (only `ft`, `escrow`, `supporter-whitelist` are public; the lending/ftUSD repos are private)
+- [DeFiLlama — Flying Tulip](https://defillama.com/protocol/flying-tulip) (slug `flying-tulip`)
+- [Sherlock bug bounty #248](https://audits.sherlock.xyz/bug-bounties/248) · [Sherlock contest #1223 (ftPUT)](https://audits.sherlock.xyz/contests/1223) · [CoinList sale](https://coinlist.co/flying-tulip)
+
+## Contract Addresses
+
+All addresses verified onchain at block `25675412` (August 3, 2026). Every contract listed is **source-verified on Etherscan**, including each proxy implementation.
+
+### Core Lending Contracts (Ethereum)
+
+| Contract | Address | Type | Implementation |
+|---|---|---|---|
+| PositionsManager | [`0xbe4050a73a7Fb384c65E885a15C33461A4B20055`](https://etherscan.io/address/0xbe4050a73a7Fb384c65E885a15C33461A4B20055) | UUPS proxy | [`0xaa3d5fc8…a23b`](https://etherscan.io/address/0xaa3d5fc84b43219391539714be5f0681aefca23b) |
+| ConfigRegistry | [`0xA8777c3D446fa7F0b0FC97a80C1Ea1d37F1ca33E`](https://etherscan.io/address/0xA8777c3D446fa7F0b0FC97a80C1Ea1d37F1ca33E) | UUPS proxy | [`0xd25f964e…47e5`](https://etherscan.io/address/0xd25f964ead7bfbf07858b5bfede58f11a5a947e5) |
+| PMWrapper (PM admin) | [`0xBDD80028c9e4b9A2D268D2cF62Fb54Ec8697C68B`](https://etherscan.io/address/0xBDD80028c9e4b9A2D268D2cF62Fb54Ec8697C68B) | admin wrapper | — |
+| RfqEngine (**sole liquidation module**) | [`0xEB00B335Ca52216Fb60fdFFA361397367C39Dc32`](https://etherscan.io/address/0xEB00B335Ca52216Fb60fdFFA361397367C39Dc32) | engine | — |
+| LeverageRfqEngine | [`0x8263a07504d93cB95e0a74f3627bb15faaf140e2`](https://etherscan.io/address/0x8263a07504d93cB95e0a74f3627bb15faaf140e2) | engine | — |
+| MetaActions | [`0x3633eb60d08756674472e2d34d6ffb5f4c1c29f2`](https://etherscan.io/address/0x3633eb60d08756674472e2d34d6ffb5f4c1c29f2) | engine + meta-module | — |
+| MetaSessionActions | [`0x4f83ac5c8a79986d0916a8849730d9cef63a3497`](https://etherscan.io/address/0x4f83ac5c8a79986d0916a8849730d9cef63a3497) | engine + meta-module | — |
+| RelayerAuth | [`0x823a97a2c32985e0f5457fc8103F36698D1F53F4`](https://etherscan.io/address/0x823a97a2c32985e0f5457fc8103F36698D1F53F4) | session layer | — |
+| SessionManager | [`0xF9f3ddF2E96Cabef94e2634c326DC6dde99360f8`](https://etherscan.io/address/0xF9f3ddF2E96Cabef94e2634c326DC6dde99360f8) | session layer | — |
+| CircuitBreaker | [`0x9676E697399581AB288844cDE5F73d0887eC18e0`](https://etherscan.io/address/0x9676E697399581AB288844cDE5F73d0887eC18e0) | outflow limiter | — |
+| Stable IRM | [`0x3253739A68640E308c8209384bb44E4ADA38710d`](https://etherscan.io/address/0x3253739A68640E308c8209384bb44E4ADA38710d) | `pure` rate model | — |
+| Major IRM | [`0x07eC8583B1bC7D97646409a2b51DdBed6725D12F`](https://etherscan.io/address/0x07eC8583B1bC7D97646409a2b51DdBed6725D12F) | `pure` rate model | — |
+| LongTail IRM | [`0x09cd852f47aCa224eE6B4AccC29BD2694F29Ef69`](https://etherscan.io/address/0x09cd852f47aCa224eE6B4AccC29BD2694F29Ef69) | `pure` rate model | — |
+
+### ftUSD Contracts (summary — see the dedicated report)
+
+ftUSD is an accepted collateral and borrowable asset here, and the contract that holds its backing is this market's largest single supplier. Full enumeration, mint authority, and the staking product are covered in **[Flying Tulip — ftUSD & Staked ftUSD](./flying-tulip-ftusd.md)**.
+
+| Contract | Address | Relevance to FT Lend |
+|---|---|---|
+| ftUSD | [`0xF7D85EC4E7710f71992752eac2111312e73E9C9C`](https://etherscan.io/address/0xF7D85EC4E7710f71992752eac2111312e73E9C9C) | Collateral + borrowable asset, 11.4% of TVL |
+| **Delta-Neutral strategy** | [`0xe0E445967256EE60111e243e0F0F94DD1D351A59`](https://etherscan.io/address/0xe0E445967256EE60111e243e0F0F94DD1D351A59) | **Largest supplier in this market — 35.1% of TVL.** Holds ftUSD's backing |
+| MintAndRedeem | [`0xAa48EcBC843cF7E9A29155D112b8Cb27902bD23C`](https://etherscan.io/address/0xAa48EcBC843cF7E9A29155D112b8Cb27902bD23C) | Source of the ftUSD price used for liquidations here |
+| FT token | [`0x5DD1A7A369e8273371d2DBf9d83356057088082c`](https://etherscan.io/address/0x5DD1A7A369e8273371d2DBf9d83356057088082c) | Reward token paid to suppliers; enabled but unpriced asset |
+
+### Governance & Multisig
+
+| Contract | Address | Threshold | Notes |
+|---|---|---|---|
+| **Admin Safe** | [`0x1118e1c057211306a40A4d7006C040dbfE1370Cb`](https://etherscan.io/address/0x1118e1c057211306a40A4d7006C040dbfE1370Cb) | **3 of 5** | Gnosis Safe v1.3.0. Root of all authority. No timelock |
+| Guardian Safe | [`0x22246a9183cE2CE6e2c2a9973F94aEA91435017C`](https://etherscan.io/address/0x22246a9183cE2CE6e2c2a9973F94aEA91435017C) | 3 of 4 | Strict **subset** of admin signers |
+| WBTC strategy-manager Safe | [`0x5557729b169082f07d3131D560E2f2cb5e6c48f6`](https://etherscan.io/address/0x5557729b169082f07d3131D560E2f2cb5e6c48f6) | 3 of 5 | **Identical five signers** to the admin Safe |
+| YieldClaimer | [`0x88432bB6EA62e774cB6d87995CC5277568d01397`](https://etherscan.io/address/0x88432bB6EA62e774cB6d87995CC5277568d01397) | contract | Holds wrapper `execute()` arbitrary-call |
+| Treasury | [`0x9B2F12De620d4E2993068e5cab6D6c7451f6cDe5`](https://etherscan.io/address/0x9B2F12De620d4E2993068e5cab6D6c7451f6cDe5) | UUPS proxy | `setStrategyDelay`; impl [`0xf32adbe8…7d21`](https://etherscan.io/address/0xf32adbe84a4560084516f807b73d7cd7f0677d21) |
+| Fee collector / epoch settler | [`0x5cd6Abe67f8af1C0c699dF36d90a6469Eaf1958a`](https://etherscan.io/address/0x5cd6Abe67f8af1C0c699dF36d90a6469Eaf1958a) | UUPS proxy | impl [`0x63176fda…beb5`](https://etherscan.io/address/0x63176fdaee7af7fd60acd896e3b6ce894901beb5) |
+
+**Admin Safe signers** (undisclosed in docs, presumed team EOAs): [`0xB7B54333…08bc8`](https://etherscan.io/address/0xB7B543337539219A5a1326aCB71dBa8Bba408bc8), [`0x3c427497…1B4E`](https://etherscan.io/address/0x3c42749709BF354B3aE0Db29Fd2dd88089b21B4E), [`0xf9E5aF16…9a10`](https://etherscan.io/address/0xf9E5aF16243041cE3141284D225CAfC0fC749a10), [`0x09E2B492…7881`](https://etherscan.io/address/0x09E2B49280f1879172b2C3345d08896921707881), [`0xD0CA8838…6f5A`](https://etherscan.io/address/0xD0CA88388d1732594D611535314e9B6745396f5A). The Guardian Safe holds the same set minus [`0xf9E5aF16…9a10`](https://etherscan.io/address/0xf9E5aF16243041cE3141284D225CAfC0fC749a10).
+
+### FT Lend Yield Wrappers & Strategies
+
+| Asset | Wrapper | Strategy | Venue | `strategyManager` |
+|---|---|---|---|---|
+| USDC | [`0xD2e4A5ac4B4Da102317cF7C9A1289aDF082639E2`](https://etherscan.io/address/0xD2e4A5ac4B4Da102317cF7C9A1289aDF082639E2) | [`0xfBE0736e…b0e5`](https://etherscan.io/address/0xfBE0736eBF5668A604D73BA93a5DdBEe9c10b0e5) | Spark | Admin Safe |
+| USDT | [`0x28b0905d83BCe5FFA6c54651F25858828A38123B`](https://etherscan.io/address/0x28b0905d83BCe5FFA6c54651F25858828A38123B) | [`0x852dc763…6a42`](https://etherscan.io/address/0x852dc7638aD159Ec12526d7E47f53f1307756a42) | Spark | Admin Safe |
+| WETH | [`0x460494aF61BcB92B59797B4e09C26A5ADecb2da2`](https://etherscan.io/address/0x460494aF61BcB92B59797B4e09C26A5ADecb2da2) | [`0x4df6f4f8…F2a7`](https://etherscan.io/address/0x4df6f4f8CDA409550A5d8A89aD66DE355CF7F2a7) | Spark | Admin Safe |
+| WBTC | [`0x1A5730c71576D77048E9FdC79DD40e4B1E8Fe042`](https://etherscan.io/address/0x1A5730c71576D77048E9FdC79DD40e4B1E8Fe042) | [`0x06980dC5…3B92`](https://etherscan.io/address/0x06980dC564e85c1eef0b2F85c803f08A30113B92) | Aave | **`0x5557…48f6` Safe** |
+| wstETH | [`0x01980BD1B58313bD3767f6adc75Af8b6464f3db7`](https://etherscan.io/address/0x01980BD1B58313bD3767f6adc75Af8b6464f3db7) | none | — | Admin Safe |
+| ftUSD | [`0xc67D966f761e8cf13Faa0a1E774425290c8453d9`](https://etherscan.io/address/0xc67D966f761e8cf13Faa0a1E774425290c8453d9) | none | idle | Admin Safe |
+| FT | [`0x7127BB9d9ad0f47B8dA9087e634D67F3946F840E`](https://etherscan.io/address/0x7127BB9d9ad0f47B8dA9087e634D67F3946F840E) | none | reward pool | Admin Safe |
+
+All seven wrappers share the implementation [`0xfaed20b307a6789481ee383adc10b9b0090b1157`](https://etherscan.io/address/0xfaed20b307a6789481ee383adc10b9b0090b1157) (`ftYieldWrapper`).
+
+### Oracle Stack
+
+| Asset | Router feed | Type | Underlying | Owner | Staleness | Deviation |
+|---|---|---|---|---|---|---|
+| USDC | [`0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6`](https://etherscan.io/address/0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6) | Chainlink `EACAggregatorProxy` | USDC/USD | Chainlink | 88,200s | 25 bps |
+| USDT | [`0x3E7d1eAB13ad0104d2750B8863b489D65364e32D`](https://etherscan.io/address/0x3E7d1eAB13ad0104d2750B8863b489D65364e32D) | Chainlink `EACAggregatorProxy` | USDT/USD | Chainlink | 88,200s | 25 bps |
+| WETH | [`0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419`](https://etherscan.io/address/0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419) | Chainlink `EACAggregatorProxy` | ETH/USD | Chainlink | 5,400s | 50 bps |
+| WBTC | [`0x183dB475d8184aA7a018ed2164e11A887afBDA55`](https://etherscan.io/address/0x183dB475d8184aA7a018ed2164e11A887afBDA55) | `ChainlinkLatestAnswerProxy` | CL [BTC/USD](https://etherscan.io/address/0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c) + Aave [`CLSynchronicityPriceAdapterPegToBase`](https://etherscan.io/address/0xDaa4B74C6bAc4e25188e64ebc68DB5050b690cAc) | **Admin Safe** | 88,200s | 50 bps |
+| wstETH | [`0x000bb128a8aBCFa05B871C97CC9C5f88e7Dcf35a`](https://etherscan.io/address/0x000bb128a8aBCFa05B871C97CC9C5f88e7Dcf35a) | `ChainlinkLatestAnswerProxy` | CL [ETH/USD](https://etherscan.io/address/0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419) + Aave [`WstETHPriceCapAdapter`](https://etherscan.io/address/0xe1D97bF61901B075E9626c8A2340a7De385861Ef) | **Admin Safe** | 5,400s | 50 bps |
+| ftUSD | [`0xA69f7a38B6c91a4bc2477f097DC8a1F16DAADFf8`](https://etherscan.io/address/0xA69f7a38B6c91a4bc2477f097DC8a1F16DAADFf8) | `FtUsdMintRedeemOracleProxy` | CL USDC/USD × `MintAndRedeem` redeem factors — **f(USDC price, mint history); does not read ftUSD collateral** | **Admin Safe** | 86,400s | **0 bps** |
+| FT | — | **no feed configured** | `priceUSD(FT)` reverts | — | — | — |
+
+On the three protocol-owned wrappers, `baseFeed` and `adapter` are **`immutable`** — the owner can `setPaused`, `setAnswerBounds` and `setMaxStaleness`, but **cannot repoint the feed**. The arbitrary-price path is at the router, not here (see [Provability](#provability)).
+
+### Can Holders Lose Money?
+
+Enumerated loss paths for a Yearn deposit into FT Lend, ordered by how directly they reach supplied principal:
+
+| # | Path | Mechanism | Gating | Severity |
+|---|---|---|---|---|
+| 1 | **Admin upgrades `PositionsManager`** | `PMWrapper.upgradePM` replaces the engine with arbitrary code that can transfer any balance | 3/5 Safe, **no timelock** | Total loss |
+| 2 | **Admin rewrites the oracle price** | `OracleRouterChainlink.setLastGoodPrice(asset, price)` writes an arbitrary price, making solvent positions liquidatable or insolvent ones invisible | 3/5 Safe | Total loss |
+| 3 | **Admin redirects lender capital** | `wrapper.setStrategy` + `confirmStrategy` with `strategyDelayConfig = 0` moves deployed funds to an arbitrary strategy in one block | 3/5 Safe (WBTC: `0x5557…48f6` Safe) | Total loss |
+| 4 | **`YieldClaimer` arbitrary call** | `wrapper.execute(strategy, to, value, data)` forwards an arbitrary call through the strategy contract | YieldClaimer contract | Total loss |
+| 5 | **Unbacked ftUSD mint** | Safe registers a new ftUSD Core module (or replaces `minter()`) and issues ftUSD with no collateral; ftUSD is collateral in FT Lend | 3/5 Safe | Severe — dilutes ftUSD collateral |
+| 6 | **ftUSD blacklist / balance wipe** | `blacklist` + `wipeBlacklistedAddress` freezes and burns a holder's ftUSD, including a Yearn position | 3/5 Safe | Severe |
+| 7 | **Bad debt from a failed liquidation** | The novel time-sliced/RFQ liquidation path fails to clear a position; the insolvency exception in `liquidateFlash` explicitly permits seizing all collateral and leaving debt. No backstop; reserves are negligible | permissionless caller via `RfqEngine` | Partial, socialized |
+| 8 | **Reflexive ftUSD impairment** | ftUSD's backing *is* a supply position in FT Lend; a loss here impairs ftUSD, which is 11.8% of the market's collateral and is priced by a feed blind to that backing | structural | Partial |
+| 9 | **Spark or Aave exit shortfall** | Wrappers hold **zero idle buffer** (`deployed() == capital()`); a freeze or cash shortfall at either *otherwise low-risk* venue blocks or impairs exits | external (concentrated exposure) | Partial to total per-asset |
+| 10 | **Withdrawal pause / breaker** | `setWithdrawPaused`, `CircuitBreaker`, or flipping `marginRestrictWithdrawToSettlement` / `marginWithdrawRequiresNoDebt` to `true` traps funds | 3/5 Safe / guardian | Temporary lockup |
+| 11 | **Chainlink feed failure** | Single feed per asset; a stale or wrong price mis-liquidates. Adapters are immutable but the owner can `setPaused` the wrapper, denying pricing | external / 3/5 Safe | Partial |
+
+Paths 1–6 require trusting a single 3-of-5 multisig with no delay. Paths 7–11 are structural or external. **There is no insurance fund and no SEAL Safe Harbor enrolment behind any of them; a live Sherlock bug bounty provides a public disclosure and reward channel.**
+
+## Audits and Due Diligence Disclosures
+
+The team provides gated portal access to the in-scope FT Lend / ftDNMM contracts and ftUSD have been audited multiple times by reputable firms, and keeps the reports and finding-level detail private.
+
+An investor-relations portal does host a structured **Audits** registry — its front-end code contains a component that renders an "Audits" heading over a list, with per-row states for entries that have **no attached report file**. The portal is behind a **unique-access-code wall**: every page renders only "Enter Your Unique Code Below" and fetches no audit data until authenticated. No firm name, date, scope, or finding count could be verified for this assessment.
+
+| Item | Status |
+|---|---|
+| Public bug bounty | **LIVE** — [Sherlock Flying Tulip Bug Bounty #248](https://audits.sherlock.xyz/bug-bounties/248?tab=scope), max reward 1,000,000 USDC; **scope is ftPUT + FT OFT**, not FT Lend / ftUSD (see below) |
+| SEAL Safe Harbor enrolment | **Not enrolled** (absent from the `security-alliance/safe-harbor` registry) |
+| Contract source verification on Etherscan | **PASS** — all 20 contracts checked are verified (see Appendix B) |
+
+- The docs' [Risks page](https://docs.flyingtulip.com/risks/) states a policy of "external audits before enabling capital-bearing features" and lists "Transparency. Publish parameters, addresses, **audit reports**, and incident post-mortems" as a security principle. The audit reports are not public.
+- Only two reviews are publicly confirmable, and **neither covers the assessed contracts**: the token-sale `Escrow` (PeckShield #2025-170, Oct 2025; Cantina Managed, Oct 2025) and the separate **ftPUT** product ([Sherlock contest #1223](https://audits.sherlock.xyz/contests/1223), Jan 2026).
+- **Accepted risks** from the Sherlock ftPUT contest README — relevant because the same team and patterns build Lend: "protocol-level loss handling and backstops are out-of-scope," "malicious strategy manager cannot be removed," "caps updates can be front-run," and a circuit-breaker that does not cover all flows. Each of these is observable in the deployed Lend contracts (see [Centralization](#centralization--control-risks)).
+
+**Contract complexity is high:** a novel dynamic-LTV money market with snapshot LTVs, an RFQ/relayer/session layer, flash-liquidations, epoch settlement, cross-product shared collateral, and a stablecoin whose backing is actively managed by a strategy contract. Complexity of this order is precisely where public, finding-level audit disclosure matters most.
+
+### Bug Bounty
+
+**LIVE.** [Sherlock's Flying Tulip Bug Bounty #248](https://audits.sherlock.xyz/bug-bounties/248?tab=scope) has been live since June 18, 2026 and advertises a maximum reward of **1,000,000 USDC**. The [Scope](https://audits.sherlock.xyz/bug-bounties/248?tab=scope) tab is public: in-scope source is `flyingtulipdotcom/ftPUT` (`PutManager`, `pFT`, `ftYieldWrapper`, `CircuitBreaker`, Aave strategy, oracle/ACL) plus listed onchain deployments of that product and the FT OFT token — the same product family as [Sherlock contest #1223](https://audits.sherlock.xyz/contests/1223).
+
+**Against this report's contracts:** none of `PositionsManager`, `ConfigRegistry`, the RFQ engines, the IRMs, or the ftUSD mint/redeem/staking stack appear in that scope. Two addresses that *are* listed also appear here, but only as shared infrastructure / reward token — not as coverage of the assessed lending path:
+
+| Address | Role in this report | In bounty scope? |
+|---|---|---|
+| [`0x88432bB6…1397`](https://etherscan.io/address/0x88432bB6EA62e774cB6d87995CC5277568d01397) | `YieldClaimer` (wrapper `execute`) | **Yes** |
+| [`0x5DD1A7A3…082c`](https://etherscan.io/address/0x5DD1A7A369e8273371d2DBf9d83356057088082c) | FT token (supplier emissions) | **Yes** (FT OFT) |
+
+So the bounty is a real disclosure channel for adjacent Flying Tulip code, but it does **not** establish bounty coverage for supplying or borrowing in FT Lend.
+
+> **Scoring note.** This does **not** trigger the "No audit" critical gate — a real audit registry demonstrably exists, so asserting "no audit" would be false. Audits can be access with team permission.
+
+## Historical Track Record
+
+- **Production history.** TGE / mainnet ~**Feb 23, 2026**; ftUSD [deployed Feb 21, 2026](https://etherscan.io/tx/0x52e7d46b7e166b8e30c5d38a09d93c44537bcb77b439e5b125d8b51d5670ea21). The assessed lending engine is newer: `ConfigRegistry` and `PositionsManager` were [deployed April 27, 2026](https://etherscan.io/tx/0x8838947473f9a3b6ba3f46bd89ecd5b28d7bd470e8c0b969cb38ceb5c4ebcdef) (block `24974967`) and the **first `Deposit` event is April 29, 2026** (block [`24986969`](https://etherscan.io/block/24986969)). Protocol ~5.4 months old; **FT Lend in its current deployment ~3.2 months.**
+- **TVL (DeFiLlama, whole protocol):** **~$12.56M** on August 3, 2026 — Ethereum $12.14M, Sonic $0.42M ([API](https://api.llama.fi/protocol/flying-tulip)). Peak **~$12.58M on July 31, 2026**; tracked since ~May 12, 2026 (85 data points). The marketed "$126M+ TVL" figure is **raise capital parked in Aave**, not protocol usage.
+- **FT Lend onchain TVL:** **$12.48M supplied / $0.97M borrowed** (6.43% utilization) — reconciles with DeFiLlama's $12.14M Ethereum figure.
+- **Genuine third-party TVL is $8.11M, not $12.48M.** $4.38M (35.1%) is the protocol's own ftUSD backing collateral supplied back into the market by its own strategy contract.
+- **Incidents / exploits / depegs:** **NONE FOUND** for Flying Tulip itself through August 2026. (An April 23, 2026 news item concerns Flying Tulip *adding* a withdrawal circuit breaker after *other* protocols' April exploits — preventive, not a breach.)
+- **ftUSD:** supply 4,142,539; oracle price ~$0.9988; `maxSupply` cap 100M (raised from 5M); thinly traded.
+
+### TVL history
+
+DeFiLlama daily series (protocol-wide, [API](https://api.llama.fi/protocol/flying-tulip)); tracking began ~May 12, 2026:
+
+| Month | Open | Close | Low | High |
+|---|---:|---:|---:|---:|
+| May 2026 | $2.93M | $5.05M | $2.93M | $5.05M |
+| June 2026 | $5.75M | $8.97M | $4.56M | $8.97M |
+| July 2026 | $8.92M | $12.58M | $8.92M | $12.58M |
+| August 2026 (MTD) | $12.41M | $12.63M | $12.41M | $12.63M |
+
+Growth has been monotonic apart from one drawdown: **−20.7% from the running peak on June 6, 2026**. That is the only stress episode in the series and it was a growth-phase dip, not a redemption event. Chain split at the latest point: **Ethereum $12.20M (96.6%), Sonic $0.42M (3.4%)**, borrowed $1.11M protocol-wide. Sonic is immaterial and out of scope for this report.
+
+Two caveats on reading this series: (1) it starts only ~2 weeks after FT Lend opened, so there is no pre-launch baseline; (2) ~35.1% of the Ethereum figure is the protocol's own recycled ftUSD collateral — the Delta-Neutral strategy deposits ftUSD's USDC/USDT backing into this same market — so the growth curve overstates third-party adoption. See [Reflexive supply](#reflexive-supply-ftusd-backing-lent-into-ft-lend).
+
+### FT Lend market state — onchain, block `25697429` (August 6, 2026)
+
+| Asset | IRM | Maint. margin | Borrowable | Collateral | Supplied | Borrowed | Util | Supply cap | Cap used |
+|-------|-----|:---:|:---:|:---:|---|---|:---:|---|:---:|
+| [USDC](https://etherscan.io/address/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48) | Stable | 1.50% | ✓ | ✓ | 3,175,623 ($3.17M) | 241,018 | 7.6% | 10M | 32% |
+| [USDT](https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7) | Stable | 1.50% | ✓ | ✓ | 1,429,877 ($1.43M) | 223,541 | 15.6% | 10M | 14% |
+| [WETH](https://etherscan.io/address/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2) | Major | 19.0% | ✓ | ✓ | 736.92 ($1.41M) | **95.35** | **12.9%** | 1,000 | 74% |
+| [WBTC](https://etherscan.io/address/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599) | Major | 22.0% | ✓ | ✓ | 75.18 ($4.86M) | 0 | 0% | 100 | 75% |
+| [wstETH](https://etherscan.io/address/0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0) | Major | 21.0% | — | ✓ | **76.54** ($0.18M) | 0 | — | 300 | 26% |
+| [ftUSD](https://etherscan.io/address/0xF7D85EC4E7710f71992752eac2111312e73E9C9C) | Stable | 1.50% | ✓ | ✓ | 1,428,403 ($1.43M) | 322,186 | 22.6% | **1.5M** | **95%** |
+| [FT](https://etherscan.io/address/0x5DD1A7A369e8273371d2DBf9d83356057088082c) | LongTail | 0% | — | — | 763.25 (unpriced) | — | — | 0 | — |
+| **Total** | | | | | **$12.48M** | **$0.97M** | **7.8%** | | |
+
+Prices at block `25697429`: USDC $0.9998, USDT $0.9991, WETH $1,911.99, WBTC $64,680.05, wstETH $2,372.33, ftUSD $0.9988. FT has **no configured price feed** — `priceUSD(FT)` reverts.
+
+**The market changed materially between August 3 and August 6.** wstETH went from 0 supplied to 76.54, and WETH borrows from 0.35 to 95.35 — both driven by the Delta-Neutral strategy activating its hedge leg (see below). WETH utilization went from 0.05% to 12.9% in three days. A market that moves this fast on one actor's decision warrants a shorter reassessment interval than its size alone would suggest.
+
+**Cap headroom is a live constraint.** ftUSD is at **95% of its 1.5M supply cap**; WBTC and WETH at ~75%. Caps are raised by the admin Safe in one transaction via `PMWrapper.setCaps` with no delay.
+
+### Interest rate models
+
+`borrowAPR(asset, utilizationWad)` sampled directly on each IRM contract (all `pure`, so the curves are fixed until the `ConfigRegistry` points an asset at a different IRM):
+
+| Utilization | Stable IRM | Major IRM | LongTail IRM |
+|---:|---:|---:|---:|
+| 0% | 1.50% | 1.00% | 6.00% |
+| 25% | 4.44% | 2.92% | 13.69% |
+| 50% | 7.38% | 4.85% | 21.38% |
+| 75% | 10.32% | 6.77% | 68.86% |
+| 80% | 10.91% | 12.45% | 90.29% |
+| 90% | 38.17% | 39.73% | 133.14% |
+| 100% | 91.50% | 67.00% | 176.00% |
+
+Kinks sit at ~80% for Stable and Major and ~50–75% for LongTail. The curves are conventional and adequately steep above the kink to defend exit liquidity. At today's 6.4% utilization, suppliers earn near the base rate, so most of the realised supply yield comes from the Spark/Aave strategies rather than from borrowers.
+
+## Funds Management
+
+### How supplying works
+
+A lender calls `deposit(asset, amount)` on the `PositionsManager`. Un-borrowed liquidity is held by the asset's `ftYieldWrapper`; where a strategy is configured the wrapper deploys it. Borrower interest and strategy yield accrue through the supply index. Withdrawals (`withdraw`) pull from currently available wrapper liquidity.
+
+| Asset | FT Lend yield wrapper | Strategy | Venue |
+|---|---|---|---|
+| USDC | [`0xD2e4A5ac…39E2`](https://etherscan.io/address/0xD2e4A5ac4B4Da102317cF7C9A1289aDF082639E2) | [`0xfBE0736e…b0e5`](https://etherscan.io/address/0xfBE0736eBF5668A604D73BA93a5DdBEe9c10b0e5) `SparkSavingsStrategy` | Spark |
+| USDT | [`0x28b0905d…123B`](https://etherscan.io/address/0x28b0905d83BCe5FFA6c54651F25858828A38123B) | [`0x852dc763…6a42`](https://etherscan.io/address/0x852dc7638aD159Ec12526d7E47f53f1307756a42) `SparkSavingsStrategy` | Spark |
+| WETH | [`0x460494aF…2da2`](https://etherscan.io/address/0x460494aF61BcB92B59797B4e09C26A5ADecb2da2) | [`0x4df6f4f8…F2a7`](https://etherscan.io/address/0x4df6f4f8CDA409550A5d8A89aD66DE355CF7F2a7) `SparkSavingsStrategy` | Spark |
+| WBTC | [`0x1A5730c7…E042`](https://etherscan.io/address/0x1A5730c71576D77048E9FdC79DD40e4B1E8Fe042) | [`0x06980dC5…3B92`](https://etherscan.io/address/0x06980dC564e85c1eef0b2F85c803f08A30113B92) `AaveStrategy` | Aave |
+| wstETH | [`0x01980BD1…3db7`](https://etherscan.io/address/0x01980BD1B58313bD3767f6adc75Af8b6464f3db7) | none | — |
+| ftUSD | [`0xc67D966f…53d9`](https://etherscan.io/address/0xc67D966f761e8cf13Faa0a1E774425290c8453d9) | none | held idle in wrapper |
+| FT | [`0x7127BB9d…840E`](https://etherscan.io/address/0x7127BB9d9ad0f47B8dA9087e634D67F3946F840E) | none | circuit breaker unset (`address(0)`) |
+
+**There is no idle buffer.** On all four wrappers with a strategy, `deployed()` equals `capital()` to the wei — 2,902,577.215876 USDC, 1,180,959.539429 of 1,180,959.539430 USDT, 736.579217 WETH and 7,518,219,204 WBTC units are inside Spark/Aave, not in the wrapper. **Every lender withdrawal is a Spark or Aave withdrawal in the same transaction** and inherits that venue's liquidity and pause state. Only the ftUSD wrapper (1,109,633 ftUSD, no strategy) holds its balance locally.
+
+### Fees, reserves and revenue
+
+| Flow | Parameter | Value | Set by |
+|---|---|---|---|
+| Lending protocol reserves | `astate.reserves` | 7.72 USDC · 13.16 USDT · 303.01 ftUSD · 0.0000257 WETH · **0 WBTC** | accrued from interest |
+| Reserve withdrawal | `PMWrapper.withdrawReserves` | unrestricted | Admin Safe |
+
+**Protocol reserves are negligible** — a few hundred dollars in total against a $12.48M book. There is no meaningful buffer between a bad-debt event and supplier principal; bad debt is socialized to suppliers of the affected asset. ftUSD mint/redeem fees are covered in the ftUSD report.
+
+### Supplier rewards are discretionary FT emissions
+
+`settleEpoch(asset, interest)` on the `PositionsManager` is **`onlyAdmin`**. The admin transfers **FT tokens** into the contract, which are deposited to the FT wrapper and distributed to that asset's suppliers pro-rata by supply-time (`totalSuppliedTime`), with the epoch rate recorded as `rateRay`. This is a material and undocumented component of advertised supply yield, and it is entirely discretionary — no rule obliges the admin to fund an epoch, and no schedule is published.
+
+Settlement history by asset (latest settled epoch, read from `astate` and `epochs`):
+
+| Asset | Epochs settled | Last settlement | FT emissions received |
+|---|---:|---|---|
+| USDC | **126** | Aug 2, 2026 | yes, ongoing |
+| USDT | **120** | Aug 2, 2026 | yes, ongoing |
+| WETH | **28** | Aug 1, 2026 | yes, ongoing |
+| WBTC | **0** | never (epoch `t_end` still the Apr 27 deploy timestamp) | **none** |
+| ftUSD | **0** | never | **none** |
+| wstETH | 0 | never (no supply) | none |
+
+**WBTC and ftUSD suppliers have never received a single FT emission** — that is 39.5% and 11.4% of TVL respectively earning only base interest, while USDC/USDT/WETH suppliers receive FT on top. Total emitted to date is the FT wrapper's balance: **43,792.78 FT** (~$4,353 at $0.0994). Any yield figure quoted for this market must be checked against which asset it applies to, and treated as revocable.
+
+### Liquidation mechanics
+
+`liquidateFlash(user, seizeTo, seizeAssets, seizeAmounts, repayAssets, repayAmounts, callbackData)` is callable **only by a registered liquidation module** — currently `RfqEngine` [`0xEB00B335…Dc32`](https://etherscan.io/address/0xEB00B335Ca52216Fb60fdFFA361397367C39Dc32) alone. The flow is:
+
+1. **Pre-check** — `hfPre < marginHfTargetBps` (1.25), else revert.
+2. **Seize** — collateral is withdrawn from the user's `avail` balance to `seizeTo`, an address the module chooses, in module-specified amounts.
+3. **Callback** — `onLiquidationFlash` lets the module trade the seized collateral and source repayment. The RFQ caller chooses the debt and collateral bundles; the engine's repayment cap permits partial fills sized around restoring the HF corridor, which is what "time-sliced / RFQ-routed" means here. Each fill is atomic — there is no onchain timer or automatic sequence of slices.
+4. **Repay** — the engine's funds are pulled and booked against the user's debt, capped at its balance and allowance.
+5. **Post-check** — `hfPost >= marginHfTargetBps`, **with an insolvency exception**: if `equityUSDPre == 0` *and* all seizable collateral is exhausted (`collUSDWadPost == 0`), the check is skipped so bad debt can be cleaned up rather than blocked.
+
+**The liquidator proposes the price, but cannot set an arbitrary penalty.** Live at block `25776852`, `RfqEngine.liqBonusBps()` is 750 (7.5%), so oracle-valued collateral seized cannot exceed `actual debt repaid × 1.075`. The protocol receives 10% of the realized bonus (`protocolLiqSplitBps` = 1000): at the maximum, repaying $100 can seize $107.50, of which $0.75 goes to the protocol and $106.75 to the filler. This uses FT Lend's oracle values, not the collateral's realized DEX sale price.
+
+| Proposed RFQ fill | Result | Why |
+|---|---|---|
+| Repay $100; seize $107.50 | Maximum permitted ordinary fill, subject to HF and dust checks | Exactly the 7.5% oracle-value cap |
+| Repay $100; seize $110 | Reverts | Seized value exceeds `repay × 1.075` |
+| Repay $50; seize $53.75 in an ordinary partial liquidation | Reverts | Fairness cap passes, but collateral-seizing partial fills have a $100 minimum repayment |
+| Repay $50; seize nothing | Not blocked by the $100 floor; normal HF checks still apply | Pure repayment is exempt; the payer receives no collateral |
+| Repay $50; seize at most $53.75 and close all debt | Permitted by the minimum-size rule | Full debt closure is exempt, but the 7.5% fairness cap still applies |
+| Repay $50; seize at most $53.75 and exhaust an already-insolvent account's collateral | Permitted by the minimum-size rule | Terminal insolvency is exempt from the minimum and normal post-HF/dust checks, but not the fairness cap |
+
+**Terminal bad debt is narrowly identified, not declared by the liquidator.** The engine computes `terminalBadDebt = (equityUSDPre == 0 && collUSDWadPost == 0)`: the account must already have zero economic equity before the fill, and the fill must leave no oracle-valued collateral. The seize-fairness cap is checked before this exception, so even a terminal fill cannot take more than repayment plus the 7.5% bonus. Any debt left after the last collateral is removed is unsecured; it can still be repaid at any size through a pure-repayment RFQ or `repayFor`, but there is no collateral incentive or funded backstop to make a third party do so.
+
+Three structural observations:
+
+- **Not keeper-protected — module-gated and mostly permissionless.** `PositionsManager.liquidateFlash` is callable only by the registered module (`RfqEngine`), but `RfqEngine.rfqFill` / `rfqFillFlash` themselves have **no general liquidator whitelist**. Anyone can liquidate a normal underwater account. The only exception is `privilegedAccounts`: those may be liquidated only by `permissionedLiquidators`. Today the sole privileged account is the ftUSD strategy [`0xe0E445…1A59`](https://etherscan.io/address/0xe0E445967256EE60111e243e0F0F94DD1D351A59), and **zero** permissioned liquidators are set — so that account is currently unliquidatable via this path. No `rfqFill*` / `liquidateFlash` execution has occurred yet.
+- **No liq bonus or close factor in `PositionsManager`.** Seize/repay sizing lives in `RfqEngine` (onchain module, not the core ledger). Core only requires HF ≥1.25 after — bounds under-liquidation, not how much collateral value the borrower loses per unit of debt repaid.
+- **The insolvency exception is an explicit bad-debt path.** It permits a position to end with all collateral seized and debt outstanding. The debt remains technically repayable, but without collateral there is no liquidator incentive or funded backstop; unless the borrower or protocol supplies the missing asset, the economic shortfall falls on suppliers against reserves of essentially zero.
+
+Because the liquidation module is swappable by the admin (`setLiquidationModule`), the economics of liquidation are a governance parameter, not a code invariant. To date the module has never been changed since deployment.
+
+### Reflexive supply: ftUSD backing lent into FT Lend
+
+The single largest supplier to FT Lend is not a third party. It is [`0xe0E44596…1A59`](https://etherscan.io/address/0xe0E445967256EE60111e243e0F0F94DD1D351A59), the `MultiCollateralDeltaNeutralStakingStrategy` that holds ftUSD's collateral, which deposits that collateral into this market (**35.1% of TVL** today):
+
+| Position | Amount | USD |
+|---|---|---|
+| USDC supplied | 2,780,139.26 | $2.78M |
+| USDT supplied | 1,417,609.56 | $1.42M |
+| wstETH supplied (collateral for its hedge) | 76.54 | $0.18M |
+| **Total** | | **$4.38M = 35.1% of TVL** |
+| WETH borrowed (hedge leg) | 95.01 | 99.6% of all WETH debt |
+
+**What a lender needs to take from this:**
+
+1. **Headline TVL overstates third-party capital.** Genuine third-party TVL is **$8.11M**, not $12.48M.
+2. **ftUSD and FT Lend cannot fail independently.** ftUSD's backing is a claim on this market; ftUSD is 11.4% of this market's collateral; and ftUSD's price feed is blind to that backing. A loss event propagates in a circle while the protocol feed does not register the backing impairment.
+3. **The largest supplier is also a leveraged borrower.** It is now 99.6% of all WETH debt, so its health factor is a solvency variable for this market — and it is operated by a key set that includes a plain EOA.
+4. **It can leave.** A 35.1% supplier unwinding would be the largest liquidity event this market has seen.
+
+Full derivation of the backing chain, the collateral reconciliation, the strategy's operator model, and the risks to ftUSD holders themselves are in **[Flying Tulip — ftUSD & Staked ftUSD](./flying-tulip-ftusd.md)**.
+
+### Accessibility
+
+| Action | Who | Atomic? | Fees | Limits |
+|---|---|---|---|---|
+| Supply to FT Lend | permissionless | yes, same tx | none | per-asset `supplyCap` |
+| Withdraw from FT Lend | permissionless | yes, if wrapper liquidity available | none | `withdrawPaused`, CircuitBreaker, available liquidity |
+| Borrow | permissionless, over-collateralized | yes | interest per IRM | `borrowCap`, `mmBps`, HF ≥ 1.25, $250 min equity |
+| Liquidate | **module-gated** (`RfqEngine.rfqFill`/`rfqFillFlash`); callers permissionless except for `privilegedAccounts` | yes | module-defined (`liqBonusBps` etc. on `RfqEngine`) | HF < 1.25 |
+
+There are **no withdrawal queues, cooldowns, or lockups** on the lending path in normal operation — a genuine strength, and a real difference from the staked-ftUSD product, which is rate-limited. All gating here is either liquidity-based or admin-flippable.
+
+### Token Mint Authority
+
+**Not applicable to the assessed position.** An FT Lend supply position is an internal balance on the `PositionsManager`, not a transferable or mintable token — there are no supply receipts and no mint authority to enumerate.
+
+The relevant mint authority is ftUSD's, because ftUSD is 11.4% of this market's collateral and an unbacked mint would dilute that collateral. In short: the 3/5 admin Safe is ftUSD `owner` + `masterMinter` and can register an arbitrary new mint module or replace the minter outright, issuing ftUSD with no backing. Full enumeration in **[Flying Tulip — ftUSD & Staked ftUSD](./flying-tulip-ftusd.md)**.
+
+**Softener, not a fix:** the FT Lend `CircuitBreaker` can **rate-limit post-mint outflows** (wrapper withdrawals, redemptions, unstaking), which can slow a dump / run cascade into this market after an unbacked mint. They do **not** prevent the mint, reverse dilution, or act as an independent check — the same admin Safe owns / can unset those breakers.
+
+### Collateralization
+
+- **Backing.** Borrowing is over-collateralized and enforced onchain via per-asset maintenance margins (`ConfigRegistry.assetCfg`) and account health (Hf - health factor): `marginHfSafeBps = 15000` (1.50), `marginHfTargetBps = 12500` (1.25), `marginMinEquityUSDWad = 250e18` ($250 minimum position equity).
+- **Collateral quality.** Blue-chip (WETH, WBTC, wstETH, USDC, USDT) plus ftUSD. The blue-chip leg is genuinely high quality; ftUSD (11.4% of TVL) carries the reflexivity above.
+- **Maintenance margins are thin on stables.** `mmBps = 150` implies a 1.5% maintenance floor — ~66× theoretical leverage before the dynamic-LTV haircut. The protocol states effective LTV is reduced from this floor by AMM depth and volatility and snapshotted at position open, but that reduction is computed off the Spot AMM/CLOB and is **not independently verifiable onchain**. The floor is what the contract enforces.
+- **Liquidations.** Onchain, module-gated through `RfqEngine` [`0xEB00B335…Dc32`](https://etherscan.io/address/0xEB00B335Ca52216Fb60fdFFA361397367C39Dc32) (`rfqFill` / `rfqFillFlash` → `liquidateFlash`; set at deployment, never changed). **Not keeper-whitelisted** — any address may call those entrypoints for normal accounts; only `privilegedAccounts` require `permissionedLiquidators`. Time-sliced / RFQ-routed by design, novel and untested at scale. Per the team's own accepted-risk list there is **no protocol-level loss backstop / insurance fund** for bad debt.
+- **Reserves are negligible.** `astate.reserves` across all assets: 7.72 USDC, 13.16 USDT, 0.0000257 WETH, 303.01 ftUSD, 0 WBTC. There is effectively no protocol-side buffer to absorb a shortfall.
+- **Curation.** The 3/5 Safe sets every risk parameter — which assets are enabled/collateral/borrowable, maintenance margins, supply/borrow caps, IRMs, and the oracle.
+
+### Provability
+
+- **Reserves are fully onchain and reconcile exactly.** Verified two independent ways at block `25675412`: (a) summing every supplier's `getBalance` across all assets reproduces each `astate.totalSupplied` and totals $12,127,035; (b) summing `debtShares` pro-rata reproduces `astate.borrows` and totals $780,125. The ftUSD backing chain reconciles to the wei (table above). This is a genuine strength — the accounting is honest and independently checkable.
+- **Oracle — better than "admin-controlled", worse than "canonical Chainlink".** Three of six feeds are canonical Chainlink `EACAggregatorProxy` contracts owned by Chainlink. Three are protocol-deployed wrappers owned by the admin Safe — but with **immutable** base feeds and adapters, so the owner cannot repoint them:
+
+| Asset | Router feed | Type | Wraps | Owner | Staleness | Dev. |
+|---|---|---|---|---|---|---|
+| USDC | [`0x8fFfFfd4…18f6`](https://etherscan.io/address/0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6) | Chainlink `EACAggregatorProxy` | USDC/USD | Chainlink | 88,200s | 25 bps |
+| USDT | [`0x3E7d1eAB…e32D`](https://etherscan.io/address/0x3E7d1eAB13ad0104d2750B8863b489D65364e32D) | Chainlink `EACAggregatorProxy` | USDT/USD | Chainlink | 88,200s | 25 bps |
+| WETH | [`0x5f4eC3Df…8419`](https://etherscan.io/address/0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419) | Chainlink `EACAggregatorProxy` | ETH/USD | Chainlink | 5,400s | 50 bps |
+| WBTC | [`0x183dB475…DA55`](https://etherscan.io/address/0x183dB475d8184aA7a018ed2164e11A887afBDA55) | `ChainlinkLatestAnswerProxy` | Chainlink BTC/USD + Aave [`CLSynchronicityPriceAdapterPegToBase`](https://etherscan.io/address/0xDaa4B74C6bAc4e25188e64ebc68DB5050b690cAc) | **3/5 Safe** | 88,200s | 50 bps |
+| wstETH | [`0x000bb128…f35a`](https://etherscan.io/address/0x000bb128a8aBCFa05B871C97CC9C5f88e7Dcf35a) | `ChainlinkLatestAnswerProxy` | Chainlink ETH/USD + Aave [`WstETHPriceCapAdapter`](https://etherscan.io/address/0xe1D97bF61901B075E9626c8A2340a7De385861Ef) | **3/5 Safe** | 5,400s | 50 bps |
+| ftUSD | [`0xA69f7a38…DFf8`](https://etherscan.io/address/0xA69f7a38B6c91a4bc2477f097DC8a1F16DAADFf8) | `FtUsdMintRedeemOracleProxy` | Chainlink USDC/USD × `MintAndRedeem` redeem factor | **3/5 Safe** | 86,400s | **0 bps** |
+
+  Using Aave's audited peg and cap adapters for WBTC and wstETH is a sound choice and better than a raw feed. The residual concerns are: the owner can `setPaused(true)` on any wrapper (a price-denial, not a price-forgery, path); ftUSD's price is **blind to its own backing** (the redeem factors are functions of the USDC price and cumulative mint history, not of the collateral) and carries a **0 bps deviation tolerance**; and WBTC's 88,200s (24.5h) staleness window is long for a 39.5%-of-TVL asset.
+- **The real override is at the router.** `OracleRouterChainlink` [`0xe4372dB4…674A`](https://etherscan.io/address/0xe4372dB43D2814750a19b93950157AD81D93674A) exposes `setLastGoodPrice(asset, price)` to its owner — the 3/5 Safe — which writes an **arbitrary price directly**, bypassing every adapter safeguard above. `setPriceFeed`, `setStaleFallback`, `setPriceDeviation` and `setOwner` are likewise owner-only; `disablePrice` is guardian-only. Immutable adapters do not constrain this path.
+- **Source availability.** All 20 assessed contracts are source-verified on Etherscan (Appendix B). **No public GitHub repo** for the lending or ftUSD code, and no public audit reports, so review is limited to reading verified bytecode.
+
+## Liquidity Risk
+
+Lender-exit frame: a supplier leaves via `withdraw` against available (un-borrowed) wrapper liquidity. Secondary-market depth for ftUSD is noted below only as context for the ftUSD collateral/supply leg — it does not exit a USDC/WETH/WBTC lending position.
+
+- **Exit mechanism.** Suppliers withdraw against available wrapper liquidity: 2.903M USDC of 3.140M supplied (7.6% utilized), 1.181M USDT of 1.404M (15.9%), 736.58 of 736.92 WETH (0.05%), all 75.18 WBTC (0%), 1.110M of 1.428M ftUSD (22.3%). Exit is instant today; borrowed funds are unavailable until repaid or liquidated. **Utilization is the primary liquidity constraint.**
+- **Depth of the market.** Thin absolutely: largest pool is WBTC at $4.79M, then USDC at $3.14M. Supply receipts are internal balances (normal for lending); no transferable receipt to sell.
+- **Concentration is the dominant liquidity risk.** Only **25 addresses** hold the entire $12.13M. Excluding the protocol's own Delta-Neutral strategy, **three genuinely third-party addresses hold 96.1% of the $8.11M third-party TVL**:
+
+| Supplier | Type | USD | % of total TVL | % of third-party TVL | Holdings |
+|---|---|---:|---:|---:|---|
+| [`0xef6953…ae0d`](https://etherscan.io/address/0xef6953954e9c753da43da41136d41a754cd5ae0d) | EOA | $4.62M | 38.1% | **58.1%** | 72.18 WBTC + 21.9K USDC |
+| [`0xe0E445…1A59`](https://etherscan.io/address/0xe0E445967256EE60111e243e0F0F94DD1D351A59) | **protocol strategy** | $4.38M | 35.1% | — | 2.78M USDC + 1.42M USDT + 76.5 wstETH |
+| [`0x666130…701c`](https://etherscan.io/address/0x66613091b75e54954f77746e160c98391f99701c) | Safe | $1.87M | 15.4% | 23.5% | 1.43M ftUSD + 237.4 WETH |
+| [`0x0d5dc6…4e83`](https://etherscan.io/address/0x0d5dc686d0a2abbfdafdfb4d0533e886517d4e83) | Safe | $1.15M | 9.5% | 14.5% | 485.1 WETH + 245.2K USDC |
+| 21 others | mixed | $0.31M | 2.5% | 3.9% | — |
+
+- **Borrowing is one account.** 11 addresses carry debt; the *same* EOA [`0xef6953…ae0d`](https://etherscan.io/address/0xef6953954e9c753da43da41136d41a754cd5ae0d) holds **72.7% of all outstanding debt** ($567K across USDC/USDT/ftUSD) while being the largest supplier. It is simultaneously the market's biggest lender, biggest borrower, and sole WBTC depositor of size. A single account's liquidation, exit, or default is the dominant tail risk.
+- **Secondary market depth for ftUSD: real, and deeper than the market itself is utilized.** The dominant venue is a Curve StableSwap-NG pool:
+
+| Venue | Pool | ftUSD side | Quote side | Notes |
+|---|---|---|---|---|
+| **Curve StableSwap-NG** | [`0xafec61e7…2630`](https://etherscan.io/address/0xafec61e7a604f8f81f7cab64ec75bfa07c542630) | **971,101 ftUSD** | **903,390 USDC** | ~$1.87M, A=1000, fee 0.2%, near-balanced |
+| Curve Twocrypto | [`0x68102ff5…ad6c`](https://etherscan.io/address/0x68102ff5406475881462880a8da3c9bc9181ad6c) | 48,838 ftUSD | FT | FT/ftUSD pair |
+| Uniswap V3 0.05% | [`0x99986c44…bf2c`](https://etherscan.io/address/0x99986c4473e3C8fF3b31FA8a92fB582d19BdBf2c) | 0.000033 ftUSD | 0.00064 USDC | dust — not a usable venue |
+| Uniswap V3/V2 (other tiers) | — | no pool deployed | — | — |
+
+  Measured slippage on the Curve pool (`get_dy`, ftUSD → USDC):
+
+| Size | Out | Slippage |
+|---|---|---|
+| 10,000 ftUSD | 9,979.15 USDC | 0.209% |
+| 100,000 ftUSD | 99,780.80 USDC | 0.219% |
+| 250,000 ftUSD | 249,398.14 USDC | 0.241% |
+| 500,000 ftUSD | 498,495.41 USDC | 0.301% |
+
+  **$500K exits at 0.30% slippage** — better execution than the FT Lend ftUSD market itself could absorb (1.11M ftUSD of wrapper liquidity, but only against protocol redemption). The pool is near-balanced (971K/903K) and `get_virtual_price()` = 1.000464, so **the ftUSD peg is externally corroborated**, not merely self-reported by the protocol's own redemption oracle. ftUSD also circulates as collateral in [Morpho](https://etherscan.io/address/0xbbbbbbbbbb9cc5e90e3b3af64bdaf62c37eeffcb) (629,675 ftUSD), which is independent third-party acceptance of the asset.
+
+- The supply receipts themselves have no secondary market which is normal for lending protocols. A lender's FT Lend position is an internal balance, not a transferable token, so exit is redemption-only against wrapper liquidity — which is a Spark/Aave withdrawal. The Curve venue above is an exit for *ftUSD holders*, not for USDC/WETH/WBTC lenders. This distinction matters: it improves the ftUSD collateral leg and the ftUSD-supplier leg, and does nothing for the other 88% of the market.
+
+- **Throttles / pause.** The admin can pause deposits/borrows/withdrawals per asset (`setDepositPaused` / `setBorrowPaused` / `setWithdrawPaused`); a `CircuitBreaker` [`0x9676E697…18e0`](https://etherscan.io/address/0x9676E697399581AB288844cDE5F73d0887eC18e0) can halt flows; config flags `marginRestrictWithdrawToSettlement` and `marginWithdrawRequiresNoDebt` can gate withdrawals (both currently `false`). The breaker is **owned by the admin Safe**, each wrapper's `setCircuitBreaker` is `onlyStrategyManager` and accepts `address(0)`, and the wrappers expose `withdrawBypassCB`. It is an operational rate limiter, not a safeguard against the admin.
+- **Dependency.** Exit liquidity for USDC/USDT/WETH/WBTC depends **entirely** on Spark/Aave withdrawability — zero idle buffer.
+- **Stress history:** none. No drawdown, mass exit, or liquidation cascade has occurred.
+
+## Centralization & Control Risks
+
+### Governance
+
+**A single 3-of-5 Gnosis Safe is the root of all authority, with no timelock.**
+
+- **Admin Safe:** [`0x1118e1c057211306a40A4d7006C040dbfE1370Cb`](https://etherscan.io/address/0x1118e1c057211306a40A4d7006C040dbfE1370Cb) — Gnosis Safe v1.3.0, **threshold 3 of 5**. Signers (undisclosed in docs, presumed team EOAs): [`0xB7B54333…08bc8`](https://etherscan.io/address/0xB7B543337539219A5a1326aCB71dBa8Bba408bc8), [`0x3c427497…1B4E`](https://etherscan.io/address/0x3c42749709BF354B3aE0Db29Fd2dd88089b21B4E), [`0xf9E5aF16…9a10`](https://etherscan.io/address/0xf9E5aF16243041cE3141284D225CAfC0fC749a10), [`0x09E2B492…7881`](https://etherscan.io/address/0x09E2B49280f1879172b2C3345d08896921707881), [`0xD0CA8838…6f5A`](https://etherscan.io/address/0xD0CA88388d1732594D611535314e9B6745396f5A).
+- **Guardian Safe:** [`0x22246a9183cE2CE6e2c2a9973F94aEA91435017C`](https://etherscan.io/address/0x22246a9183cE2CE6e2c2a9973F94aEA91435017C) — **3 of 4**, signer set a strict *subset* of the admin Safe. No independent parties.
+- **WBTC strategy-manager Safe:** [`0x5557729b169082f07d3131D560E2f2cb5e6c48f6`](https://etherscan.io/address/0x5557729b169082f07d3131D560E2f2cb5e6c48f6) — a **third** Safe, **3 of 5**, with the *identical five signers* as the admin Safe. `strategyManager` of the WBTC wrapper only. Separate address, zero added independence.
+- **Upgradeability:** every core contract is an OpenZeppelin **UUPS proxy** (EIP-1967 admin slot empty; upgrade gated by `owner()`/`admin()`). `PositionsManager.admin()` is `PMWrapper` [`0xBDD80028…C68B`](https://etherscan.io/address/0xBDD80028c9e4b9A2D268D2cF62Fb54Ec8697C68B), whose `admin()` is the same 3/5 Safe and which can `upgradePM`, `setCaps`, pause, and `withdrawReserves`.
+
+With **no delay**, the 3/5 Safe can: upgrade any contract to arbitrary code, change which assets/caps/margins apply, write an arbitrary oracle price, pause user funds, redirect where lender capital is deployed, and (for ftUSD) mint unbacked supply, blacklist, and burn balances. There is **no timelock, no DAO, and no independent guardian.**
+
+### Admin powers over FT Lend (verified onchain)
+
+| Role | Who | Powers |
+|------|-----|--------|
+| Owner — ConfigRegistry, OracleRouter, MintAndRedeem, ftUSD Core, CircuitBreaker, all 7 yield wrappers; ftUSD owner/masterMinter/pauser/blacklister | [3/5 Safe `0x1118…70Cb`](https://etherscan.io/address/0x1118e1c057211306a40A4d7006C040dbfE1370Cb) | Enable/disable assets, set maintenance margins, set IRMs, set/override oracle prices, upgrade all proxies, mint/seize ftUSD |
+| PositionsManager admin (via PMWrapper) | 3/5 Safe | `upgradePM`, `setCaps`, `setBorrowPaused`/`setDepositPaused`/`setWithdrawPaused`, `setLiquidationModule`, `setEngine`, `withdrawReserves`, `settleEpoch` |
+| Guardian — ConfigRegistry, OracleRouter | [3/4 Safe `0x22246a…017C`](https://etherscan.io/address/0x22246a9183cE2CE6e2c2a9973F94aEA91435017C) | `disablePrice`, pause |
+| Yield-wrapper `strategyManager` (6 of 7 wrappers) | 3/5 Safe | `setStrategy`, `removeStrategy`, `setStrategiesOrder`, `setCircuitBreaker` (incl. `address(0)`), `setDepositor`, `setPutManager` |
+| Yield-wrapper `strategyManager` (**WBTC only**) | [3/5 Safe `0x5557729b…48f6`](https://etherscan.io/address/0x5557729b169082f07d3131D560E2f2cb5e6c48f6) | Same powers over the wrapper holding 39.5% of TVL |
+| Yield-wrapper `yieldClaimer` | [`YieldClaimer 0x88432bB6…1397`](https://etherscan.io/address/0x88432bB6EA62e774cB6d87995CC5277568d01397) | **`execute(strategy, to, value, data)` — arbitrary call forwarded through the strategy** — plus `forceWithdrawToWrapper`, `claimYield` |
+| Yield-wrapper `treasury` | [`0x9B2F12De…cDe5`](https://etherscan.io/address/0x9B2F12De620d4E2993068e5cab6D6c7451f6cDe5) | `setStrategyDelay` (UUPS proxy, impl [`0xf32adbe8…7d21`](https://etherscan.io/address/0xf32adbe84a4560084516f807b73d7cd7f0677d21)) |
+| Fee collector / epoch settler | [`0x5cd6Abe6…958a`](https://etherscan.io/address/0x5cd6Abe67f8af1C0c699dF36d90a6469Eaf1958a) | Receives reserves/fees, settles epochs (UUPS proxy, impl [`0x63176fda…beb5`](https://etherscan.io/address/0x63176fdaee7af7fd60acd896e3b6ce894901beb5)) |
+
+**`strategyDelayConfig` is `0` on every wrapper.** The two-step `setStrategy` → `confirmStrategy` flow exists but its timelock is set to zero, so a strategy manager can register and activate a new strategy — redirecting where lender capital is deployed — in the same block. Combined with `execute`'s arbitrary-call path and the Safe's ability to upgrade the wrapper proxies, custody of supplied assets is fully discretionary.
+
+### Privileged engines and modules
+
+Four contracts are whitelisted on the `PositionsManager` and can move user balances via `engineDebitAllowanceOf` / `engineHeld`. All were set in the **deployment block `24974967`** and none has changed since — a genuine positive (no post-launch privilege drift):
+
+| Contract | Address | Engine | MetaModule | Liquidation module |
+|---|---|:---:|:---:|:---:|
+| `RfqEngine` | [`0xEB00B335…Dc32`](https://etherscan.io/address/0xEB00B335Ca52216Fb60fdFFA361397367C39Dc32) | ✓ | — | **✓ (sole)** |
+| `LeverageRfqEngine` | [`0x8263a075…40e2`](https://etherscan.io/address/0x8263a07504d93cB95e0a74f3627bb15faaf140e2) | ✓ | — | — |
+| `MetaActions` | [`0x3633eb60…29f2`](https://etherscan.io/address/0x3633eb60d08756674472e2d34d6ffb5f4c1c29f2) | ✓ | ✓ | — |
+| `MetaSessionActions` | [`0x4f83ac5c…3497`](https://etherscan.io/address/0x4f83ac5c8a79986d0916a8849730d9cef63a3497) | ✓ | ✓ | — |
+
+### Programmability
+
+Lending accounting (supply/borrow indices, health factors) is onchain and the oracle is Chainlink-anchored — good. The offchain/operator surface is nonetheless substantial: an RFQ/relayer/session layer (`RelayerAuth` [`0x823a97a2…53F4`](https://etherscan.io/address/0x823a97a2c32985e0f5457fc8103F36698D1F53F4), `SessionManager` [`0xF9f3ddF2…60f8`](https://etherscan.io/address/0xF9f3ddF2E96Cabef94e2634c326DC6dde99360f8), `MetaActions`/`MetaSessionActions`), a module-gated but mostly permissionless RFQ liquidation path, admin-settable oracle prices, epoch settlement by a privileged collector, and — uniquely here — a **discretionary strategy contract that decides where ftUSD's backing sits**.
+
+### External Dependencies
+
+- **Spark & Aave** — **low counterparty risk**, high *exposure*. Mature, heavily audited venues hold 100% of idle USDC/USDT/WETH/WBTC (`deployed() == capital()`). A freeze or withdrawal shortfall at either venue blocks lender exits only because FT Lend keeps **no idle buffer** — that is concentration of exit path, not a judgment that Spark/Aave are risky protocols.
+- **Chainlink** — **low counterparty risk**. Canonical feeds price solvency for USDC/USDT/ETH; WBTC/wstETH use Chainlink bases plus Aave's audited peg/cap adapters (immutable). Ordinary residual: single feed per asset, no fallback oracle. The high-impact price risk in this system is the admin `setLastGoodPrice` override, scored under Governance — not Chainlink itself.
+- **Aave price adapters** — `CLSynchronicityPriceAdapterPegToBase` (WBTC) and `WstETHPriceCapAdapter` (wstETH) sit in the pricing path for 39.5% of TVL; sound, audited construction.
+- **FT Lend itself (reflexive)** — ftUSD's backing (~$4.38M) is supplied into this market by the Delta-Neutral strategy, and ftUSD is also accepted as collateral here, so the stablecoin and the money market cannot fail independently. See [Reflexive supply](#reflexive-supply-ftusd-backing-lent-into-ft-lend). This is the unusual dependency — not Spark/Aave/Chainlink.
+- **The Spot AMM / CLOB — verified absent from the deployed contracts.** The docs describe dynamic LTV "snapshotted from AMM depth and volatility," and earlier revisions of this report carried that as an unverified critical dependency. It is not wired in. `ConfigRegistry`'s entire risk surface is `assetCfg` (IRM, `mmBps`, enabled/borrowable/collateral flags, wrapper), the three margin thresholds and the oracle pointer — **no depth input, no volatility input, no LTV machinery**. The `PositionsManager` contains no AMM or order-book reference beyond a comment on the `engines` mapping (`// PositionsManager, RFQ, ftLP, OrderBook, AMM, etc`), and all four registered engines are RFQ/meta-action contracts. The `RfqEngine`'s only "Uniswap" string is an MIT licence header on a copied math library. *Caveat: the lending repos are private, so this is established from deployed ABIs, source and event logs, not from the team's source of truth.*
+- **Lido / stETH** — referenced by the Delta-Neutral strategy design but **not currently held** (0 balance).
+- **Curve** — a StableSwap-NG [ftUSD/USDC pool](https://etherscan.io/address/0xafec61e7a604f8f81f7cab64ec75bfa07c542630) (~$1.87M) is the **only secondary-market** exit and the only external ftUSD price reference. Primary exit is protocol redeem via [`MintAndRedeem`](https://etherscan.io/address/0xAa48EcBC843cF7E9A29155D112b8Cb27902bD23C) (permissionless, 7 bps, capacity-capped by FT Lend cash). **Curve liquidity is highly concentrated:** 100% of the LP supply sits in a [Curve gauge](https://etherscan.io/address/0x8abf0a7e4b59ace59cb214fcb158285cd7cf7c3f) whose `manager` is [`0x3c427497…1B4E`](https://etherscan.io/address/0x3c42749709BF354B3aE0Db29Fd2dd88089b21B4E) — **an admin Safe signer** — and 99.998% of the gauge is held by a single EOA. `A` = 1000 with no ramp in progress; fee 0.2%; `offpeg_fee_multiplier` 2.5×. Full analysis in the [ftUSD report](./flying-tulip-ftusd.md).
+
+## Operational Risk
+
+- **Team:** Founder **Andre Cronje** (public; founded Yearn, Keep3r, co-founded Sonic/Fantom) strong founder, but mixed reputation on other projects.
+- **Legal entity / jurisdiction:** **NOT FOUND** / undisclosed (docs reference a "Foundation" with no domicile). CoinList sale excluded the US, Canada and ~21 other jurisdictions.
+- **Funding:** ~$200M seed (Sep 2025, $1B FDV), ~$25.5M Series A (Jan 2026), public sale; the official sale-update blog reports total raised ≈ **$184M** (below the "$200M seed" headline — a reconciliation gap). FT token (Aug 3, 2026): max supply 10B, mainnet `totalSupply()` **1,197,190,528**, circulating ~547M, price ~**$0.0994**, **market cap ~$54.5M**, FDV ~$119M ([CoinGecko](https://www.coingecko.com/en/coins/flying-tulip)). FT is an OFT, so mainnet supply is not the cross-chain total.
+- **Documentation vs. reality gap.** Beyond the usual omissions (oracle design, risk parameters, multisig setup), two deployed behaviours are not disclosed publicly: that **ftUSD's backing is lent into FT Lend**, and that the **"delta-neutral" strategy currently runs no hedge**. The docs' own transparency principle commits to publishing audit reports, which has not happened.
+- **Incident response:** the docs claim "continuous monitoring and formal incident runbooks" and list "incident post-mortems" as a published artefact. **No runbook, no post-mortem, and no security contact are public**, and there have been no incidents to test the claim. Onchain emergency capability genuinely exists and is broad — per-asset pause, the `CircuitBreaker`, guardian `disablePrice`, ftUSD `pause` and `blacklist`. The live Sherlock bounty provides a public reporting channel for **ftPUT**, but Safe Harbor enrolment remains absent and the bounty scope does not cover the assessed FT Lend / ftUSD contracts.
+- **Other deployments:** Flying Tulip also runs on **Sonic**, which DeFiLlama puts at **$0.52M — 3.8%** of protocol TVL against Ethereum's $12.99M ([API](https://api.llama.fi/protocol/flying-tulip)). It is a separate deployment: none of the contracts assessed here exists on Sonic, so **nothing in this report transfers to it**, and no Ethereum position is exposed to it. Deliberately out of scope rather than pending — a Sonic allocation would need its own assessment, and at 3.8% of a $13M protocol that is not currently worth the effort.
+- **Governance transparency:** no DAO, no forum/Snapshot, multisig signer identities undisclosed.
+
+## Monitoring
+
+Recommended frequency: **hourly** for pause/circuit-breaker, oracle overrides, and large supply/borrow swings; **daily** for governance, caps, and the reflexivity ratio.
+
+### Contracts to monitor
+
+| Contract | Address | Why |
+|----------|---------|-----|
+| PositionsManager | [`0xbe4050a7…0055`](https://etherscan.io/address/0xbe4050a73a7Fb384c65E885a15C33461A4B20055) | `astate` per asset, `supplyCap`/`borrowCap`, pause flags, `EngineSet`/`MetaModuleSet`/`LiquidationModuleSet`, `Upgraded` |
+| ConfigRegistry | [`0xA8777c3D…a33E`](https://etherscan.io/address/0xA8777c3D446fa7F0b0FC97a80C1Ea1d37F1ca33E) | Asset enable/disable, `mmBps`, margins, oracle pointer, `Upgraded` |
+| OracleRouterChainlink | [`0xe4372dB4…674A`](https://etherscan.io/address/0xe4372dB43D2814750a19b93950157AD81D93674A) | **`setLastGoodPrice` (arbitrary price write!)**, `setPriceFeed`, `setStaleFallback`, `disablePrice`, `setOwner` |
+| Oracle wrapper proxies | WBTC [`0x183dB475…DA55`](https://etherscan.io/address/0x183dB475d8184aA7a018ed2164e11A887afBDA55), wstETH [`0x000bb128…f35a`](https://etherscan.io/address/0x000bb128a8aBCFa05B871C97CC9C5f88e7Dcf35a), ftUSD [`0xA69f7a38…DFf8`](https://etherscan.io/address/0xA69f7a38B6c91a4bc2477f097DC8a1F16DAADFf8) | `PausedSet`, `AnswerBoundsSet`, `MaxStalenessSet` — a pause here denies pricing |
+| PMWrapper | [`0xBDD80028…C68B`](https://etherscan.io/address/0xBDD80028c9e4b9A2D268D2cF62Fb54Ec8697C68B) | `upgradePM`, `setCaps`, `withdrawReserves` |
+| Admin Safe (3/5) | [`0x1118e1c0…70Cb`](https://etherscan.io/address/0x1118e1c057211306a40A4d7006C040dbfE1370Cb) | Any `ExecutionSuccess`; `AddedOwner`/`RemovedOwner`/`ChangedThreshold` |
+| Guardian Safe (3/4) | [`0x22246a91…017C`](https://etherscan.io/address/0x22246a9183cE2CE6e2c2a9973F94aEA91435017C) | Pause / `disablePrice` actions |
+| WBTC strategy-mgr Safe (3/5) | [`0x5557729b…48f6`](https://etherscan.io/address/0x5557729b169082f07d3131D560E2f2cb5e6c48f6) | Any execution — controls the wrapper holding 39.5% of TVL |
+| CircuitBreaker | [`0x9676E697…18e0`](https://etherscan.io/address/0x9676E697399581AB288844cDE5F73d0887eC18e0) | Trips, ownership changes, removal from wrappers |
+| ftUSD | [`0xF7D85EC4…9C9C`](https://etherscan.io/address/0xF7D85EC4E7710f71992752eac2111312e73E9C9C) | `MinterConfigured`, `setMaxSupply`, `Blacklisted`, `Upgraded`; `totalSupply` vs cap |
+| ftUSD Core | [`0x56c5892B…8ca9`](https://etherscan.io/address/0x56c5892B0cF41B792217CCDD208f0FA85B178ca9) | **New module enablement**, `globalDebtCeiling` changes, `moduleDebt` vs `totalSupply` drift |
+| MintAndRedeem | [`0xAa48EcBC…D23C`](https://etherscan.io/address/0xAa48EcBC843cF7E9A29155D112b8Cb27902bD23C) | `addCollateral`, `setCollateralCapFtUSD`, fee changes, `sweepExcess`, `recoverERC20` |
+| **Delta-Neutral strategy** | [`0xe0E44596…1A59`](https://etherscan.io/address/0xe0E445967256EE60111e243e0F0F94DD1D351A59) | **Reflexivity ratio** — its FT Lend position as % of TVL; any move of ftUSD backing to a new venue |
+| FT Lend yield wrappers ×7 | see Funds Management table | `setStrategy`/`confirmStrategy` (no delay!), `setCircuitBreaker`, `execute`, available liquidity |
+
+### Governance monitoring — immediate alert, no timelock means zero warning
+
+| Event | Contract | Why it is urgent |
+|---|---|---|
+| `ExecutionSuccess` | all three Safes | Every privileged action in the system flows through one of these. There is no delay window in which to react after the fact |
+| `Upgraded` | PositionsManager, ConfigRegistry, ftUSD, ftUSD Core, MintAndRedeem, all 7 wrappers, fee collector, treasury | Arbitrary code replacement |
+| `AddedOwner` / `RemovedOwner` / `ChangedThreshold` | all three Safes | Signer-set change on the root of trust |
+| `MinterConfigured` / `MinterRemoved` / `MasterMinterChanged` | ftUSD | Unbacked-mint path |
+| module enablement | ftUSD Core | A new module with a ceiling is an unbacked-mint path |
+| `EngineSet` / `MetaModuleSet` / `LiquidationModuleSet` | PositionsManager | Changes who can move user balances or set liquidation economics. **None has fired since the deploy block — any occurrence is novel** |
+
+### Oracle monitoring
+
+- Alert on **any** `setLastGoodPrice` on the router — this is the arbitrary-price write and there is no legitimate routine use of it.
+- Alert on `setPriceFeed`, `setStaleFallback`, `setPriceDeviation`, `setOwner`, `setGuardian` on the router, and `disablePrice` from the guardian.
+- Alert on `PausedSet`, `AnswerBoundsSet`, `MaxStalenessSet` on the three protocol-owned wrapper proxies — a pause denies pricing for that asset entirely.
+- Poll `priceUSD(asset)` against the corresponding Chainlink feed; alert on >0.5% divergence (detects a router override even without catching the event).
+- Watch the ftUSD feed specially: it is derived from the USDC price and mint history rather than from ftUSD's collateral, and carries a **0 bps** deviation tolerance — it will not register a genuine ftUSD discount or a backing impairment. **Compare `priceUSD(ftUSD)` against the Curve pool's spot price** ([`0xafec61e7…2630`](https://etherscan.io/address/0xafec61e7a604f8f81f7cab64ec75bfa07c542630), `get_dy(0,1,1e6)`) — this is the only external reference for ftUSD and the only way to detect the protocol feed drifting from reality. Alert on >0.5% divergence, and on the Curve pool becoming materially imbalanced (>70/30) or losing >50% of its TVL.
+
+### Reflexive-supplier monitoring
+
+- Poll the Delta-Neutral strategy's [`0xe0E44596…1A59`](https://etherscan.io/address/0xe0E445967256EE60111e243e0F0F94DD1D351A59) `getBalance` on the PositionsManager for USDC and USDT. Alert if its share of total TVL crosses **40%** upward or **10%** downward.
+- Alert on any change to the strategy's operator set (`OperatorSet`) — it currently includes a plain EOA.
+- Track its WETH debt and account health factor: it is 99.6% of all WETH borrows, so its liquidation would be this market's first at size.
+- Deeper ftUSD-side monitoring (backing reconciliation, mint modules, redemption capacity) is specified in the ftUSD report.
+
+### Liquidity and exit-capacity monitoring
+
+- Poll each funded wrapper's `deployed()` and `capital()`. They are currently equal — alert if Spark or Aave utilization exceeds 95% while that holds, which is the precise condition under which lender exits begin to fail.
+- Poll `astate(asset).cash` per asset as the true instantaneous exit capacity.
+- Alert on `setWithdrawPaused`, `setDepositPaused`, `setBorrowPaused`, any CircuitBreaker trip, `setCircuitBreaker` (especially to `address(0)`), and any flip of `marginRestrictWithdrawToSettlement` or `marginWithdrawRequiresNoDebt` to `true`.
+- Alert on `setStrategy` / `confirmStrategy` on any wrapper — `strategyDelayConfig` is `0`, so these can land in the same block with no warning.
+
+### Position and solvency monitoring
+
+- Track the four dominant addresses via `getBalance(user, asset)` and `debtShares(user, asset)`; alert on any withdrawal >25% of a position.
+- The dominant EOA [`0xef6953…ae0d`](https://etherscan.io/address/0xef6953954e9c753da43da41136d41a754cd5ae0d) warrants its own alert set: it is 38% of supply and 73% of debt simultaneously, so its health factor is a systemic variable. Poll its account HF and alert below 1.35 (ahead of the 1.25 liquidation threshold).
+- Alert on any `liquidateFlash` execution — none has occurred at size; the first one is a live test of an untested engine.
+- Alert if any `astate.borrows` exceeds `astate.totalSupplied` for an asset, or if reserves move (they are currently ~$325 in total, so any movement is significant relative to the balance).
+
+### Key thresholds / values
+
+- **Oracle integrity:** alert on **any** `setLastGoodPrice`, and on any router `priceUSD` deviating >0.5% from the corresponding Chainlink feed.
+- **Governance:** alert on **any** execution by any of the three Safes and **any** proxy `Upgraded` event — no timelock means zero warning.
+- **Reflexivity:** alert if the Delta-Neutral strategy's share of FT Lend TVL exceeds 40%, or if ftUSD's supply cap is raised while its backing remains deployed into FT Lend.
+- **Caps:** alert above ~90% of `supplyCap` — **ftUSD is already at 95%** — and on every `setCaps`.
+- **Concentration:** track [`0xef6953…ae0d`](https://etherscan.io/address/0xef6953954e9c753da43da41136d41a754cd5ae0d) (38% of supply, 73% of debt), [`0x666130…701c`](https://etherscan.io/address/0x66613091b75e54954f77746e160c98391f99701c), [`0x0d5dc6…4e83`](https://etherscan.io/address/0x0d5dc686d0a2abbfdafdfb4d0533e886517d4e83) via `getBalance`; alert on any withdrawal >25% of a position.
+- **Exit capacity:** alert if wrapper `deployed()` remains equal to `capital()` while Spark or Aave utilization exceeds 95% — that is the condition under which exits fail.
+- **Solvency:** monitor liquidations and `astate.reserves` (currently negligible); alert on any bad-debt socialization event.
+
+## Appendix A: Contract Architecture
+
+```
+GOVERNANCE (no timelock, identical signer set across all three Safes)
+  Admin Safe 3/5  0x1118…70Cb ── owns/upgrades ─────────────┐
+  Guardian Safe 3/4  0x22246a…017C (subset signers)         │ disablePrice / pause
+  WBTC StrategyMgr Safe 3/5  0x5557…48f6 (same 5 signers)   │
+        │                                                    ▼
+        ▼                                            LEND ENGINE (ftDNMM)
+TOKEN / STABLE LAYER                                   PositionsManager (UUPS)
+  ftUSD (FiatToken, UUPS)                               ├─ admin via PMWrapper (admin=Safe)
+     ▲ mint (module-gated, ceiling 100M)                ├─ config → ConfigRegistry
+  ftUSD Core (sole minter)                              │    • per-asset IRM, mmBps, wrapper, flags
+     ▲                                                  │    • HF safe 1.50 / target 1.25 / minEq $250
+  MintAndRedeem  ── collateral in ──┐                   ├─ oracle → OracleRouterChainlink
+  FT token (OFT, unpriced in Lend)  │                   │    ├─ USDC/USDT/ETH → canonical Chainlink
+                                    │                   │    ├─ WBTC → CL BTC/USD + Aave peg adapter
+                                    │                   │    ├─ wstETH → CL ETH/USD + Aave cap adapter
+                                    │                   │    └─ ftUSD → MintAndRedeem redeem factor ⟲
+                                    │                   ├─ IRMs: Stable / Major / LongTail
+                                    │                   ├─ engines: RfqEngine* / LeverageRfqEngine
+                                    │                   │           MetaActions / MetaSessionActions
+                                    │                   │           (*sole liquidation module)
+                                    │                   ├─ session: RelayerAuth / SessionManager
+                                    │                   └─ CircuitBreaker (owned by Admin Safe)
+                                    │                          ▲
+   ftUSD-USDC wrapper 0x6aaf…837D ──┤                          │
+   ftUSD-USDT wrapper 0x28CC…47D6 ──┘                          │
+        └─► MultiCollateralDeltaNeutralStakingStrategy         │
+              0xe0E4…1A59  ── deposits 2.77M USDC + 1.42M USDT ┘
+              (hedge leg live since ~Aug 3: 76.5 wstETH collateral, 95.0 WETH borrowed)
+              ⟲ REFLEXIVITY: ftUSD backing is 35.1% of FT Lend TVL
+
+LEND SUPPLY ROUTING (third-party lenders)          UNDERLYING YIELD
+  USDC / USDT / WETH wrappers ──────────────────►  Spark   (deployed == capital, no buffer)
+  WBTC wrapper ─────────────────────────────────►  Aave    (deployed == capital, no buffer)
+  ftUSD / wstETH / FT wrappers ─────────────────►  no strategy configured
+```
+
+## Appendix B: Source-verification check
+
+All contracts in the trust surface were checked via Etherscan `getsourcecode` on August 3, 2026. **Every one is source-verified**, so the "Unverified contract source" critical gate does not trigger.
+
+| Contract | Address | Implementation (if proxy) |
+|---|---|---|
+| PositionsManager | [`0xbe4050a7…0055`](https://etherscan.io/address/0xbe4050a73a7Fb384c65E885a15C33461A4B20055) | [`0xaa3d5fc8…a23b`](https://etherscan.io/address/0xaa3d5fc84b43219391539714be5f0681aefca23b) |
+| ConfigRegistry | [`0xA8777c3D…a33E`](https://etherscan.io/address/0xA8777c3D446fa7F0b0FC97a80C1Ea1d37F1ca33E) | [`0xd25f964e…47e5`](https://etherscan.io/address/0xd25f964ead7bfbf07858b5bfede58f11a5a947e5) |
+| ftUSD (`FlyingTulipUSD`) | [`0xF7D85EC4…9C9C`](https://etherscan.io/address/0xF7D85EC4E7710f71992752eac2111312e73E9C9C) | [`0xf47bb65f…1885`](https://etherscan.io/address/0xf47bb65fb0886be183db541afce555345e3e1885) |
+| ftUSD Core | [`0x56c5892B…8ca9`](https://etherscan.io/address/0x56c5892B0cF41B792217CCDD208f0FA85B178ca9) | [`0x986841b7…5440`](https://etherscan.io/address/0x986841b77f3aa934d315d48121842e3c622e5440) |
+| MintAndRedeem | [`0xAa48EcBC…D23C`](https://etherscan.io/address/0xAa48EcBC843cF7E9A29155D112b8Cb27902bD23C) | [`0x8852b132…c3c6`](https://etherscan.io/address/0x8852b132b72613a16f1e3960978a3d45c0a7c3c6) |
+| MultiCollateralDeltaNeutralStakingStrategy | [`0xe0E44596…1A59`](https://etherscan.io/address/0xe0E445967256EE60111e243e0F0F94DD1D351A59) | — |
+| RfqEngine | [`0xEB00B335…Dc32`](https://etherscan.io/address/0xEB00B335Ca52216Fb60fdFFA361397367C39Dc32) | — |
+| LeverageRfqEngine | [`0x8263a075…40e2`](https://etherscan.io/address/0x8263a07504d93cB95e0a74f3627bb15faaf140e2) | — |
+| MetaActions | [`0x3633eb60…29f2`](https://etherscan.io/address/0x3633eb60d08756674472e2d34d6ffb5f4c1c29f2) | — |
+| MetaSessionActions | [`0x4f83ac5c…3497`](https://etherscan.io/address/0x4f83ac5c8a79986d0916a8849730d9cef63a3497) | — |
+| RelayerAuth | [`0x823a97a2…53F4`](https://etherscan.io/address/0x823a97a2c32985e0f5457fc8103F36698D1F53F4) | — |
+| SessionManager | [`0xF9f3ddF2…60f8`](https://etherscan.io/address/0xF9f3ddF2E96Cabef94e2634c326DC6dde99360f8) | — |
+| CircuitBreaker | [`0x9676E697…18e0`](https://etherscan.io/address/0x9676E697399581AB288844cDE5F73d0887eC18e0) | — |
+| YieldClaimer | [`0x88432bB6…1397`](https://etherscan.io/address/0x88432bB6EA62e774cB6d87995CC5277568d01397) | — |
+| Fee collector | [`0x5cd6Abe6…958a`](https://etherscan.io/address/0x5cd6Abe67f8af1C0c699dF36d90a6469Eaf1958a) | [`0x63176fda…beb5`](https://etherscan.io/address/0x63176fdaee7af7fd60acd896e3b6ce894901beb5) |
+| Treasury | [`0x9B2F12De…cDe5`](https://etherscan.io/address/0x9B2F12De620d4E2993068e5cab6D6c7451f6cDe5) | [`0xf32adbe8…7d21`](https://etherscan.io/address/0xf32adbe84a4560084516f807b73d7cd7f0677d21) |
+| Oracle wrapper — WBTC | [`0x183dB475…DA55`](https://etherscan.io/address/0x183dB475d8184aA7a018ed2164e11A887afBDA55) | — (immutable base feed + adapter) |
+| Oracle wrapper — wstETH | [`0x000bb128…f35a`](https://etherscan.io/address/0x000bb128a8aBCFa05B871C97CC9C5f88e7Dcf35a) | — (immutable base feed + adapter) |
+| Oracle wrapper — ftUSD | [`0xA69f7a38…DFf8`](https://etherscan.io/address/0xA69f7a38B6c91a4bc2477f097DC8a1F16DAADFf8) | — (immutable base feed + mintRedeem) |
+| Yield wrappers ×7 | see Funds Management table | [`0xfaed20b3…1157`](https://etherscan.io/address/0xfaed20b307a6789481ee383adc10b9b0090b1157) (`ftYieldWrapper`) |
+
+---
+
+## Risk Summary
+
+### Key Strengths
+
+- **Accounting is honest and independently verifiable.** Every reserve figure reconciles exactly: supplier balances sum to `astate.totalSupplied` ($12,127,035), debt shares sum to `astate.borrows` ($780,125), and the four-hop ftUSD backing chain reconciles to the wei at a 101.03% collateral ratio. This is better than most protocols at this size.
+- **Genuine onchain over-collateralization with blue-chip collateral** (WETH, WBTC, wstETH, USDC, USDT) and enforced health factors.
+- **Oracle construction is more careful than it first appears** — canonical Chainlink for USDC/USDT/ETH, plus Aave's audited peg and cap adapters for WBTC and wstETH, all wired **immutably** so the owner cannot repoint them.
+- **No privilege drift since launch.** All four engines, both meta-modules and the sole liquidation module were set in the deployment block and have never changed.
+- **ftUSD has a genuine external market.** A ~$1.87M Curve StableSwap-NG pool clears $500K at 0.30% slippage and sits near-balanced, which both provides a real exit for the ftUSD leg and corroborates the peg independently of the protocol's own oracle. ftUSD is separately accepted as Morpho collateral.
+- **Conservative caps and a small footprint** limit blast radius today.
+
+### Key Risks
+
+- **34.5% of TVL is the protocol lending to itself.** ftUSD's backing is deployed into FT Lend, so ftUSD and the lending market cannot fail independently, and ftUSD's own price feed cannot register an impairment of that collateral at all.
+- **Single 3/5 multisig controls everything with no timelock** — instant upgrade of any contract, arbitrary oracle price override, pause of user funds, unbacked ftUSD mint, blacklist and seizure. Two further Safes share the identical signer set, so apparent separation of duties is cosmetic.
+- **Extreme lender and borrower concentration:** 25 suppliers total; three third-party addresses are 96.1% of third-party TVL; one EOA is 38% of all supply and 73% of all debt.
+- **Audit quality is good but non-public, and FT Lend has no in-scope bounty** — the private package was reviewed for this assessment, while firm/date/scope/finding details remain unavailable to public depositors. The live $1M Sherlock bounty covers **ftPUT / FT OFT**, not the lending core.
+- **Very new** (engine ~3.2 months) with **no stress history**, an untested novel liquidation engine, and **no loss backstop** (reserves are negligible).
+- **Reflexive collateral.** A loss event in FT Lend impairs ftUSD's backing, which impairs ftUSD, which is 11.8% of FT Lend's collateral; the backing-blind feed would not register that impairment.
+
+### Critical Risks
+
+- **Unilateral, instant admin control.** A 3/5 multisig — effectively one party, given the identical signer set across all three Safes — can upgrade the engine, rewrite the oracle price via `setLastGoodPrice`, redirect lender capital through a zero-delay `setStrategy`, or mint unbacked ftUSD, with no delay and no independent check. Deployed invariants must be treated as mutable, not durable.
+
+---
+
+## Risk Score Assessment
+
+**Scoring guidelines applied:** conservative rounding (higher/riskier when uncertain), decimals where a subcategory falls between bands, onchain evidence prioritised over documentation.
+
+### Critical Risk Gates
+
+- [ ] **Unverified contract source** — **PASS.** All 20 contracts in the trust surface, including every proxy implementation, are source-verified on Etherscan (Appendix B).
+- [ ] **No audit** — **PASS, with material reservation.** A structured audit registry demonstrably exists in the investor portal, so "no audit" would be a false statement. However it is access-code gated and **zero audits are independently confirmable** for the assessed contracts. The two publicly confirmable reviews (token-sale `Escrow`; ftPUT via Sherlock) cover neither the lending engine nor ftUSD. Scored down hard in Category 1 rather than gated.
+- [ ] **Unverifiable reserves** — **PASS.** Reserves are fully onchain and were reconciled exactly, twice, including the complete ftUSD backing chain.
+- [ ] **Total centralization (single EOA)** — **PASS, marginally.** Control is a 3/5 multisig, not a lone EOA. But all three Safes share one signer set and there is no timelock, so the practical distance from the gate is small. Reflected as a 5.0 in Category 2A.
+
+**No critical gate is triggered.** The final score uses weighted category scoring.
+
+### Category Scores
+
+#### Category 1: Audits & Historical Track Record (Weight: 20%)
+
+**Subcategory A: Audits & Security Reviews — 3.0**
+- The privately reviewed audit package provides good in-scope coverage from reputable firms including ChainSecurity, MixBytes, and Cantina; the audit quality itself maps to rubric row 2.
+- **+0.5** because the reports and finding-level detail remain behind an access-code wall rather than being publicly inspectable.
+- **+0.5 because FT Lend is not covered by the bug bounty.** The live $1M Sherlock program covers ftPUT / FT OFT, not `PositionsManager`, `ConfigRegistry`, the IRMs, or the RFQ engines. This is the explicit reason FT Lend scores worse than ftUSD's 2.5 audit subscore; it is not a negative judgment on the audit quality.
+- The only two publicly confirmable reviews cover the token-sale `Escrow` and the separate ftPUT product — **neither touches `PositionsManager`, `ConfigRegistry`, the IRMs, the RFQ engines, ftUSD, ftUSD Core, or `MintAndRedeem`.**
+- Contract surface is large and novel: dynamic snapshot LTV, RFQ/relayer/session layer, flash liquidation, epoch settlement, cross-product shared collateral, and a discretionary backing strategy. The rubric notes simple surfaces score better than complex ones.
+
+**Subcategory B: Historical Track Record — 4.0**
+- Time in production: the assessed `PositionsManager` was deployed **April 27, 2026** with first deposit **April 29, 2026** — **3.2 months**. The wider protocol is 5.4 months. Rubric band "3–6 months" = 4.
+- Scale: headline TVL $12.13M would sit in the ">$10M" band (3), but **$4.18M of it is the protocol's own recycled ftUSD collateral**. Genuine third-party TVL is **$8.11M**, which is the "<$10M" band (4).
+- No incidents, exploits, or depegs — but also no stress event of any kind, no drawdown, and no liquidation cascade. The clean record carries little information at this age and size.
+- Both columns land on 4. **4.0.**
+
+**Score: 3.5/5** — (3.0 + 4.0) / 2 = 3.5. The audit work is good, but FT Lend lacks in-scope bounty coverage and the market is young and small.
+
+#### Category 2: Centralization & Control Risks (Weight: 30%)
+
+**Subcategory A: Governance — 5.0**
+- 3-of-5 Gnosis Safe, **no timelock anywhere in the system**. Rubric row 4 is "Multisig 3/5 or low threshold | <12 hours | Powerful admin roles with limited constraints"; row 5 is "No timelock | Unlimited admin powers". Two of three columns are row 5.
+- Every core contract is a **UUPS proxy upgradeable by that Safe** — audited (or unaudited) code can be replaced with arbitrary code in one transaction. This alone makes every other invariant in this report non-durable.
+- The Safe is ftUSD `owner` + `masterMinter` + `pauser` + `blacklister`: it can register a new mint module with an arbitrary ceiling (**unbacked mint**), and `blacklist` + `wipeBlacklistedAddress` (**freeze and burn user balances**).
+- It can write **arbitrary oracle prices** via `setLastGoodPrice`, bypassing the immutable adapter safeguards.
+- **Apparent separation of duties is cosmetic:** the Guardian Safe (3/4) is a strict subset of the admin signers, and the WBTC strategy-manager Safe (3/5) has the *identical five signers*. Three Safes, one party.
+- `strategyDelayConfig = 0` on all seven wrappers, so the strategy-change timelock that exists in code is disabled in configuration.
+- Signer identities undisclosed. **5.0** — this is the top of the band and is the single largest contributor to the final score.
+
+**Subcategory B: Programmability — 3.0**
+- Positives: supply/borrow indices, health factors and liquidation eligibility are computed onchain; IRM curves are `pure` functions; the supply index accrues without operator action.
+- Offsetting: admin-settable prices; instant proxy upgrades; four whitelisted engines holding debit allowances over user balances; a module-gated, mostly permissionless, time-sliced RFQ liquidation path (`rfqFill`/`rfqFillFlash`) that still depends on offchain callers sourcing repayment; epoch settlement performed by a privileged collector; and a **discretionary strategy contract that decides where ftUSD's backing is deployed** with no onchain rule constraining it.
+
+**Subcategory C: External Dependencies — 2.5**
+- **Spark, Aave, and Chainlink are not high-risk counterparties.** They are mature, heavily audited infrastructure — among the best external deps a money market can pick. Individual counterparty risk is low (~1.5–2.0 band).
+- What elevates this subcategory is **exposure design**, not venue quality: wrappers keep `deployed() == capital()`, so lender exits inherit Spark/Aave cash and pause state with **no idle buffer**. That is concentrated exit-path risk on otherwise sound venues.
+- Chainlink (plus immutable Aave peg/cap adapters for WBTC/wstETH) is sound oracle construction; single-feed residual is ordinary. Arbitrary-price risk sits on the admin router override and is scored under Governance.
+- **The unusual dependency is reflexive FT Lend via ftUSD's backing** — correlated failure of the stablecoin and this market — not Spark/Aave/Chainlink.
+- Spot AMM/CLOB is **not wired** into the deployed contracts (no score credit or debit).
+
+**Score: 3.50/5** — (5.0 + 3.0 + 2.5) / 3 = 3.50. Governance remains the ceiling; external deps no longer treat blue-chip venues as if they were risky protocols.
+
+#### Category 3: Funds Management (Weight: 30%)
+
+**Subcategory A: Collateralization — 3.5**
+- The direct lending book is strong: 100% onchain, over-collateralized, blue-chip collateral, health factors enforced in-contract (`marginHfSafeBps` 1.50 / `marginHfTargetBps` 1.25 / $250 min equity).
+- Dragging it down: **ftUSD (11.4% of TVL) is collateral whose own backing is a claim on this same market**, at a nominal 101.03% CR with no independent buffer.
+- **Maintenance margins on stables are 1.5%, and there is nothing beneath them.** The dynamic-LTV haircut the docs describe is **not implemented in the deployed contracts** — no depth or volatility input exists in `ConfigRegistry` or the `PositionsManager`. With `mmBps` = 150 and a 1.25 target HF, the contract permits roughly **50× leverage** on a stable position. This is an admin-set constant, not a risk engine, and it is the only thing standing between a borrower and the collateral.
+- **No loss backstop.** Protocol reserves are 7.72 USDC / 13.16 USDT / 303.01 ftUSD / ~0 WETH / 0 WBTC — negligible against $12.13M. Bad debt would be socialized to suppliers.
+- Liquidation engine is novel, module-gated via permissionless `rfqFill(Flash)`, and has never run at scale. **The `PositionsManager` defines no liquidation bonus and no close factor** — the seize/repay split is set by the swappable `RfqEngine`, and the insolvency exception explicitly permits leaving bad debt.
+- **Supplier yield is partly discretionary FT emissions** paid via admin-only `settleEpoch`. WBTC and ftUSD suppliers (51.3% of TVL combined) have received **zero** emissions to date.
+- Admin can override the price that determines whether a position is solvent at all.
+
+**Subcategory B: Provability — 2.5**
+- Strong: reserves reconcile exactly and independently (supplier balances → `totalSupplied`; debt shares → `borrows`; ftUSD collateral chain → wrapper `capital()` → strategy position). Anyone can reproduce this with `cast`. The supply index is computed onchain.
+- Strong: oracle wrappers have **immutable** base feeds and adapters, so the pricing *construction* is fixed and auditable.
+- Weak: `setLastGoodPrice` lets the admin write an arbitrary price, which defeats the above at will.
+- Weak: **ftUSD's price does not read ftUSD's backing** — `MintAndRedeem`'s redeem factors are functions of the USDC price and cumulative mint history — and carries a 0 bps deviation tolerance, so neither a market discount nor a backing impairment can surface in liquidation pricing.
+- Weak: verifying ftUSD's backing takes four hops through undocumented contracts; nothing in the public docs describes it.
+- Weak: no public source repository and no public audit reports, so review is confined to reading verified bytecode.
+
+**Score: 3.0/5** — (3.5 + 2.5) / 2 = 3.0. The arithmetic is honest and checkable, which is a real strength; the risks are structural (reflexivity, no backstop) and discretionary (price override), not accounting opacity. High governance power keeps the score higher
+
+#### Category 4: Liquidity Risk (Weight: 15%)
+
+Framed for an **FT Lend supplier**. Exit is protocol `withdraw` against available cash — there is no secondary market for the supply receipt, which is normal for a money market and is not scored as a missing DEX.
+
+- **Binding constraint is utilization.** A lender can exit only the un-borrowed share of each asset. At today's **6.4% utilization**, cash is ample (USDC ~92% available, WBTC 100%, WETH ~100%, USDT ~84%) and withdrawal is same-block. Risk rises as utilization approaches the kink / 100% — borrowed liquidity is unavailable until repaid or liquidated.
+- **Underlying venue is a second utilization gate.** Wrappers keep `deployed() == capital()` into Spark (USDC/USDT/WETH) and Aave (WBTC), so even low FT Lend utilization still requires those venues to have withdrawable cash / not be paused. That is dependency risk expressed as liquidity, not a separate market-depth story.
+- **Concentration can force utilization.** Three third-party addresses hold 96.1% of third-party TVL; a large simultaneous withdrawal (or the Delta-Neutral strategy unwinding its 35.1%) is the realistic path to an unavailable-cash state on a thin book ($4.79M WBTC / $3.14M USDC largest pools).
+- **No stress history** — exit under high utilization has not been observed.
+
+**Score: 2.0/5** — The money-market withdrawal path is permissionless and same-block at current low utilization. It is not scored lower because Spark/Aave sit under every funded wrapper with no idle buffer, and supplier concentration makes a utilization spike plausible. Admin-triggered withdrawal pauses are captured under centralization rather than treated as an active liquidity throttle. Curve depth is out of scope for this lender score.
+
+#### Category 5: Operational Risk (Weight: 5%)
+
+- **Team:** founder is public and well known (Andre Cronje — Yearn, Keep3r, Sonic/Fantom), which is a genuine positive. His track record is mixed, with a documented history of abandoned or incomplete launches. The remaining ~15 team members are anonymous.
+- **Legal:** **no disclosed legal entity or jurisdiction** — docs reference a "Foundation" with no domicile.
+- **Documentation:** conceptually reasonable, but omits oracle design, risk parameters and the multisig setup. The docs do not disclose that ftUSD's backing is lent into FT Lend, and the "delta-neutral" strategy holds no hedge. The docs' own transparency principle promises published audit reports that do not exist.
+- **Governance transparency:** no DAO, no forum, no Snapshot, signers undisclosed.
+- **Incident response:** docs reference "formal incident runbooks"; none is public. Emergency capability exists onchain (pause, circuit breaker, `disablePrice`) and has never been exercised.
+
+**Score: 3.5/5**
+
+### Final Score Calculation
+
+| Category | Score | Weight | Weighted |
+|----------|-------|--------|----------|
+| Audits & Historical | 3.50 | 20% | 0.700 |
+| Centralization & Control | 3.50 | 30% | 1.050 |
+| Funds Management | 3.00 | 30% | 0.900 |
+| Liquidity Risk | 2.00 | 15% | 0.300 |
+| Operational Risk | 3.50 | 5% | 0.175 |
+| **Final Score** | | | **3.125** |
+
+**Final Score: 3.1**
+
+**Optional modifiers:** none apply. Protocol is <1 year old (no −0.5 for >2 years incident-free) and TVL is far below $500M (no −0.5 for scale).
+
+### Risk Tier
+
+| Final Score | Risk Tier | Recommendation |
+|------------|-----------|----------------|
+| 1.0-1.5 | Minimal Risk | Approved, high confidence |
+| 1.5-2.5 | Low Risk | Approved with standard monitoring |
+| **2.5-3.5** | **Medium Risk** | **Approved with enhanced monitoring** |
+| 3.5-4.5 | Elevated Risk | Limited approval, strict limits |
+| 4.5-5.0 | High Risk | Not recommended |
+
+**Final Risk Tier: MEDIUM RISK — approved with enhanced monitoring.**
+
+The composite is 3.1, in the Medium band. The determining factors are:
+
+- **Governance is the dominant term** (Category 2A at 5.0, carrying 10% of the total weight on its own). A 3/5 Safe with no timelock, holding upgrade authority over every contract, arbitrary oracle-price authority, and an unbacked-mint path on ftUSD, means no invariant in this report survives an adverse governance action. Three Safes with one signer set provide no meaningful separation.
+- **Reflexive collateral.** 35.1% of TVL is the protocol's own ftUSD backing; ftUSD is 11.4% of this market's collateral; and ftUSD's price feed is blind to that backing, so an impairment would not surface in liquidation pricing. FT Lend and ftUSD cannot fail independently.
+- **Concentration.** Three third-party addresses are 96.1% of third-party TVL; one EOA is 38% of supply and 73% of debt.
+- **Lender exit is utilization-bound**, with a second gate at Spark/Aave because wrappers hold zero idle buffer. Liquidity score is not driven by Curve — that venue is for ftUSD holders, not FT Lend suppliers.
+- **Audit evidence is not inspectable** for any in-scope contract, with no bounty and no Safe Harbor.
+- **No loss backstop** and a novel, untested liquidation engine.
+
+Offsetting these, and the reason this is not High Risk: the accounting is honest and fully reconcilable onchain, the collateral is genuinely blue-chip and over-collateralized, the oracle construction uses canonical Chainlink plus audited Aave adapters wired immutably, privileges have not drifted since deployment, every contract is source-verified, and current utilization leaves ample cash for same-block lender exits.
+
+**Recommendation for Yearn:** if an allocation proceeds, size it against **third-party TVL ($7.95M), not headline TVL**, cap exposure well below the position of the dominant EOA, avoid ftUSD as a supplied asset (it is the reflexive leg), and treat any admin Safe execution or proxy upgrade as an immediate exit trigger given the absence of a timelock.
+
+---
+
+## Reassessment Triggers
+
+- **Audit status:** reassess if any in-scope audit report is published with firm, date and scope, if the bounty publishes or expands assessed-contract coverage, or if the protocol enrols in SEAL Safe Harbor.
+- **Governance hardening:** reassess if a timelock is added, if the admin Safe threshold or signer independence materially improves, or if the three Safes are given genuinely distinct signer sets.
+- **Reflexivity:** reassess if the Delta-Neutral strategy's share of FT Lend TVL exceeds 40% or falls below 10%, if ftUSD backing is redeployed to a venue outside FT Lend, or if the hedge leg (stETH/WETH) is actually activated at size.
+- **Dynamic LTV:** reassess if an AMM or order-book contract is ever registered via `EngineSet`, or if `ConfigRegistry` gains a depth/volatility input — that would introduce the risk engine the docs already describe and change the collateralization analysis.
+- **Time-based:** reassess in **2 months**. Shortened from 3: the hedge leg activating mid-assessment showed this market's state can move materially in days on one actor's decision.
+- **TVL/usage-based:** using the August 3 baseline of $7.95M *third-party* lending TVL, reassess if it grows above ~$24M, falls below ~$2.6M, or if any of the three dominant third-party suppliers exits.
+- **ftUSD market-based:** reassess if the Curve ftUSD/USDC pool loses >50% of its TVL, becomes materially imbalanced (>70/30), or if its spot price diverges >0.5% from the protocol's `priceUSD(ftUSD)` — that pool is the only external check on the ftUSD feed.
+- **Cap-based:** reassess if `supplyCap` is materially raised on any asset — ftUSD is already 95% subscribed against a 1.5M cap.
+- **Concentration:** reassess if the dominant EOA's share of supply or debt moves by more than 15 percentage points in either direction.
+- **Incident-based:** reassess after any exploit, bad-debt event, oracle override (`setLastGoodPrice`), oracle-wrapper pause, proxy upgrade, ftUSD depeg or unbacked mint, new ftUSD Core module enablement, or any Spark/Aave incident affecting a configured strategy.
+
+---
+
+## Assessment History
+
+| Date | Score | Notes |
+| --- | --- | --- |
+| [August 7, 2026](https://github.com/yearn/risk-score/pull/237) | 3.1 | Initial assessment |

--- a/reports/report/flying-tulip.md
+++ b/reports/report/flying-tulip.md
@@ -4,7 +4,7 @@
 - **Token:** FT Lend market — supply / borrow positions (internal balances, not tokenised)
 - **Chain:** Ethereum Mainnet
 - **Core Contract:** PositionsManager [`0xbe4050a73a7Fb384c65E885a15C33461A4B20055`](https://etherscan.io/address/0xbe4050a73a7Fb384c65E885a15C33461A4B20055)
-- **Final Score: 3.1/5.0**
+- **Final Score: 3.0/5.0**
 - **Medium Risk** — approved with enhanced monitoring. A 3-of-5 Safe with no timelock can upgrade every contract and override every price. **35.1% of the market's TVL is the protocol's own ftUSD backing collateral supplied back into itself**, and only three genuinely third-party addresses hold 96% of the remainder. The audit package was privately reviewed and is strong but remains non-public; a live $1M Sherlock bounty covers deployed Flying Tulip contracts through the dynamic production-contract list incorporated by its Additional Scope. See [Risk Score Assessment](#risk-score-assessment). (Also deployed on Sonic; this report covers Ethereum.)
 - **Companion report:** ftUSD and staked ftUSD are assessed separately in **[Flying Tulip — ftUSD & Staked ftUSD](./flying-tulip-ftusd.md)**.
 
@@ -485,8 +485,8 @@ Recommended frequency: **hourly** for pause/circuit-breaker, oracle overrides, a
 | `ExecutionSuccess` | all three Safes | Every privileged action in the system flows through one of these. There is no delay window in which to react after the fact |
 | `Upgraded` | PositionsManager, ConfigRegistry, ftUSD, ftUSD Core, MintAndRedeem, all 7 wrappers, fee collector, treasury | Arbitrary code replacement |
 | `AddedOwner` / `RemovedOwner` / `ChangedThreshold` | all three Safes | Signer-set change on the root of trust |
-| `MinterConfigured` / `MinterRemoved` / `MasterMinterChanged` | ftUSD | Unbacked-mint path |
-| module enablement | ftUSD Core | A new module with a ceiling is an unbacked-mint path |
+| `MinterConfigured` / `MinterRemoved` / `MasterMinterChanged` | ftUSD | Privileged mint-authority change; verify that the resulting path enforces collateral |
+| module enablement | ftUSD Core | Verify immediately whether the new module independently enforces collateral before minting |
 | `EngineSet` / `MetaModuleSet` / `LiquidationModuleSet` | PositionsManager | Changes who can move user balances or set liquidation economics. **None has fired since the deploy block — any occurrence is novel** |
 
 ### Oracle monitoring
@@ -495,7 +495,7 @@ Recommended frequency: **hourly** for pause/circuit-breaker, oracle overrides, a
 - Alert on `setPriceFeed`, `setStaleFallback`, `setPriceDeviation`, `setOwner`, `setGuardian` on the router, and `disablePrice` from the guardian.
 - Alert on `PausedSet`, `AnswerBoundsSet`, `MaxStalenessSet` on the three protocol-owned wrapper proxies — a pause denies pricing for that asset entirely.
 - Poll `priceUSD(asset)` against the corresponding Chainlink feed; alert on >0.5% divergence (detects a router override even without catching the event).
-- Watch the ftUSD feed specially: it is derived from the USDC price and mint history rather than from ftUSD's collateral, and carries a **0 bps** deviation tolerance — it will not register a genuine ftUSD discount or a backing impairment. **Compare `priceUSD(ftUSD)` against the Curve pool's spot price** ([`0xafec61e7…2630`](https://etherscan.io/address/0xafec61e7a604f8f81f7cab64ec75bfa07c542630), `get_dy(0,1,1e6)`) — this is the only external reference for ftUSD and the only way to detect the protocol feed drifting from reality. Alert on >0.5% divergence, and on the Curve pool becoming materially imbalanced (>70/30) or losing >50% of its TVL.
+- Watch the ftUSD feed specially: it is derived from the USDC price and mint history rather than from ftUSD's collateral, and carries a **0 bps** deviation tolerance — it will not register a genuine ftUSD discount or a backing impairment. **Compare `priceUSD(ftUSD)` against the Curve pool's spot price** ([`0xafec61e7…2630`](https://etherscan.io/address/0xafec61e7a604f8f81f7cab64ec75bfa07c542630), `get_dy(0,1,1e6)`) — this is the only external reference for ftUSD and the only way to detect the protocol feed drifting from reality. Alert on >0.5% divergence, pool imbalance above 70/30, another 25% liquidity decline from the September 4 baseline, or a $100K quote exceeding 2% impact.
 
 ### Reflexive-supplier monitoring
 
@@ -639,12 +639,12 @@ All contracts in the trust surface were checked via Etherscan `getsourcecode` on
 
 #### Category 1: Audits & Historical Track Record (Weight: 20%)
 
-**Subcategory A: Audits & Security Reviews — 2.5**
+**Subcategory A: Audits & Security Reviews — 2.0**
 - The privately reviewed audit package provides good in-scope coverage from reputable firms including ChainSecurity, MixBytes, and Cantina; the audit quality itself maps to rubric row 2.
-- **+0.5** because the reports and finding-level detail remain behind an access-code wall rather than being publicly inspectable.
 - The live Sherlock bounty has a maximum reward of 1,000,000 USDC and covers Flying Tulip's deployed production contracts through the dynamic contract list incorporated by the bounty's Additional Scope, including `PositionsManager`, `ConfigRegistry`, the IRMs, and the RFQ engines.
 - The only two publicly confirmable reviews cover the token-sale `Escrow` and the separate ftPUT product — **neither touches `PositionsManager`, `ConfigRegistry`, the IRMs, the RFQ engines, ftUSD, ftUSD Core, or `MintAndRedeem`.**
 - Contract surface is large and novel: dynamic snapshot LTV, RFQ/relayer/session layer, flash liquidation, epoch settlement, cross-product shared collateral, and a discretionary backing strategy. The rubric notes simple surfaces score better than complex ones.
+- The reports and finding-level details remain non-public, Safe Harbor enrolment was not found, and complexity is high. Those facts prevent a stronger row-1 score but do not justify an extra half-point above rubric row 2.
 
 **Subcategory B: Historical Track Record — 4.0**
 - Time in production: the assessed `PositionsManager` was deployed **April 27, 2026** with first deposit **April 29, 2026** — **3.2 months**. The wider protocol is 5.4 months. Rubric band "3–6 months" = 4.
@@ -652,7 +652,7 @@ All contracts in the trust surface were checked via Etherscan `getsourcecode` on
 - No incidents, exploits, or depegs — but also no stress event of any kind, no drawdown, and no liquidation cascade. The clean record carries little information at this age and size.
 - Both columns land on 4. **4.0.**
 
-**Score: 3.25/5** — (2.5 + 4.0) / 2 = 3.25. The audit work and bounty coverage are good, while the non-public reports and the market's limited age and scale keep the category above the low-risk bands.
+**Score: 3.0/5** — (2.0 + 4.0) / 2 = 3.0. Multiple reputable reviews plus the $1M all-production-contract bounty satisfy rubric row 2; the market's limited history remains the riskier half of this category.
 
 #### Category 2: Centralization & Control Risks (Weight: 30%)
 
@@ -724,14 +724,14 @@ Framed for an **FT Lend supplier**. Exit is protocol `withdraw` against availabl
 
 | Category | Score | Weight | Weighted |
 |----------|-------|--------|----------|
-| Audits & Historical | 3.25 | 20% | 0.650 |
+| Audits & Historical | 3.00 | 20% | 0.600 |
 | Centralization & Control | 3.50 | 30% | 1.050 |
 | Funds Management | 3.00 | 30% | 0.900 |
 | Liquidity Risk | 2.00 | 15% | 0.300 |
 | Operational Risk | 3.50 | 5% | 0.175 |
-| **Final Score** | | | **3.075** |
+| **Final Score** | | | **3.025** |
 
-**Final Score: 3.1** (3.075 weighted)
+**Final Score: 3.0** (3.025 weighted, displayed to one decimal)
 
 **Optional modifiers:** none apply. Protocol is <1 year old (no −0.5 for >2 years incident-free) and TVL is far below $500M (no −0.5 for scale).
 
@@ -747,7 +747,7 @@ Framed for an **FT Lend supplier**. Exit is protocol `withdraw` against availabl
 
 **Final Risk Tier: MEDIUM RISK — approved with enhanced monitoring.**
 
-The composite is 3.1, in the Medium band. The determining factors are:
+The composite is 3.0, in the Medium band. The determining factors are:
 
 - **Governance is the dominant term** (Category 2A at 5.0, carrying 10% of the total weight on its own). A 3/5 Safe with no timelock holds upgrade authority over every contract, arbitrary oracle-price authority, and a privileged path to authorize an ftUSD issuance module that need not enforce collateral. The current production mint path is collateralized and no evidence of privileged unbacked issuance was found, but no invariant survives an adverse governance action. Three Safes with one signer set provide no meaningful separation.
 - **Reflexive collateral.** 35.1% of TVL is the protocol's own ftUSD backing; ftUSD is 11.4% of this market's collateral; and ftUSD's price feed is blind to that backing, so an impairment would not surface in liquidation pricing. FT Lend and ftUSD cannot fail independently.
@@ -781,5 +781,5 @@ Offsetting these, and the reason this is not High Risk: the accounting is honest
 
 | Date | Score | Notes |
 | --- | --- | --- |
-| [September 4, 2026](https://github.com/yearn/risk-score/pull/237) | 3.1 | Bounty scope corrected; team-response wording and ftUSD Curve context refreshed; score unchanged |
+| [September 4, 2026](https://github.com/yearn/risk-score/pull/237) | 3.0 | $1M all-production-contract bounty scored at rubric row 2; team-response wording and ftUSD context refreshed |
 | [August 7, 2026](https://github.com/yearn/risk-score/pull/237) | 3.1 | Initial assessment |

--- a/reports/report/flying-tulip.md
+++ b/reports/report/flying-tulip.md
@@ -1,18 +1,18 @@
 # Protocol Risk Assessment: Flying Tulip — FT Lend (ftDNMM)
 
-- **Assessment Date:** August 7, 2026 (team-response update: September 4, 2026)
+- **Assessment Date:** August 7, 2026 (team-response and TRS update: September 4, 2026)
 - **Token:** FT Lend market — supply / borrow positions (internal balances, not tokenised)
 - **Chain:** Ethereum Mainnet
 - **Core Contract:** PositionsManager [`0xbe4050a73a7Fb384c65E885a15C33461A4B20055`](https://etherscan.io/address/0xbe4050a73a7Fb384c65E885a15C33461A4B20055)
 - **Final Score: 3.0/5.0**
-- **Medium Risk** — approved with enhanced monitoring. A 3-of-5 Safe with no timelock can upgrade every contract and override every price. **35.1% of the market's TVL is the protocol's own ftUSD backing collateral supplied back into itself**, and only three genuinely third-party addresses hold 96% of the remainder. The audit package was privately reviewed and is strong but remains non-public; a live $1M Sherlock bounty covers deployed Flying Tulip contracts through the dynamic production-contract list incorporated by its Additional Scope. See [Risk Score Assessment](#risk-score-assessment). (Also deployed on Sonic; this report covers Ethereum.)
+- **Medium Risk** — approved with enhanced monitoring. A 3-of-5 Safe with no timelock can upgrade every core protocol contract and override every price. **35.1% of the market's TVL is the protocol's own ftUSD backing collateral supplied back into itself**, and only three genuinely third-party addresses hold 96% of the remainder. The newly live TRS product uses this same account, borrowing, margin and liquidation infrastructure and adds permissioned RFQ execution, but does not change the score by itself. The audit package was privately reviewed and is strong but remains non-public; a live $1M Sherlock bounty covers deployed Flying Tulip contracts through the dynamic production-contract list incorporated by its Additional Scope. See [Risk Score Assessment](#risk-score-assessment). (Also deployed on Sonic; this report covers Ethereum.)
 - **Companion report:** ftUSD and staked ftUSD are assessed separately in **[Flying Tulip — ftUSD & Staked ftUSD](./flying-tulip-ftusd.md)**.
 
-> **Scope.** Yearn's interest (issue [yearn/risk-score#234](https://github.com/yearn/risk-score/issues/234)) is the risk of supplying ("just lend") and/or borrowing in the **FT Lend** market. This report covers the lending engine and the assets it touches. **Holding ftUSD and staking ftUSD are out of scope** and are assessed in the companion report [Flying Tulip — ftUSD & Staked ftUSD](./flying-tulip-ftusd.md). ftUSD appears here only as an accepted collateral asset and because the contract holding its backing is this market's largest supplier. Nothing in this report should be used to size an ftUSD or sftUSD position. The unrelated `tulip.garden` protocol on Solana is **not** Flying Tulip and is excluded. Original values were verified **June 7, 2026 at block `25264957`**; this revision re-verified everything on **August 6, 2026 at block `25697429`** via `cast` and Etherscan. Bug-bounty scope and Curve context were refreshed **September 4, 2026 at block `25903824`** in response to team comments.
+> **Scope.** Yearn's interest (issue [yearn/risk-score#234](https://github.com/yearn/risk-score/issues/234)) is the risk of supplying ("just lend") and/or borrowing in the **FT Lend** market. This report covers the lending engine and the assets it touches. TRS is covered only where its shared account, borrowing, execution and liquidation paths can affect FT Lend suppliers; the return profile of a direct TRS position is not separately scored. **Holding ftUSD and staking ftUSD are out of scope** and are assessed in the companion report [Flying Tulip — ftUSD & Staked ftUSD](./flying-tulip-ftusd.md). ftUSD appears here only as an accepted collateral asset and because the contract holding its backing is this market's largest supplier. Nothing in this report should be used to size an ftUSD or sftUSD position. The unrelated `tulip.garden` protocol on Solana is **not** Flying Tulip and is excluded. Original values were verified **June 7, 2026 at block `25264957`**; this revision re-verified everything on **August 6, 2026 at block `25697429`** via `cast` and Etherscan. Bug-bounty scope, Curve context and the live Ethereum TRS configuration were refreshed **September 4, 2026**, with TRS engine registration verified through block `25904682`.
 
 ## Overview + Links
 
-**Flying Tulip** is Andre Cronje's "on-chain financial system that standardizes pricing, credit, and risk across a suite of products" — a hybrid AMM-CLOB spot exchange, a lending market (FT Lend), perpetual futures, and a yield stablecoin (ftUSD). The products share collateral and pricing so "a single deposit can back a loan, serve as collateral for a limit order, and support a future position simultaneously."
+**Flying Tulip** is Andre Cronje's "on-chain financial system that standardizes pricing, credit, and risk across a suite of products" — an integrated lending market, spot/RFQ execution, Total Return Swaps (TRS), and a yield stablecoin (ftUSD). The products share collateral and pricing so the same account can supply assets, borrow, swap collateral, and support leveraged exposure.
 
 **FT Lend** (the contract suite is labelled **ftDNMM** in the protocol's address registry) works as follows:
 
@@ -21,18 +21,19 @@
 - **Borrow side.** Borrowers post collateral and borrow against it. **LTV is dynamic and snapshotted** at position open based on AMM depth and multi-timeframe volatility. Onchain, each asset carries a **maintenance-margin rate (`mmBps`)** in the `ConfigRegistry`, and account health is enforced against `marginHfTargetBps`/`marginHfSafeBps`.
 - **Pricing.** An onchain `OracleRouterChainlink` — Chainlink-anchored, with Aave-style adapters for WBTC and wstETH, and a protocol-internal redemption oracle for ftUSD.
 - **Liquidations.** Module-gated through `RfqEngine` (`rfqFill` / `rfqFillFlash` → `liquidateFlash`), designed as time-sliced / RFQ-routed soft liquidations. Anyone can liquidate using partial liquidation.
+- **TRS / leveraged execution.** [TRS](https://blog.flyingtulip.com/introducing-total-return-swaps-trs-perps-built-differently/) is now live on Ethereum. It constructs long/short exposure by borrowing through FT Lend, executing against spot liquidity through RFQ, and retaining collateral, debt and P&L in the same margin account; ftUSD is a settlement asset. There is no separate perp order book or insurance fund.
 
 **Links:**
 
 - [Protocol Documentation](https://docs.flyingtulip.com/) · [FT Lend docs](https://docs.flyingtulip.com/product-suite/ft-lend/) · [Contract Addresses](https://docs.flyingtulip.com/contract-addresses/) · [Risks page](https://docs.flyingtulip.com/risks/)
-- [App](https://flyingtulip.com/) · [Lend dashboard](https://flyingtulip.com/lend/dashboard/) · [Blog](https://blog.flyingtulip.com/)
+- [App](https://flyingtulip.com/) · [Lend dashboard](https://flyingtulip.com/lend/dashboard/) · [TRS app](https://flyingtulip.com/trs/swap/) · [TRS overview](https://blog.flyingtulip.com/introducing-total-return-swaps-trs-perps-built-differently/) · [Blog](https://blog.flyingtulip.com/)
 - [GitHub org `flyingtulipdotcom`](https://github.com/flyingtulipdotcom) (only `ft`, `escrow`, `supporter-whitelist` are public; the lending/ftUSD repos are private)
 - [DeFiLlama — Flying Tulip](https://defillama.com/protocol/flying-tulip) (slug `flying-tulip`)
 - [Sherlock bug bounty #248](https://audits.sherlock.xyz/bug-bounties/248) · [Sherlock contest #1223 (ftPUT)](https://audits.sherlock.xyz/contests/1223) · [CoinList sale](https://coinlist.co/flying-tulip)
 
 ## Contract Addresses
 
-All addresses verified onchain at block `25675412` (August 3, 2026). Every contract listed is **source-verified on Etherscan**, including each proxy implementation.
+Original addresses were verified onchain at block `25675412` (August 3, 2026); the TRS additions below were verified September 4 through block `25904682`. Core lending contracts and the two new engine implementations are source-verified. The EIP-7702 executor's delegated implementation was not verified on Etherscan or Blockscout at the check and is called out separately.
 
 ### Core Lending Contracts (Ethereum)
 
@@ -41,8 +42,10 @@ All addresses verified onchain at block `25675412` (August 3, 2026). Every contr
 | PositionsManager | [`0xbe4050a73a7Fb384c65E885a15C33461A4B20055`](https://etherscan.io/address/0xbe4050a73a7Fb384c65E885a15C33461A4B20055) | UUPS proxy | [`0xaa3d5fc8…a23b`](https://etherscan.io/address/0xaa3d5fc84b43219391539714be5f0681aefca23b) |
 | ConfigRegistry | [`0xA8777c3D446fa7F0b0FC97a80C1Ea1d37F1ca33E`](https://etherscan.io/address/0xA8777c3D446fa7F0b0FC97a80C1Ea1d37F1ca33E) | UUPS proxy | [`0xd25f964e…47e5`](https://etherscan.io/address/0xd25f964ead7bfbf07858b5bfede58f11a5a947e5) |
 | PMWrapper (PM admin) | [`0xBDD80028c9e4b9A2D268D2cF62Fb54Ec8697C68B`](https://etherscan.io/address/0xBDD80028c9e4b9A2D268D2cF62Fb54Ec8697C68B) | admin wrapper | — |
-| RfqEngine (**sole liquidation module**) | [`0xEB00B335Ca52216Fb60fdFFA361397367C39Dc32`](https://etherscan.io/address/0xEB00B335Ca52216Fb60fdFFA361397367C39Dc32) | engine | — |
-| LeverageRfqEngine | [`0x8263a07504d93cB95e0a74f3627bb15faaf140e2`](https://etherscan.io/address/0x8263a07504d93cB95e0a74f3627bb15faaf140e2) | engine | — |
+| RfqEngine (legacy liquidation module) | [`0xEB00B335Ca52216Fb60fdFFA361397367C39Dc32`](https://etherscan.io/address/0xEB00B335Ca52216Fb60fdFFA361397367C39Dc32) | engine + liquidation module | — |
+| LeverageRfqEngine (legacy / ftUSD hedge) | [`0x8263a07504d93cB95e0a74f3627bb15faaf140e2`](https://etherscan.io/address/0x8263a07504d93cB95e0a74f3627bb15faaf140e2) | engine | — |
+| **RfqEngine v2 (Trade / liquidation)** | [`0xc64516d58f8b83bc256448bc69d7bf2361557fdb`](https://etherscan.io/address/0xc64516d58f8b83bc256448bc69d7bf2361557fdb) | ERC-1967 proxy; engine + liquidation module | [`0xD5b3B315…4bB4`](https://etherscan.io/address/0xD5b3B315635A8c3c56b8284b6927573b2F554bB4) |
+| **LeverageRfqEngine v2 (TRS)** | [`0x93496075909f56d93b33302DF5D1655568Eb6e70`](https://etherscan.io/address/0x93496075909f56d93b33302DF5D1655568Eb6e70) | UUPS proxy; engine | [`0x6595C190…8734`](https://etherscan.io/address/0x6595C1907df6cC7ae81a80C5DcaaB43FD9068734) |
 | MetaActions | [`0x3633eb60d08756674472e2d34d6ffb5f4c1c29f2`](https://etherscan.io/address/0x3633eb60d08756674472e2d34d6ffb5f4c1c29f2) | engine + meta-module | — |
 | MetaSessionActions | [`0x4f83ac5c8a79986d0916a8849730d9cef63a3497`](https://etherscan.io/address/0x4f83ac5c8a79986d0916a8849730d9cef63a3497) | engine + meta-module | — |
 | RelayerAuth | [`0x823a97a2c32985e0f5457fc8103F36698D1F53F4`](https://etherscan.io/address/0x823a97a2c32985e0f5457fc8103F36698D1F53F4) | session layer | — |
@@ -51,6 +54,16 @@ All addresses verified onchain at block `25675412` (August 3, 2026). Every contr
 | Stable IRM | [`0x3253739A68640E308c8209384bb44E4ADA38710d`](https://etherscan.io/address/0x3253739A68640E308c8209384bb44E4ADA38710d) | `pure` rate model | — |
 | Major IRM | [`0x07eC8583B1bC7D97646409a2b51DdBed6725D12F`](https://etherscan.io/address/0x07eC8583B1bC7D97646409a2b51DdBed6725D12F) | `pure` rate model | — |
 | LongTail IRM | [`0x09cd852f47aCa224eE6B4AccC29BD2694F29Ef69`](https://etherscan.io/address/0x09cd852f47aCa224eE6B4AccC29BD2694F29Ef69) | `pure` rate model | — |
+
+### Live TRS Execution Contracts (Ethereum)
+
+| Contract | Address | Role |
+|---|---|---|
+| SessionManager v2 | [`0x880A371CE2C5Dbb2EB47EC0023b358e8aE80071b`](https://etherscan.io/address/0x880A371CE2C5Dbb2EB47EC0023b358e8aE80071b) | Delegated session authorization used by the live TRS frontend |
+| LeverageRfqBatchModule | [`0x91Ecc9c9E9B32fe198a3e2c7F2FCB27C0A57Bf24`](https://etherscan.io/address/0x91Ecc9c9E9B32fe198a3e2c7F2FCB27C0A57Bf24) | Batch-matches leverage orders; delegate-called by the TRS engine |
+| Permissioned executor | [`0xa505815A526f1200c17B7ffaE0067318d734b9d8`](https://etherscan.io/address/0xa505815A526f1200c17B7ffaE0067318d734b9d8) | Authorized RFQ filler; EIP-7702 delegates to [`0x4428809A…a5c`](https://etherscan.io/address/0x4428809A80082E826FA336521258973Da1251a5c), whose source was not verified at the check |
+
+The live [TRS API](https://api.flyingtulip.com/trs/) identifies the v2 engine, session manager and executor above. Onchain, `LeverageRfqEngine.permissionedFillers(executor)` is `true`, the Admin Safe is also an authorized filler, and both new engines were registered on `PositionsManager` in block `25812534` (August 22, 2026). This is a material post-snapshot privilege change, not merely a frontend release.
 
 ### ftUSD Contracts (summary — see the dedicated report)
 
@@ -276,11 +289,11 @@ Settlement history by asset (latest settled epoch, read from `astate` and `epoch
 
 Three structural observations:
 
-- **Not keeper-protected — module-gated and mostly permissionless.** `PositionsManager.liquidateFlash` is callable only by the registered module (`RfqEngine`), but `RfqEngine.rfqFill` / `rfqFillFlash` themselves have **no general liquidator whitelist**. Anyone can liquidate a normal underwater account. The only exception is `privilegedAccounts`: those may be liquidated only by `permissionedLiquidators`. Today the sole privileged account is the ftUSD strategy [`0xe0E445…1A59`](https://etherscan.io/address/0xe0E445967256EE60111e243e0F0F94DD1D351A59), and **zero** permissioned liquidators are set — so that account is currently unliquidatable via this path. No `rfqFill*` / `liquidateFlash` execution has occurred yet.
+- **Two RFQ liquidation modules now exist.** The legacy module remains mostly permissionless for normal underwater accounts; its sole privileged account, the ftUSD strategy [`0xe0E445…1A59`](https://etherscan.io/address/0xe0E445967256EE60111e243e0F0F94DD1D351A59), has no permissioned liquidator there. The v2 module [`0xc645…7fdb`](https://etherscan.io/address/0xc64516d58f8b83bc256448bc69d7bf2361557fdb) was authorized on August 22, also marks that strategy privileged, and authorizes the Admin Safe as both ordinary and privileged liquidator. The strategy is therefore no longer unliquidatable across all available paths, but its v2 liquidation availability depends on the same Safe that governs it.
 - **No liq bonus or close factor in `PositionsManager`.** Seize/repay sizing lives in `RfqEngine` (onchain module, not the core ledger). Core only requires HF ≥1.25 after — bounds under-liquidation, not how much collateral value the borrower loses per unit of debt repaid.
 - **The insolvency exception is an explicit bad-debt path.** It permits a position to end with all collateral seized and debt outstanding. The debt remains technically repayable, but without collateral there is no liquidator incentive or funded backstop; unless the borrower or protocol supplies the missing asset, the economic shortfall falls on suppliers against reserves of essentially zero.
 
-Because the liquidation module is swappable by the admin (`setLiquidationModule`), the economics of liquidation are a governance parameter, not a code invariant. To date the module has never been changed since deployment.
+Because liquidation modules are admin-authorized through `setLiquidationModule`, liquidation access and economics are governance parameters, not code invariants. The allowed set expanded post-launch from one module to two. Both currently expose a 7.5% maximum bonus and 10% protocol share of that bonus, but either implementation or authorization can change without a timelock.
 
 ### Reflexive supply: ftUSD backing lent into FT Lend
 
@@ -310,7 +323,7 @@ Full derivation of the backing chain, the collateral reconciliation, the strateg
 | Supply to FT Lend | permissionless | yes, same tx | none | per-asset `supplyCap` |
 | Withdraw from FT Lend | permissionless | yes, if wrapper liquidity available | none | `withdrawPaused`, CircuitBreaker, available liquidity |
 | Borrow | permissionless, over-collateralized | yes | interest per IRM | `borrowCap`, `mmBps`, HF ≥ 1.25, $250 min equity |
-| Liquidate | **module-gated** (`RfqEngine.rfqFill`/`rfqFillFlash`); callers permissionless except for `privilegedAccounts` | yes | module-defined (`liqBonusBps` etc. on `RfqEngine`) | HF < 1.25 |
+| Liquidate | **module-gated** through either authorized `RfqEngine`; legacy callers permissionless except for `privilegedAccounts`, v2 has permissioned liquidator roles | yes | module-defined (`liqBonusBps` etc.) | HF < 1.25 |
 
 There are **no withdrawal queues, cooldowns, or lockups** on the lending path in normal operation — a genuine strength, and a real difference from the staked-ftUSD product, which is rate-limited. All gating here is either liquidity-based or admin-flippable.
 
@@ -326,8 +339,8 @@ The relevant mint authority is ftUSD's, because ftUSD is 11.4% of this market's 
 
 - **Backing.** Borrowing is over-collateralized and enforced onchain via per-asset maintenance margins (`ConfigRegistry.assetCfg`) and account health (Hf - health factor): `marginHfSafeBps = 15000` (1.50), `marginHfTargetBps = 12500` (1.25), `marginMinEquityUSDWad = 250e18` ($250 minimum position equity).
 - **Collateral quality.** Blue-chip (WETH, WBTC, wstETH, USDC, USDT) plus ftUSD. The blue-chip leg is genuinely high quality; ftUSD (11.4% of TVL) carries the reflexivity above.
-- **Maintenance margins are thin on stables.** `mmBps = 150` implies a 1.5% maintenance floor — ~66× theoretical leverage before the dynamic-LTV haircut. The protocol states effective LTV is reduced from this floor by AMM depth and volatility and snapshotted at position open, but that reduction is computed off the Spot AMM/CLOB and is **not independently verifiable onchain**. The floor is what the contract enforces.
-- **Liquidations.** Onchain, module-gated through `RfqEngine` [`0xEB00B335…Dc32`](https://etherscan.io/address/0xEB00B335Ca52216Fb60fdFFA361397367C39Dc32) (`rfqFill` / `rfqFillFlash` → `liquidateFlash`; set at deployment, never changed). **Not keeper-whitelisted** — any address may call those entrypoints for normal accounts; only `privilegedAccounts` require `permissionedLiquidators`. Time-sliced / RFQ-routed by design, novel and untested at scale. Per the team's own accepted-risk list there is **no protocol-level loss backstop / insurance fund** for bad debt.
+- **Maintenance margins are thin on stables.** `mmBps = 150` implies a 1.5% maintenance floor. The documented AMM-depth/volatility dynamic-LTV haircut is not implemented in the deployed `ConfigRegistry` or `PositionsManager`; the admin-set constant and account-health target are what the contracts enforce. TRS therefore adds live leveraged use without adding the documented dynamic risk input.
+- **Liquidations.** Onchain, module-gated through the legacy `RfqEngine` [`0xEB00B335…Dc32`](https://etherscan.io/address/0xEB00B335Ca52216Fb60fdFFA361397367C39Dc32) and v2 [`0xc64516d5…7fdb`](https://etherscan.io/address/0xc64516d58f8b83bc256448bc69d7bf2361557fdb), added August 22. Both are RFQ-routed, module-defined and untested at scale. The v2 path introduces permissioned liquidator roles and makes the Admin Safe the privileged liquidator for the ftUSD strategy. Per the team's own accepted-risk list there is **no protocol-level loss backstop / insurance fund** for bad debt.
 - **Reserves are negligible.** `astate.reserves` across all assets: 7.72 USDC, 13.16 USDT, 0.0000257 WETH, 303.01 ftUSD, 0 WBTC. There is effectively no protocol-side buffer to absorb a shortfall.
 - **Curation.** The 3/5 Safe sets every risk parameter — which assets are enabled/collateral/borrowable, maintenance margins, supply/borrow caps, IRMs, and the oracle.
 
@@ -422,18 +435,24 @@ With **no delay**, the 3/5 Safe can: upgrade any contract to arbitrary code, cha
 
 ### Privileged engines and modules
 
-Four contracts are whitelisted on the `PositionsManager` and can move user balances via `engineDebitAllowanceOf` / `engineHeld`. All were set in the **deployment block `24974967`** and none has changed since — a genuine positive (no post-launch privilege drift):
+Six contracts are now whitelisted on the `PositionsManager` and can move user balances subject to user/session approvals through `engineDebitAllowanceOf` / `engineHeld`. The original four were set in deployment block `24974967`; the v2 Trade and TRS engines were added in block `25812534` on August 22. The earlier conclusion that engine privileges had not changed since launch is therefore no longer true:
 
 | Contract | Address | Engine | MetaModule | Liquidation module |
 |---|---|:---:|:---:|:---:|
-| `RfqEngine` | [`0xEB00B335…Dc32`](https://etherscan.io/address/0xEB00B335Ca52216Fb60fdFFA361397367C39Dc32) | ✓ | — | **✓ (sole)** |
-| `LeverageRfqEngine` | [`0x8263a075…40e2`](https://etherscan.io/address/0x8263a07504d93cB95e0a74f3627bb15faaf140e2) | ✓ | — | — |
+| `RfqEngine` (legacy) | [`0xEB00B335…Dc32`](https://etherscan.io/address/0xEB00B335Ca52216Fb60fdFFA361397367C39Dc32) | ✓ | — | ✓ |
+| `LeverageRfqEngine` (legacy) | [`0x8263a075…40e2`](https://etherscan.io/address/0x8263a07504d93cB95e0a74f3627bb15faaf140e2) | ✓ | — | — |
 | `MetaActions` | [`0x3633eb60…29f2`](https://etherscan.io/address/0x3633eb60d08756674472e2d34d6ffb5f4c1c29f2) | ✓ | ✓ | — |
 | `MetaSessionActions` | [`0x4f83ac5c…3497`](https://etherscan.io/address/0x4f83ac5c8a79986d0916a8849730d9cef63a3497) | ✓ | ✓ | — |
+| `RfqEngine` v2 | [`0xc64516d5…7fdb`](https://etherscan.io/address/0xc64516d58f8b83bc256448bc69d7bf2361557fdb) | ✓ | — | ✓ |
+| `LeverageRfqEngine` v2 | [`0x93496075…6e70`](https://etherscan.io/address/0x93496075909f56d93b33302DF5D1655568Eb6e70) | ✓ | — | — |
+
+The v2 leverage engine handles OPEN, CLOSE and collateral-SWAP orders. Its verified implementation requires a user or session signature, consumes borrow/engine allowances, enforces the signed minimum buy amount and checks the account health factor after execution. It also restricts fills to admin-selected `permissionedFillers`; currently the Admin Safe and the EIP-7702 executor are authorized. That is not direct custody of every lender balance, but it centralizes order availability and execution routing and adds a new way leveraged activity can create debt requiring liquidation.
+
+**Execution timing is bounded by expiry, not guaranteed settlement.** The current frontend signs TRS orders with `validTo = now + 3,600 seconds`. The engine rejects a fill only once `block.timestamp > validTo` and defines no relative minimum or maximum lifetime, so an admin/frontend revision could choose another deadline. A quote can fill in seconds and settles atomically in the fill transaction; an unmatched order may remain pending until cancelled or expiry. There is no protocol guarantee that an RFQ receives a bid within the one-hour window.
 
 ### Programmability
 
-Lending accounting (supply/borrow indices, health factors) is onchain and the oracle is Chainlink-anchored — good. The offchain/operator surface is nonetheless substantial: an RFQ/relayer/session layer (`RelayerAuth` [`0x823a97a2…53F4`](https://etherscan.io/address/0x823a97a2c32985e0f5457fc8103F36698D1F53F4), `SessionManager` [`0xF9f3ddF2…60f8`](https://etherscan.io/address/0xF9f3ddF2E96Cabef94e2634c326DC6dde99360f8), `MetaActions`/`MetaSessionActions`), a module-gated but mostly permissionless RFQ liquidation path, admin-settable oracle prices, epoch settlement by a privileged collector, and — uniquely here — a **discretionary strategy contract that decides where ftUSD's backing sits**.
+Lending accounting (supply/borrow indices, health factors) is onchain and the oracle is Chainlink-anchored — good. The offchain/operator surface is nonetheless substantial: the legacy RFQ/relayer/session layer, the new TRS `SessionManager`, permissioned fillers, the EIP-7702 executor, external quote/routing services, RFQ liquidation, admin-settable oracle prices, epoch settlement by a privileged collector, and — uniquely here — a **discretionary strategy contract that decides where ftUSD's backing sits**. TRS execution is signed and health-checked onchain, but order discovery, route construction and timely fills remain operational dependencies.
 
 ### External Dependencies
 
@@ -441,16 +460,18 @@ Lending accounting (supply/borrow indices, health factors) is onchain and the or
 - **Chainlink** — **low counterparty risk**. Canonical feeds price solvency for USDC/USDT/ETH; WBTC/wstETH use Chainlink bases plus Aave's audited peg/cap adapters (immutable). Ordinary residual: single feed per asset, no fallback oracle. The high-impact price risk in this system is the admin `setLastGoodPrice` override, scored under Governance — not Chainlink itself.
 - **Aave price adapters** — `CLSynchronicityPriceAdapterPegToBase` (WBTC) and `WstETHPriceCapAdapter` (wstETH) sit in the pricing path for 39.5% of TVL; sound, audited construction.
 - **FT Lend itself (reflexive)** — ftUSD's backing (~$4.38M) is supplied into this market by the Delta-Neutral strategy, and ftUSD is also accepted as collateral here, so the stablecoin and the money market cannot fail independently. See [Reflexive supply](#reflexive-supply-ftusd-backing-lent-into-ft-lend). This is the unusual dependency — not Spark/Aave/Chainlink.
-- **The Spot AMM / CLOB — verified absent from the deployed contracts.** The docs describe dynamic LTV "snapshotted from AMM depth and volatility," and earlier revisions of this report carried that as an unverified critical dependency. It is not wired in. `ConfigRegistry`'s entire risk surface is `assetCfg` (IRM, `mmBps`, enabled/borrowable/collateral flags, wrapper), the three margin thresholds and the oracle pointer — **no depth input, no volatility input, no LTV machinery**. The `PositionsManager` contains no AMM or order-book reference beyond a comment on the `engines` mapping (`// PositionsManager, RFQ, ftLP, OrderBook, AMM, etc`), and all four registered engines are RFQ/meta-action contracts. The `RfqEngine`'s only "Uniswap" string is an MIT licence header on a copied math library. *Caveat: the lending repos are private, so this is established from deployed ABIs, source and event logs, not from the team's source of truth.*
+- **TRS / Trade execution — now wired into FT Lend.** The new `RfqEngine` and `LeverageRfqEngine` are registered directly on the assessed `PositionsManager`; the former is also an approved liquidation module. TRS therefore reuses lender-funded borrowing and account-level margin rather than operating as an isolated perp venue. It can increase utilization and the volume of accounts that must be liquidated, while successful liquidations still depend on executable RFQ bids.
+- **External execution venues.** The live configuration exposes KyberSwap, Velora and 0x routes, plus internal self-fill and ftUSD `MintAndRedeem` adapters. A route failure, API outage or loss of permissioned-filler availability can prevent a trade or delay a close; it does not by itself transfer lender assets. The signed minimum output and post-fill health check are the onchain protections. `pricingFailureMode = fail_open` in the frontend session configuration warrants monitoring because route/pricing-service failure handling is partly offchain.
+- **Dynamic LTV remains absent.** Although Trade/TRS now sources execution from spot liquidity, the deployed `ConfigRegistry` and `PositionsManager` still have no AMM-depth, order-book-depth or volatility input. `mmBps` and the account health thresholds remain admin-set constants. The existence of the new execution engines must not be confused with implementation of the documented dynamic-LTV model.
 - **Lido / wstETH** — a live component of the Delta-Neutral strategy's hedge at the August 6 snapshot (76.54 wstETH financed by 95.01 WETH debt).
-- **Curve** — a StableSwap-NG [ftUSD/USDC pool](https://etherscan.io/address/0xafec61e7a604f8f81f7cab64ec75bfa07c542630) is the **only secondary-market** exit and external ftUSD price reference. Primary exit is protocol redemption. After the former dominant EOA exited on August 28, pool liquidity fell by more than 85% to ~$249K. Current gauge custody is 87.1% through the Convex voter proxy, 7.1% through an EOA, and 5.6% through `CurveYCRVVoter`; Convex aggregation does not establish beneficial ownership. Full analysis in the [ftUSD report](./flying-tulip-ftusd.md).
+- **Curve** — a StableSwap-NG [ftUSD/USDC pool](https://etherscan.io/address/0xafec61e7a604f8f81f7cab64ec75bfa07c542630) is the independently executable secondary market and external ftUSD price reference. Primary exit is protocol redemption. TRS also exposes ftUSD swap routes, but those are conditional RFQ/adapter routes and are not counted as independent liquidity without a funded executable quote. After the former dominant EOA exited on August 28, pool liquidity fell by more than 85% to ~$249K. Current gauge custody is 87.1% through the Convex voter proxy, 7.1% through an EOA, and 5.6% through `CurveYCRVVoter`; Convex aggregation does not establish beneficial ownership. Full analysis in the [ftUSD report](./flying-tulip-ftusd.md).
 
 ## Operational Risk
 
 - **Team:** Founder **Andre Cronje** (public; founded Yearn, Keep3r, co-founded Sonic/Fantom) strong founder, but mixed reputation on other projects.
 - **Legal entity / jurisdiction:** **NOT FOUND** / undisclosed (docs reference a "Foundation" with no domicile). CoinList sale excluded the US, Canada and ~21 other jurisdictions.
 - **Funding:** ~$200M seed (Sep 2025, $1B FDV), ~$25.5M Series A (Jan 2026), public sale; the official sale-update blog reports total raised ≈ **$184M** (below the "$200M seed" headline — a reconciliation gap). FT token (Aug 3, 2026): max supply 10B, mainnet `totalSupply()` **1,197,190,528**, circulating ~547M, price ~**$0.0994**, **market cap ~$54.5M**, FDV ~$119M ([CoinGecko](https://www.coingecko.com/en/coins/flying-tulip)). FT is an OFT, so mainnet supply is not the cross-chain total.
-- **Documentation vs. reality gap.** Beyond the usual omissions (oracle design, risk parameters, multisig setup), the public material does not clearly disclose that **ftUSD's backing is lent into FT Lend**. The hedge was inactive at the June snapshot and active by August 6, showing that strategy state can change materially between reviews. The docs' own transparency principle commits to publishing audit reports, which has not happened.
+- **Documentation vs. reality gap.** Beyond the usual omissions (oracle design, risk parameters, multisig setup), the public material does not clearly disclose that **ftUSD's backing is lent into FT Lend**. The hedge was inactive at the June snapshot and active by August 6, showing that strategy state can change materially between reviews. TRS's public launch article explains the high-level Lend/Trade/ftUSD relationship, but operational parameters such as the permissioned executor, route set and order lifetime are exposed through the live app/API and contracts rather than durable documentation. The docs' own transparency principle commits to publishing audit reports, which has not happened.
 - **Incident response:** the docs claim "continuous monitoring and formal incident runbooks" and list "incident post-mortems" as a published artefact. **No runbook, no post-mortem, and no security contact are public**, and there have been no incidents to test the claim. Onchain emergency capability genuinely exists and is broad — per-asset pause, the `CircuitBreaker`, guardian `disablePrice`, ftUSD `pause` and `blacklist`. The live Sherlock bounty provides a public reporting channel covering deployed Flying Tulip production contracts through the dynamic contract list incorporated by its Additional Scope; Safe Harbor enrolment remains absent.
 - **Other deployments:** Flying Tulip also runs on **Sonic**, which DeFiLlama puts at **$0.52M — 3.8%** of protocol TVL against Ethereum's $12.99M ([API](https://api.llama.fi/protocol/flying-tulip)). It is a separate deployment: none of the contracts assessed here exists on Sonic, so **nothing in this report transfers to it**, and no Ethereum position is exposed to it. Deliberately out of scope rather than pending — a Sonic allocation would need its own assessment, and at 3.8% of a $13M protocol that is not currently worth the effort.
 - **Governance transparency:** no DAO, no forum/Snapshot, multisig signer identities undisclosed.
@@ -477,6 +498,9 @@ Recommended frequency: **hourly** for pause/circuit-breaker, oracle overrides, a
 | MintAndRedeem | [`0xAa48EcBC…D23C`](https://etherscan.io/address/0xAa48EcBC843cF7E9A29155D112b8Cb27902bD23C) | `addCollateral`, `setCollateralCapFtUSD`, fee changes, `sweepExcess`, `recoverERC20` |
 | **Delta-Neutral strategy** | [`0xe0E44596…1A59`](https://etherscan.io/address/0xe0E445967256EE60111e243e0F0F94DD1D351A59) | **Reflexivity ratio** — its FT Lend position as % of TVL; any move of ftUSD backing to a new venue |
 | FT Lend yield wrappers ×7 | see Funds Management table | `setStrategy`/`confirmStrategy` (no delay!), `setCircuitBreaker`, `execute`, available liquidity |
+| **TRS LeverageRfqEngine v2** | [`0x93496075…6e70`](https://etherscan.io/address/0x93496075909f56d93b33302DF5D1655568Eb6e70) | `Upgraded`, `AdminTransferred`, `PermissionedFillerUpdated`, session/batch-module changes, orders and fills |
+| **RfqEngine v2** | [`0xc64516d5…7fdb`](https://etherscan.io/address/0xc64516d58f8b83bc256448bc69d7bf2361557fdb) | Upgrades, RFQ liquidations and fee-parameter changes; now an engine and liquidation module |
+| TRS SessionManager / executor | [`0x880A371C…071b`](https://etherscan.io/address/0x880A371CE2C5Dbb2EB47EC0023b358e8aE80071b) / [`0xa505815A…b9d8`](https://etherscan.io/address/0xa505815A526f1200c17B7ffaE0067318d734b9d8) | Session creation/revocation/expiry; executor delegation code, availability and route outcomes |
 
 ### Governance monitoring — immediate alert, no timelock means zero warning
 
@@ -487,7 +511,7 @@ Recommended frequency: **hourly** for pause/circuit-breaker, oracle overrides, a
 | `AddedOwner` / `RemovedOwner` / `ChangedThreshold` | all three Safes | Signer-set change on the root of trust |
 | `MinterConfigured` / `MinterRemoved` / `MasterMinterChanged` | ftUSD | Privileged mint-authority change; verify that the resulting path enforces collateral |
 | module enablement | ftUSD Core | Verify immediately whether the new module independently enforces collateral before minting |
-| `EngineSet` / `MetaModuleSet` / `LiquidationModuleSet` | PositionsManager | Changes who can move user balances or set liquidation economics. **None has fired since the deploy block — any occurrence is novel** |
+| `EngineSet` / `MetaModuleSet` / `LiquidationModuleSet` | PositionsManager | Changes who can move approved user balances or set liquidation economics. Two engines and one liquidation-module authorization were added in block `25812534`; alert on every further occurrence |
 
 ### Oracle monitoring
 
@@ -508,8 +532,17 @@ Recommended frequency: **hourly** for pause/circuit-breaker, oracle overrides, a
 
 - Poll each funded wrapper's `deployed()` and `capital()`. They are currently equal — alert if Spark or Aave utilization exceeds 95% while that holds, which is the precise condition under which lender exits begin to fail.
 - Poll `astate(asset).cash` per asset as the true instantaneous exit capacity.
+- Attribute new borrowing and utilization to TRS where events permit. A sharp rise in TRS open interest can consume the same cash needed by ordinary FT Lend withdrawals; a TRS swap screen is not a substitute exit for a lender's internal supply balance.
 - Alert on `setWithdrawPaused`, `setDepositPaused`, `setBorrowPaused`, any CircuitBreaker trip, `setCircuitBreaker` (especially to `address(0)`), and any flip of `marginRestrictWithdrawToSettlement` or `marginWithdrawRequiresNoDebt` to `true`.
 - Alert on `setStrategy` / `confirmStrategy` on any wrapper — `strategyDelayConfig` is `0`, so these can land in the same block with no warning.
+
+### TRS / RFQ execution monitoring
+
+- Alert immediately on `PermissionedFillerUpdated`, `AdminTransferred`, `SessionManagerSet`, batch-module changes, or `Upgraded` on the v2 leverage engine. Re-read executor bytecode after any EIP-7702 delegation change.
+- Track `OrderBroadcast`, `PendingOrderOpened`, `OrderCancelled`, `OrderFill`, and `LeverageFillSettled`. Measure quote-to-fill latency, expired/unfilled share, partial fills, and realised output versus the signed minimum and contemporaneous external spot price.
+- Poll the live configuration for engine, session-manager, executor, aggregator-code, `minBuyAmountBps` and `pricingFailureMode` changes. At the September 4 check the defaults were 8,000 bps and `fail_open`; these are frontend/session guardrails, not immutable engine constants.
+- Track fill routes separately: KyberSwap, Velora, 0x, internal self-fill, `mintredeem`, and composite ftUSD routes. Alert if retired/test/unknown codes execute in production, if one venue dominates, or if an external route fails repeatedly.
+- Monitor TRS accounts' health and liquidations alongside ordinary borrowers. Alert if v2 `RfqEngine` liquidations fail to restore target health, if collateral seizure/repayment diverges from previews, or if bad debt/reserves move after a TRS liquidation.
 
 ### Position and solvency monitoring
 
@@ -527,6 +560,7 @@ Recommended frequency: **hourly** for pause/circuit-breaker, oracle overrides, a
 - **Concentration:** track [`0xef6953…ae0d`](https://etherscan.io/address/0xef6953954e9c753da43da41136d41a754cd5ae0d) (38% of supply, 73% of debt), [`0x666130…701c`](https://etherscan.io/address/0x66613091b75e54954f77746e160c98391f99701c), [`0x0d5dc6…4e83`](https://etherscan.io/address/0x0d5dc686d0a2abbfdafdfb4d0533e886517d4e83) via `getBalance`; alert on any withdrawal >25% of a position.
 - **Exit capacity:** alert if wrapper `deployed()` remains equal to `capital()` while Spark or Aave utilization exceeds 95% — that is the condition under which exits fail.
 - **Solvency:** monitor liquidations and `astate.reserves` (currently negligible); alert on any bad-debt socialization event.
+- **TRS execution:** alert on any permissioned-filler or executor-delegation change, >10% expired/unfilled orders over 24h, repeated quote failures, or realised output materially below contemporaneous external spot after fees.
 
 ## Appendix A: Contract Architecture
 
@@ -548,10 +582,11 @@ TOKEN / STABLE LAYER                                   PositionsManager (UUPS)
                                     │                   │    ├─ wstETH → CL ETH/USD + Aave cap adapter
                                     │                   │    └─ ftUSD → MintAndRedeem redeem factor ⟲
                                     │                   ├─ IRMs: Stable / Major / LongTail
-                                    │                   ├─ engines: RfqEngine* / LeverageRfqEngine
-                                    │                   │           MetaActions / MetaSessionActions
-                                    │                   │           (*sole liquidation module)
-                                    │                   ├─ session: RelayerAuth / SessionManager
+                                    │                   ├─ engines: legacy RFQ/leverage + MetaActions
+                                    │                   │           v2 RfqEngine* + TRS LeverageRfqEngine
+                                    │                   │           (*second liquidation module)
+                                    │                   ├─ sessions: legacy + TRS SessionManager
+                                    │                   ├─ TRS permissioned executor (EIP-7702)
                                     │                   └─ CircuitBreaker (owned by Admin Safe)
                                     │                          ▲
    ftUSD-USDC wrapper 0x6aaf…837D ──┤                          │
@@ -565,11 +600,17 @@ LEND SUPPLY ROUTING (third-party lenders)          UNDERLYING YIELD
   USDC / USDT / WETH wrappers ──────────────────►  Spark   (deployed == capital, no buffer)
   WBTC wrapper ─────────────────────────────────►  Aave    (deployed == capital, no buffer)
   ftUSD / wstETH / FT wrappers ─────────────────►  no strategy configured
+
+TRS / TRADE (live post-snapshot)
+  signed OPEN / CLOSE / SWAP ─► permissioned RFQ executor ─► Kyber / Velora / 0x
+                 │                         ├─ internal self-fill
+                 │                         └─ ftUSD mint/redeem + composite routes
+                 └──────────────► same PM balances, borrows, health checks and liquidations
 ```
 
 ## Appendix B: Source-verification check
 
-All contracts in the trust surface were checked via Etherscan `getsourcecode` on August 3, 2026. **Every one is source-verified**, so the "Unverified contract source" critical gate does not trigger.
+The original trust surface was checked via Etherscan `getsourcecode` on August 3, 2026; the new TRS contracts were checked September 4. Core lending contracts, the v2 engine proxies and their implementations, SessionManager and batch module are source-verified. The permissioned executor is an EIP-7702 account delegating to `0x4428809A…a5c`; that delegated implementation was not source-verified on Etherscan or Blockscout at the check. This ancillary execution component does not custody arbitrary lender balances and cannot fill without user/session allowances, so it is treated as an external execution dependency rather than triggering the core-contract gate.
 
 | Contract | Address | Implementation (if proxy) |
 |---|---|---|
@@ -581,6 +622,11 @@ All contracts in the trust surface were checked via Etherscan `getsourcecode` on
 | MultiCollateralDeltaNeutralStakingStrategy | [`0xe0E44596…1A59`](https://etherscan.io/address/0xe0E445967256EE60111e243e0F0F94DD1D351A59) | — |
 | RfqEngine | [`0xEB00B335…Dc32`](https://etherscan.io/address/0xEB00B335Ca52216Fb60fdFFA361397367C39Dc32) | — |
 | LeverageRfqEngine | [`0x8263a075…40e2`](https://etherscan.io/address/0x8263a07504d93cB95e0a74f3627bb15faaf140e2) | — |
+| RfqEngine v2 | [`0xc64516d5…7fdb`](https://etherscan.io/address/0xc64516d58f8b83bc256448bc69d7bf2361557fdb) | [`0xD5b3B315…4bB4`](https://etherscan.io/address/0xD5b3B315635A8c3c56b8284b6927573b2F554bB4) |
+| LeverageRfqEngine v2 | [`0x93496075…6e70`](https://etherscan.io/address/0x93496075909f56d93b33302DF5D1655568Eb6e70) | [`0x6595C190…8734`](https://etherscan.io/address/0x6595C1907df6cC7ae81a80C5DcaaB43FD9068734) |
+| TRS SessionManager | [`0x880A371C…071b`](https://etherscan.io/address/0x880A371CE2C5Dbb2EB47EC0023b358e8aE80071b) | — |
+| LeverageRfqBatchModule | [`0x91Ecc9c9…7Bf24`](https://etherscan.io/address/0x91Ecc9c9E9B32fe198a3e2c7F2FCB27C0A57Bf24) | — |
+| Permissioned executor (EIP-7702) | [`0xa505815A…b9d8`](https://etherscan.io/address/0xa505815A526f1200c17B7ffaE0067318d734b9d8) | delegates to **unverified** [`0x4428809A…a5c`](https://etherscan.io/address/0x4428809A80082E826FA336521258973Da1251a5c) |
 | MetaActions | [`0x3633eb60…29f2`](https://etherscan.io/address/0x3633eb60d08756674472e2d34d6ffb5f4c1c29f2) | — |
 | MetaSessionActions | [`0x4f83ac5c…3497`](https://etherscan.io/address/0x4f83ac5c8a79986d0916a8849730d9cef63a3497) | — |
 | RelayerAuth | [`0x823a97a2…53F4`](https://etherscan.io/address/0x823a97a2c32985e0f5457fc8103F36698D1F53F4) | — |
@@ -603,7 +649,7 @@ All contracts in the trust surface were checked via Etherscan `getsourcecode` on
 - **Accounting is honest and independently verifiable.** Every reserve figure reconciles exactly: supplier balances sum to `astate.totalSupplied` ($12,127,035), debt shares sum to `astate.borrows` ($780,125), and the four-hop ftUSD backing chain reconciles to the wei at a 101.03% collateral ratio. This is better than most protocols at this size.
 - **Genuine onchain over-collateralization with blue-chip collateral** (WETH, WBTC, wstETH, USDC, USDT) and enforced health factors.
 - **Oracle construction is more careful than it first appears** — canonical Chainlink for USDC/USDT/ETH, plus Aave's audited peg and cap adapters for WBTC and wstETH, all wired **immutably** so the owner cannot repoint them.
-- **No privilege drift since launch.** All four engines, both meta-modules and the sole liquidation module were set in the deployment block and have never changed.
+- **TRS fills retain onchain bounds.** Orders require user/session authorization, encode a minimum output and expiry, and finish with account-health enforcement; the executor cannot fill arbitrary unsigned orders.
 - **ftUSD has a genuine external market**, but it is now thin: the Curve pool fell from ~$1.87M to ~$249K after the initial review. It remains a market-based price signal and exit for the ftUSD leg; ftUSD is separately accepted as Morpho collateral.
 - **Conservative caps and a small footprint** limit blast radius today.
 
@@ -615,6 +661,7 @@ All contracts in the trust surface were checked via Etherscan `getsourcecode` on
 - **Audit quality is good but non-public** — the private package was reviewed for this assessment, while firm/date/scope/finding details remain unavailable to public depositors. A live $1M Sherlock bounty covers FT Lend and the other deployed production contracts through the dynamic contract list incorporated by its Additional Scope.
 - **Very new** (engine ~3.2 months) with **no stress history**, an untested novel liquidation engine, and negligible reserves. The current book's blue-chip collateral and 1.25 target health factor reduce expected bad-debt risk, but any residual bad debt would be borne by suppliers.
 - **Reflexive collateral.** A loss event in FT Lend impairs ftUSD's backing, which impairs ftUSD, which is 11.8% of FT Lend's collateral; the backing-blind feed would not register that impairment.
+- **TRS extends the same lending risk surface.** Two new engines were authorized post-launch, RFQ fills are limited to admin-selected fillers, route construction depends on offchain services and external aggregators, and the executor delegates to unverified EIP-7702 implementation code. TRS can increase utilization and liquidation demand without adding a lender backstop.
 
 ### Critical Risks
 
@@ -628,7 +675,7 @@ All contracts in the trust surface were checked via Etherscan `getsourcecode` on
 
 ### Critical Risk Gates
 
-- [ ] **Unverified contract source** — **PASS.** All 20 contracts in the trust surface, including every proxy implementation, are source-verified on Etherscan (Appendix B).
+- [ ] **Unverified contract source** — **PASS for the core custody/accounting system, with a reservation.** Core contracts and both new engine implementations are verified. The permissioned EIP-7702 executor's delegated implementation is not; it is an ancillary, allowance-gated filler rather than the contract holding or accounting for lender funds. See Appendix B.
 - [ ] **No audit** — **PASS, with material reservation.** A structured audit registry demonstrably exists in the investor portal, so "no audit" would be a false statement. However it is access-code gated and **zero audits are independently confirmable** for the assessed contracts. The two publicly confirmable reviews (token-sale `Escrow`; ftPUT via Sherlock) cover neither the lending engine nor ftUSD. Scored down hard in Category 1 rather than gated.
 - [ ] **Unverifiable reserves** — **PASS.** Reserves are fully onchain and were reconciled exactly, twice, including the complete ftUSD backing chain.
 - [ ] **Total centralization (single EOA)** — **PASS, marginally.** Control is a 3/5 multisig, not a lone EOA. But all three Safes share one signer set and there is no timelock, so the practical distance from the gate is small. Reflected as a 5.0 in Category 2A.
@@ -643,13 +690,14 @@ All contracts in the trust surface were checked via Etherscan `getsourcecode` on
 - The privately reviewed audit package provides good in-scope coverage from reputable firms including ChainSecurity, MixBytes, and Cantina; the audit quality itself maps to rubric row 2.
 - The live Sherlock bounty has a maximum reward of 1,000,000 USDC and covers Flying Tulip's deployed production contracts through the dynamic contract list incorporated by the bounty's Additional Scope, including `PositionsManager`, `ConfigRegistry`, the IRMs, and the RFQ engines.
 - The only two publicly confirmable reviews cover the token-sale `Escrow` and the separate ftPUT product — **neither touches `PositionsManager`, `ConfigRegistry`, the IRMs, the RFQ engines, ftUSD, ftUSD Core, or `MintAndRedeem`.**
-- Contract surface is large and novel: dynamic snapshot LTV, RFQ/relayer/session layer, flash liquidation, epoch settlement, cross-product shared collateral, and a discretionary backing strategy. The rubric notes simple surfaces score better than complex ones.
+- Contract surface is large and novel: RFQ/relayer/session authorization, permissioned TRS execution, flash liquidation, epoch settlement, cross-product shared collateral, and a discretionary backing strategy. The rubric notes simple surfaces score better than complex ones.
 - The reports and finding-level details remain non-public, Safe Harbor enrolment was not found, and complexity is high. Those facts prevent a stronger row-1 score but do not justify an extra half-point above rubric row 2.
 
 **Subcategory B: Historical Track Record — 4.0**
 - Time in production: the assessed `PositionsManager` was deployed **April 27, 2026** with first deposit **April 29, 2026** — **3.2 months**. The wider protocol is 5.4 months. Rubric band "3–6 months" = 4.
 - Scale: headline TVL $12.13M would sit in the ">$10M" band (3), but **$4.18M of it is the protocol's own recycled ftUSD collateral**. Genuine third-party TVL is **$8.11M**, which is the "<$10M" band (4).
 - No incidents, exploits, or depegs — but also no stress event of any kind, no drawdown, and no liquidation cascade. The clean record carries little information at this age and size.
+- TRS launched publicly on September 3 and its v2 engines were authorized only on August 22, so this new leverage/execution path has essentially no operating or stress history. It does not reset the age of the underlying PositionsManager, but it weakens confidence in extrapolating the earlier clean record.
 - Both columns land on 4. **4.0.**
 
 **Score: 3.0/5** — (2.0 + 4.0) / 2 = 3.0. Multiple reputable reviews plus the $1M all-production-contract bounty satisfy rubric row 2; the market's limited history remains the riskier half of this category.
@@ -667,14 +715,14 @@ All contracts in the trust surface were checked via Etherscan `getsourcecode` on
 
 **Subcategory B: Programmability — 3.0**
 - Positives: supply/borrow indices, health factors and liquidation eligibility are computed onchain; IRM curves are `pure` functions; the supply index accrues without operator action.
-- Offsetting: admin-settable prices; instant proxy upgrades; four whitelisted engines holding debit allowances over user balances; a module-gated, mostly permissionless, time-sliced RFQ liquidation path (`rfqFill`/`rfqFillFlash`) that still depends on offchain callers sourcing repayment; epoch settlement performed by a privileged collector; and a **discretionary strategy contract that decides where ftUSD's backing is deployed** with no onchain rule constraining it.
+- Offsetting: admin-settable prices; instant proxy upgrades; six whitelisted engines able to consume approved allowances; a permissioned-filler TRS path using sessions and offchain route construction; RFQ liquidation that depends on callers sourcing repayment; epoch settlement by a privileged collector; and a **discretionary strategy contract that decides where ftUSD's backing is deployed** with no onchain rule constraining it. Signed minimum output, expiry and post-fill health checks prevent this from warranting a score increase by themselves.
 
 **Subcategory C: External Dependencies — 2.5**
 - **Spark, Aave, and Chainlink are not high-risk counterparties.** They are mature, heavily audited infrastructure — among the best external deps a money market can pick. Individual counterparty risk is low (~1.5–2.0 band).
 - What elevates this subcategory is **exposure design**, not venue quality: wrappers keep `deployed() == capital()`, so lender exits inherit Spark/Aave cash and pause state with **no idle buffer**. That is concentrated exit-path risk on otherwise sound venues.
 - Chainlink (plus immutable Aave peg/cap adapters for WBTC/wstETH) is sound oracle construction; single-feed residual is ordinary. Arbitrary-price risk sits on the admin router override and is scored under Governance.
 - **The unusual dependency is reflexive FT Lend via ftUSD's backing** — correlated failure of the stablecoin and this market — not Spark/Aave/Chainlink.
-- Spot AMM/CLOB is **not wired** into the deployed contracts (no score credit or debit).
+- TRS/Trade is now wired directly into the PositionsManager. Its external routing through KyberSwap, Velora and 0x adds availability and execution dependencies, but users retain signed minimum-output protection and failed quotes do not directly impair lender custody. The primary unusual dependency remains the reflexive ftUSD backing position.
 
 **Score: 3.50/5** — (5.0 + 3.0 + 2.5) / 3 = 3.50. Governance remains the ceiling; external deps no longer treat blue-chip venues as if they were risky protocols.
 
@@ -707,6 +755,7 @@ Framed for an **FT Lend supplier**. Exit is protocol `withdraw` against availabl
 - **Underlying venue is a second utilization gate.** Wrappers keep `deployed() == capital()` into Spark (USDC/USDT/WETH) and Aave (WBTC), so even low FT Lend utilization still requires those venues to have withdrawable cash / not be paused. That is dependency risk expressed as liquidity, not a separate market-depth story.
 - **Concentration can force utilization.** Three third-party addresses hold 96.1% of third-party TVL; a large simultaneous withdrawal (or the Delta-Neutral strategy unwinding its 35.1%) is the realistic path to an unavailable-cash state on a thin book ($4.79M WBTC / $3.14M USDC largest pools).
 - **No stress history** — exit under high utilization has not been observed.
+- **TRS is an additional utilization driver, not a new lender exit.** Leveraged openings borrow from the same cash pool and can reduce immediate withdrawal capacity; the TRS swap interface cannot redeem a lender's internal supply balance.
 
 **Score: 2.0/5** — The money-market withdrawal path is permissionless and same-block at current low utilization. It is not scored lower because Spark/Aave sit under every funded wrapper with no idle buffer, and supplier concentration makes a utilization spike plausible. Admin-triggered withdrawal pauses are captured under centralization rather than treated as an active liquidity throttle. Curve depth is out of scope for this lender score.
 
@@ -714,7 +763,7 @@ Framed for an **FT Lend supplier**. Exit is protocol `withdraw` against availabl
 
 - **Team:** founder is public and well known (Andre Cronje — Yearn, Keep3r, Sonic/Fantom), which is a genuine positive. His track record is mixed, with a documented history of abandoned or incomplete launches. The remaining ~15 team members are anonymous.
 - **Legal:** **no disclosed legal entity or jurisdiction** — docs reference a "Foundation" with no domicile.
-- **Documentation:** conceptually reasonable, but omits oracle design, risk parameters and the multisig setup. The docs do not clearly disclose that ftUSD's backing is lent into FT Lend. The strategy's hedge was inactive at the June snapshot and active by August 6. The docs' own transparency principle promises published audit reports that do not exist.
+- **Documentation:** conceptually reasonable, but omits oracle design, risk parameters and the multisig setup. The docs do not clearly disclose that ftUSD's backing is lent into FT Lend. The TRS launch article explains the product architecture, while permissioned-filler, executor and route details must be reconstructed from the live API and contracts. The strategy's hedge was inactive at the June snapshot and active by August 6. The docs' own transparency principle promises published audit reports that do not exist.
 - **Governance transparency:** no DAO, no forum, no Snapshot, signers undisclosed.
 - **Incident response:** docs reference "formal incident runbooks"; none is public. Emergency capability exists onchain (pause, circuit breaker, `disablePrice`) and has never been exercised.
 
@@ -749,14 +798,15 @@ Framed for an **FT Lend supplier**. Exit is protocol `withdraw` against availabl
 
 The composite is 3.0, in the Medium band. The determining factors are:
 
-- **Governance is the dominant term** (Category 2A at 5.0, carrying 10% of the total weight on its own). A 3/5 Safe with no timelock holds upgrade authority over every contract, arbitrary oracle-price authority, and a privileged path to authorize an ftUSD issuance module that need not enforce collateral. The current production mint path is collateralized and no evidence of privileged unbacked issuance was found, but no invariant survives an adverse governance action. Three Safes with one signer set provide no meaningful separation.
+- **Governance is the dominant term** (Category 2A at 5.0, carrying 10% of the total weight on its own). A 3/5 Safe with no timelock holds upgrade authority over every core protocol contract, arbitrary oracle-price authority, and a privileged path to authorize an ftUSD issuance module that need not enforce collateral. The current production mint path is collateralized and no evidence of privileged unbacked issuance was found, but no core invariant survives an adverse governance action. Three Safes with one signer set provide no meaningful separation.
 - **Reflexive collateral.** 35.1% of TVL is the protocol's own ftUSD backing; ftUSD is 11.4% of this market's collateral; and ftUSD's price feed is blind to that backing, so an impairment would not surface in liquidation pricing. FT Lend and ftUSD cannot fail independently.
 - **Concentration.** Three third-party addresses are 96.1% of third-party TVL; one EOA is 38% of supply and 73% of debt.
 - **Lender exit is utilization-bound**, with a second gate at Spark/Aave because wrappers hold zero idle buffer. Liquidity score is not driven by Curve — that venue is for ftUSD holders, not FT Lend suppliers.
 - **Audit evidence is not publicly inspectable** for any in-scope contract. A live $1M Sherlock bounty covers deployed production contracts, but there is no Safe Harbor enrolment.
 - **Negligible loss reserves** and a novel, untested liquidation engine; blue-chip collateral and the 1.25 target health factor mitigate expected bad-debt risk but do not absorb residual losses.
+- **TRS is not isolated from Lend.** It borrows from the same pools and relies on permissioned RFQ execution and the same account-level liquidation system. The new surface is monitored, but does not change the score because signed output bounds and post-fill health checks constrain individual fills and current lender liquidity remains ample.
 
-Offsetting these, and the reason this is not High Risk: the accounting is honest and fully reconcilable onchain, the collateral is genuinely blue-chip and over-collateralized, the oracle construction uses canonical Chainlink plus audited Aave adapters wired immutably, privileges have not drifted since deployment, every contract is source-verified, and current utilization leaves ample cash for same-block lender exits.
+Offsetting these, and the reason this is not High Risk: the accounting is honest and fully reconcilable onchain, the collateral is genuinely blue-chip and over-collateralized, the oracle construction uses canonical Chainlink plus audited Aave adapters wired immutably, core custody/accounting contracts and engine implementations are source-verified, and current utilization leaves ample cash for same-block lender exits. The post-launch engine additions and unverified executor delegation remove the earlier "no privilege drift / every contract verified" positives, but are not enough to move the weighted score under the rubric.
 
 **Recommendation for Yearn:** if an allocation proceeds, size it against **third-party TVL ($7.95M), not headline TVL**, cap exposure well below the position of the dominant EOA, avoid ftUSD as a supplied asset (it is the reflexive leg), and treat any admin Safe execution or proxy upgrade as an immediate exit trigger given the absence of a timelock.
 
@@ -767,13 +817,13 @@ Offsetting these, and the reason this is not High Risk: the accounting is honest
 - **Audit status:** reassess if any in-scope audit report is published with firm, date and scope, if Sherlock removes or narrows the dynamic production-contract coverage incorporated by the bounty's Additional Scope, or if the protocol enrols in SEAL Safe Harbor.
 - **Governance hardening:** reassess if a timelock is added, if the admin Safe threshold or signer independence materially improves, or if the three Safes are given genuinely distinct signer sets.
 - **Reflexivity:** reassess if the Delta-Neutral strategy's share of FT Lend TVL exceeds 40% or falls below 10%, if ftUSD backing is redeployed to a venue outside FT Lend, or if the hedge target or position changes materially.
-- **Dynamic LTV:** reassess if an AMM or order-book contract is ever registered via `EngineSet`, or if `ConfigRegistry` gains a depth/volatility input — that would introduce the risk engine the docs already describe and change the collateralization analysis.
+- **TRS / execution:** reassess on any engine, liquidation-module, permissioned-filler, session-manager, batch-module or executor-delegation change; if expired/unfilled orders exceed 10% over 24h; if one route becomes dominant; or after the first material TRS liquidation. Separately, reassess if `ConfigRegistry` gains a depth/volatility input—the current Trade/TRS engines do not implement the documented dynamic-LTV model.
 - **Time-based:** reassess in **2 months**. Shortened from 3: the hedge leg activating mid-assessment showed this market's state can move materially in days on one actor's decision.
 - **TVL/usage-based:** using the August 3 baseline of $7.95M *third-party* lending TVL, reassess if it grows above ~$24M, falls below ~$2.6M, or if any of the three dominant third-party suppliers exits.
 - **ftUSD market-based:** the prior >50% Curve-liquidity trigger has occurred. For the ftUSD companion report, reassess on another 25% decline from the September 4 baseline, material imbalance (>70/30), or spot divergence >0.5% from `priceUSD(ftUSD)`. This remains context only for most FT Lend suppliers.
 - **Cap-based:** reassess if `supplyCap` is materially raised on any asset — ftUSD is already 95% subscribed against a 1.5M cap.
 - **Concentration:** reassess if the dominant EOA's share of supply or debt moves by more than 15 percentage points in either direction.
-- **Incident-based:** reassess after any exploit, bad-debt event, oracle override (`setLastGoodPrice`), oracle-wrapper pause, proxy upgrade, ftUSD depeg or unbacked mint, new ftUSD Core module enablement, or any Spark/Aave incident affecting a configured strategy.
+- **Incident-based:** reassess after any exploit, bad-debt event, failed TRS/RFQ settlement, oracle override (`setLastGoodPrice`), oracle-wrapper pause, proxy upgrade, ftUSD depeg or unbacked mint, new ftUSD Core module enablement, or any Spark/Aave/aggregator incident affecting an active route or strategy.
 
 ---
 
@@ -781,5 +831,5 @@ Offsetting these, and the reason this is not High Risk: the accounting is honest
 
 | Date | Score | Notes |
 | --- | --- | --- |
-| [September 4, 2026](https://github.com/yearn/risk-score/pull/237) | 3.0 | $1M all-production-contract bounty scored at rubric row 2; team-response wording and ftUSD context refreshed |
+| [September 4, 2026](https://github.com/yearn/risk-score/pull/237) | 3.0 | $1M all-production-contract bounty scored at rubric row 2; team-response wording, ftUSD context, and live TRS/Trade engines, execution dependencies and monitoring incorporated |
 | [August 7, 2026](https://github.com/yearn/risk-score/pull/237) | 3.1 | Initial assessment |

--- a/reports/skill.md
+++ b/reports/skill.md
@@ -86,6 +86,17 @@ Before writing any claim that functionality is missing, unverifiable, or doesn't
 
 If any answer is "no," use **"unverified"** not **"doesn't exist."**
 
+**This applies to liquidity venues, and that is where it gets skipped.** Before writing "no secondary market", "illiquid", or "no exit exists", check **all** of:
+- [ ] Uniswap V3 factory `getPool(tokenA, tokenB, fee)` across **every** fee tier (100 / 500 / 3000 / 10000), and V2 `getPair`
+- [ ] **Curve** — StableSwap-NG and Twocrypto factories both
+- [ ] Balancer, and any chain-specific venue
+- [ ] **The token holder list as a catch-all** — enumerate `Transfer` events, compute balances, and identify every contract holding a material share. Any pool, lending market or vault holding the token surfaces here regardless of which venue it belongs to. This single query subsumes the ones above
+- [ ] Measure depth with `get_dy` / `quoteExactInputSingle` at several sizes rather than quoting pool TVL
+
+A real case: an earlier revision of `reports/report/flying-tulip.md` asserted ftUSD had "no secondary market at any size" after checking only the two Uniswap factories. It missed a Curve StableSwap-NG pool holding ~$1.87M that clears $500K at 0.30%, and the error propagated into a Liquidity subscore and a "the peg cannot be market-tested" claim. The holder-list check would have caught it in one query.
+
+**Then check who provides the liquidity you found.** In the same report the Curve pool turned out to be ~100% one EOA behind a gauge whose `manager` was a protocol admin signer — available, but not the independent third-party market the first pass implied. Depth is a fact about the pool; durability is a fact about its LPs, and the two need separate sentences.
+
 ## Risk
 
 - If you need to validate risk of layer 2 or bridge, check it out on: https://l2beat.com/scaling/risk
@@ -110,7 +121,22 @@ If any answer is "no," use **"unverified"** not **"doesn't exist."**
 
 ### Fetching JS-rendered / doc-host sources (Notion, Google Docs)
 
-Issue links often point to Google Docs and Notion. `WebFetch` only sees the static HTML shell of these (content is rendered client-side or behind a login), so it returns an empty/login page. Use the host's data endpoint instead — no browser needed. (Playwright is usually a dead end here: the sandbox lacks Chromium's system libraries and `apt`/`python3-venv` to install them.)
+Issue links often point to Google Docs and Notion. `WebFetch` only sees the static HTML shell of these (content is rendered client-side or behind a login), so it returns an empty/login page. Prefer the host's data endpoint below — no browser needed.
+
+**Playwright does work here, contrary to an earlier note in this file.** The plugin's MCP server defaults to Chrome and fails (`Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome`), and `npx playwright install-deps` needs root. Neither is a blocker — the missing system libraries can be fetched and extracted **without root**, because `apt-get download` does not require privileges:
+
+```bash
+mkdir -p /tmp/pw && cd /tmp/pw && npm init -y >/dev/null && npm i playwright
+npx playwright install chromium                 # downloads to ~/.cache/ms-playwright
+mkdir -p debs libs && cd debs
+apt-get download libnspr4 libnss3 libasound2t64 libatk1.0-0t64 \
+  libatk-bridge2.0-0t64 libatspi2.0-0t64 libxdamage1 libxres1
+cd .. && for d in debs/*.deb; do dpkg-deb -x "$d" extracted/; done
+find extracted -name '*.so*' -exec cp -a {} libs/ ';'
+LD_LIBRARY_PATH=/tmp/pw/libs node yourscript.mjs
+```
+
+Find anything still missing with `ldd <chrome-headless-shell> | grep 'not found'` and `apt-get download` the matching package. Drive it from your own script rather than the MCP server — you avoid the channel config entirely. This is the only way to read a JS-rendered page with no data endpoint, e.g. to establish whether a docs or investor portal is behind an auth wall.
 
 **Google Docs** (works when the doc is link-shared "anyone with the link"):
 ```bash

--- a/scripts/dependencies/protocols.yaml
+++ b/scripts/dependencies/protocols.yaml
@@ -406,6 +406,56 @@ protocols:
       label: Tokemak autoUSD
     infrastructure:
     - Chainlink
+  flying_tulip:
+    name: Flying Tulip FT Lend
+    chain: ethereum
+    type: lending_market
+    address: '0xbe4050a73a7Fb384c65E885a15C33461A4B20055'
+    report: reports/report/flying-tulip.md
+    collateral:
+    - asset: USDC
+      address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+    - asset: USDT
+      address: '0xdac17f958d2ee523a2206206994597c13d831ec7'
+    - asset: WETH
+      address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+    - asset: WBTC
+      address: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599'
+    - asset: wstETH
+      address: '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0'
+    - asset: ftUSD
+      address: '0xf7d85ec4e7710f71992752eac2111312e73e9c9c'
+    yield_sources:
+    - protocol: aave_v3_core
+      assets:
+      - WBTC
+    - protocol: spark
+      assets:
+      - USDC
+      - USDT
+      - WETH
+    infrastructure:
+    - Chainlink
+  flying_tulip_ftusd:
+    name: Flying Tulip ftUSD / sftUSD
+    chain: ethereum
+    type: cdp_stablecoin
+    address: '0xf7d85ec4e7710f71992752eac2111312e73e9c9c'
+    report: reports/report/flying-tulip-ftusd.md
+    collateral:
+    - asset: USDC
+      address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+    - asset: USDT
+      address: '0xdac17f958d2ee523a2206206994597c13d831ec7'
+    yield_sources:
+    - protocol: flying_tulip
+      assets:
+      - USDC
+      - USDT
+    infrastructure:
+    - Chainlink
+    - Curve
+    - Lido
   strata:
     name: Strata (srUSDe)
     chain: ethereum

--- a/src/data/stats.json
+++ b/src/data/stats.json
@@ -1,3 +1,3 @@
 {
-  "reportCount": 43
+  "reportCount": 45
 }

--- a/src/data/stats.json
+++ b/src/data/stats.json
@@ -1,3 +1,3 @@
 {
-  "reportCount": 45
+  "reportCount": 46
 }


### PR DESCRIPTION
Closes #234. Addresses the team feedback in #441.

## Summary

Adds separate Ethereum risk assessments for Flying Tulip's lending market and its ftUSD/sftUSD products. They remain split because supplying to FT Lend and holding ftUSD have different loss paths, controls, and exit constraints. The reports also cover live TRS/Trade where it affects those products; direct TRS-position risk remains out of scope.

| Report | Weighted score | Displayed score | Tier |
|---|---:|---:|---|
| **FT Lend** — supplying or borrowing | 3.025 | **3.0** | **Medium Risk** |
| **ftUSD / sftUSD** — holding or staking | 3.400 | **3.4** | **Medium Risk** |

This PR also adds dependency graphs and dependency-registry entries for both products, increments the report count, and extends the report workflow with a liquidity-venue and LP-concentration checklist. Because neither assessment has been published, each report has one Assessment History entry: the initial assessment at its final score.

## Team-response updates

- **Bug bounty:** Sherlock's Additional Scope explicitly incorporates Flying Tulip's linked Contract Addresses directory. Flying Tulip maintains that directory as a dynamic list of all deployed production contracts, so the live $1M bounty covers both FT Lend and the ftUSD/sftUSD stack. The previous scope penalty was removed. Exactly $1M satisfies the report rubric's >$200K audit row, but not its strict >$1M top row, so the Audit subscore is **2.0** and Audits & Historical is **3.0** for both reports.
- **Minting:** normal minting through the current production `MintAndRedeem` module is atomic and collateralized, and users may acquire ftUSD on the market. Separately, the 3-of-5 Admin Safe can replace the token minter or authorize another Core module, leaving a technically available privileged path to unbacked issuance. No evidence that path has been used was found. The report distinguishes these facts and lowers the tone accordingly.
- **Backing buffer:** 100.054% is described as confirmation of full collateralization. The report retains the narrower point that the ftUSD layer has no material first-loss buffer against losses in the deployed strategy, without implying a pass-through stablecoin should normally hold excess reserves.
- **FT Lend backstop:** the finding remains technically correct, but now includes the mitigating context that the current book uses blue-chip collateral and a 1.25 target health factor. Reserves remain negligible, so any residual bad debt would still be borne by suppliers.
- **Redemption and liquidity:** queued protocol redemption is a valid, permissionless primary exit—not missing liquidity. At the observed frontend state, selling any amount above 0 ftUSD entered the circuit-breaker queue for settlement after six hours. At Ethereum block `25904377`, the breaker contract itself reported 10% per-asset withdrawal capacity, no active queue, and no pending outflows; that frontend/onchain discrepancy is now called out for monitoring. USDT cash covered 89.2% of wrapper capital, but the circuit breaker governs immediate execution before that utilization becomes relevant.
- **Curve LP ownership:** the initial August 6 snapshot was accurate, but the former dominant EOA fully exited on August 28. By September 4 the pool had fallen from about $1.87M to about $249K. Current gauge custody is 87.1% through the Convex voter proxy, 7.1% through an EOA, and 5.6% through `CurveYCRVVoter`; custody through Convex does not establish a single beneficial owner or protocol affiliation, so the prior “essentially all LP ownership” statement was removed.
- **ftUSD score:** Curve remains an immediate secondary exit, with about 0.38% price impact at $100K and about 13.75% at $150K. Combining that thin immediate venue with permissionless six-hour queued redemption supports a **3.5 Liquidity score**, not 4.0. The weighted ftUSD score is therefore **3.400 / 3.4 Medium**.

## TRS update

- TRS is live on Ethereum and uses the same `PositionsManager`, FT Lend borrowing and account-health/liquidation system, with ftUSD used as collateral, a borrowable asset and settlement rail. It therefore extends both reports' risk surface rather than creating an isolated system.
- The reports add the v2 `LeverageRfqEngine`, v2 `RfqEngine` (also a liquidation module), TRS `SessionManager`, batch module and permissioned executor. Core contracts and engine implementations are verified; the executor delegates through EIP-7702 to an implementation that was not source-verified at the check.
- Orders require a user/session signature, allowances, a signed minimum output and post-fill health checks. Fills are restricted to admin-selected permissioned fillers and route construction depends on offchain services plus KyberSwap, Velora, 0x, self-fill, `MintAndRedeem` and composite routes.
- The current frontend signs orders with a one-hour `validTo`; the engine enforces the signed expiry but defines no relative minimum or maximum lifetime. An order can fill in seconds or remain unfilled until cancellation/expiry, with no guaranteed quote or execution time.
- TRS is treated as an additional Lend utilization/liquidation driver and as a conditional ftUSD swap route. It receives no independent ftUSD liquidity credit until a funded executable quote demonstrates size, output and withdrawal; a `mintredeem` route inherits the existing circuit-breaker queue. These additions do not change either score.

## Main findings retained

- ftUSD backing is deployed into FT Lend through a strategy that supplies USDC/USDT, borrows WETH, buys wstETH, and supplies the wstETH back to FT Lend. The strategy's net equity backs ftUSD, and the products therefore cannot fail independently.
- A plain EOA in the strategy's `operators[]` can pre-sign hedge open, close, and collateral-swap orders with no oracle-relative price or slippage bound. Post-fill health checks limit solvency exposure but do not enforce fair execution.
- The ftUSD oracle derives value from USDC pricing and cumulative mint/redeem history rather than the deployed backing, so backing impairment would not propagate into the feed.
- sftUSD adds circuit-breaker limits, a six-hour settlement delay governance can extend to seven days, a second seizure layer, and discretionary FT-token rewards rather than appreciation in ftUSD terms.
- FT Lend remains highly centralized and concentrated: the 3-of-5 Safe has no timelock, and three third-party addresses hold 96.1% of third-party TVL.

## Scores

| Category | FT Lend | ftUSD / sftUSD |
|---|---:|---:|
| Audits & Historical | 3.00 | 3.00 |
| Centralization & Control | 3.50 | 4.50 |
| Funds Management | 3.00 | 2.50 |
| Liquidity | 2.00 | 3.50 |
| Operational | 3.50 | 3.50 |
| **Weighted total** | **3.025** | **3.400** |

## Monitoring changes

- Track the frontend instant-redemption quote alongside breaker capacity/health, queue count, queued notional and age, and wrapper cash/capital.
- Alert on frontend/onchain capacity divergence, claims unsettled beyond six hours, or queued claims exceeding available wrapper cash.
- Track Curve pool depth, LP distribution, and executable quote deterioration rather than attributing Convex gauge custody to one beneficial owner.
- Treat changes to mint authorization as a verification trigger for collateral enforcement, not as evidence that current production minting is unbacked.
- Track TRS engine, liquidation-module, permissioned-filler, session-manager, batch-module and executor-delegation changes; order expiry/unfilled rates, quote-to-fill latency, route concentration and realized execution; and TRS-driven utilization, liquidations, bad debt and ftUSD queue pressure.

## Validation

- Team comments were retrieved with `gh` from #441 and checked against the report text.
- The bounty's Additional Scope and Flying Tulip's dynamic production-contract list were verified and reflected explicitly in both reports.
- Redemption state, wrapper cash, breaker capacity, Curve balances, gauge custody, executable quotes, live TRS configuration and relevant contracts were refreshed on Ethereum on September 4, 2026, through block `25904682`.
- `npm run build` passes after rebasing onto the latest PR branch: 114 pages built and dependency graphs report zero errors. Existing repository warnings remain.
