### PR TITLE
feat(web): show per-report score rationale on report pages

### DIFF
--- a/src/components/ScoreDetails.astro
+++ b/src/components/ScoreDetails.astro
@@ -1,0 +1,201 @@
+---
+import { scoreColor } from "../lib/colors";
+import type { ScoreDetails } from "../lib/parseReport";
+
+interface Props {
+  details: ScoreDetails;
+}
+
+const { details } = Astro.props;
+---
+
+{
+  details.fallbackHtml ? (
+    <div class="prose" set:html={details.fallbackHtml} />
+  ) : (
+    <div class="score-details">
+      {details.guidelinesHtml && (
+        <div class="guidelines prose" set:html={details.guidelinesHtml} />
+      )}
+
+      {details.gatesHtml && (
+        <section class="block">
+          <h3>Critical Risk Gates</h3>
+          <div class="prose" set:html={details.gatesHtml} />
+        </section>
+      )}
+
+      {details.rationales.length > 0 && (
+        <section class="block">
+          <h3>Category Scores</h3>
+          <p class="hint">Expand a category to see how it was scored.</p>
+          <div class="cat-list">
+            {details.rationales.map((r) => (
+              <details class="cat">
+                <summary>
+                  <span class="cat-head">
+                    <span
+                      class="color-dot"
+                      style={`background:${r.score != null ? scoreColor(r.score) : "var(--text-secondary)"}`}
+                    />
+                    <span class="cat-name">{r.category}</span>
+                    <span class="cat-weight">{r.weight}</span>
+                    <span
+                      class="cat-score"
+                      style={r.score != null ? `color:${scoreColor(r.score)}` : ""}
+                    >
+                      {r.score != null ? r.score.toFixed(2) : "—"}
+                    </span>
+                    <svg
+                      class="chevron"
+                      width="18"
+                      height="18"
+                      viewBox="0 0 20 20"
+                      fill="none"
+                      aria-hidden="true"
+                    >
+                      <path
+                        d="M6 8l4 4 4-4"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </span>
+                </summary>
+                <div class="prose cat-body" set:html={r.html} />
+              </details>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {details.calculationHtml && (
+        <section class="block">
+          <h3>Final Score Calculation</h3>
+          <div class="prose" set:html={details.calculationHtml} />
+        </section>
+      )}
+
+      {details.tierHtml && (
+        <section class="block">
+          <h3>Risk Tier</h3>
+          <div class="prose" set:html={details.tierHtml} />
+        </section>
+      )}
+    </div>
+  )
+}
+
+<style>
+  .guidelines {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    margin-bottom: 1.5rem;
+  }
+  .block {
+    margin-bottom: 1.75rem;
+  }
+  .block:last-child {
+    margin-bottom: 0;
+  }
+  .block h3 {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-secondary);
+    margin-bottom: 0.75rem;
+  }
+  .hint {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    margin-bottom: 0.75rem;
+  }
+  .cat-list {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .cat + .cat {
+    border-top: 1px solid var(--border);
+  }
+  /*
+   * Keep the summary a list-item and lay out the row in an inner span: making
+   * <summary> a flex container breaks the native toggle on iOS Safari (same
+   * trap noted in graph/[slug].astro).
+   */
+  .cat > summary {
+    display: list-item;
+    list-style: none;
+    cursor: pointer;
+    padding: 0.7rem 0.9rem;
+    user-select: none;
+  }
+  .cat > summary::-webkit-details-marker {
+    display: none;
+  }
+  .cat > summary:hover {
+    background: var(--bg-secondary);
+  }
+  .cat[open] > summary {
+    background: var(--bg-secondary);
+    border-bottom: 1px solid var(--border);
+  }
+  .cat-head {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+  }
+  .color-dot {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .cat-name {
+    flex: 1;
+    min-width: 0;
+    font-weight: 600;
+    font-size: 0.95rem;
+  }
+  .cat-weight {
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+  }
+  .cat-score {
+    font-weight: 700;
+    font-size: 0.95rem;
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+    min-width: 2.6rem;
+    text-align: right;
+  }
+  .chevron {
+    flex-shrink: 0;
+    color: var(--text-secondary);
+    transition: transform 0.2s ease;
+  }
+  .cat[open] .chevron {
+    transform: rotate(180deg);
+  }
+  .cat-body {
+    padding: 1rem 0.9rem;
+    font-size: 0.9rem;
+  }
+  .cat-body :global(> *:last-child) {
+    margin-bottom: 0;
+  }
+  @media (max-width: 520px) {
+    .cat-name {
+      font-size: 0.9rem;
+    }
+    .cat-weight {
+      display: none;
+    }
+  }
+</style>

--- a/src/components/ScoreTable.astro
+++ b/src/components/ScoreTable.astro
@@ -5,9 +5,21 @@ import type { CategoryScore } from "../lib/parseReport";
 interface Props {
   scores: CategoryScore[];
   finalScore: number | null;
+  /**
+   * id of a <details> panel explaining the score. When given, the risk-tier
+   * badge becomes a link that opens and scrolls to it; otherwise it stays a
+   * plain badge, so the component still works on pages with no such panel.
+   */
+  detailsId?: string;
 }
 
-const { scores, finalScore } = Astro.props;
+const { scores, finalScore, detailsId } = Astro.props;
+
+const tierLabel = finalScore != null ? scoreTier(finalScore) : "Not Rated";
+const tierStyle =
+  finalScore != null
+    ? `background:${scoreColor(finalScore)};color:${scoreTextColor(finalScore)}`
+    : "background:#dc2626;color:#fff";
 
 // Build pie chart segments (sized by weight, colored by score)
 const totalWeight = scores.reduce((sum, s) => sum + parseFloat(s.weight), 0);
@@ -69,12 +81,40 @@ function labelPos(cx: number, cy: number, r: number, start: number, end: number)
               <td colspan="2">
                 <strong>Final Score</strong>
               </td>
-              {finalScore != null ? (
-                <td style={`color:${scoreColor(finalScore)};font-weight:700;`}>
-                  {finalScore.toFixed(1)} / 5.0
+              {finalScore == null ? (
+                <td style="font-weight:700;">N/A</td>
+              ) : detailsId ? (
+                <td>
+                  <a
+                    href={`#${detailsId}`}
+                    class="final-score final-score-link"
+                    style={`color:${scoreColor(finalScore)}`}
+                    data-opens-details={detailsId}
+                    title="See how this score was derived"
+                  >
+                    <span>{finalScore.toFixed(1)} / 5.0</span>
+                    <svg
+                      class="score-arrow"
+                      width="15"
+                      height="15"
+                      viewBox="0 0 20 20"
+                      fill="none"
+                      aria-hidden="true"
+                    >
+                      <path
+                        d="M6 8l4 4 4-4"
+                        stroke="currentColor"
+                        stroke-width="2.5"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </a>
                 </td>
               ) : (
-                <td style="font-weight:700;">N/A</td>
+                <td class="final-score" style={`color:${scoreColor(finalScore)}`}>
+                  {finalScore.toFixed(1)} / 5.0
+                </td>
               )}
             </tr>
           </tfoot>
@@ -109,15 +149,8 @@ function labelPos(cx: number, cy: number, r: number, start: number, end: number)
           </svg>
           <div class="chart-tooltip" id="chart-tooltip"></div>
         </div>
-        <div
-          class="risk-tier-badge"
-          style={
-            finalScore != null
-              ? `background:${scoreColor(finalScore)};color:${scoreTextColor(finalScore)}`
-              : "background:#dc2626;color:#fff"
-          }
-        >
-          {finalScore != null ? scoreTier(finalScore) : "Not Rated"}
+        <div class="risk-tier-badge" style={tierStyle}>
+          {tierLabel}
         </div>
       </div>
     </div>
@@ -196,6 +229,35 @@ function labelPos(cx: number, cy: number, r: number, start: number, end: number)
     letter-spacing: 0.03em;
     white-space: nowrap;
   }
+  .final-score {
+    font-weight: 700;
+    white-space: nowrap;
+  }
+  /* The final score doubles as the way into the Score Details panel. */
+  .final-score-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    cursor: pointer;
+    transition: opacity 0.15s;
+  }
+  .final-score-link:hover {
+    text-decoration: underline;
+    opacity: 0.85;
+  }
+  .final-score-link:focus-visible {
+    outline: 2px solid var(--brand-blue);
+    outline-offset: 3px;
+    border-radius: 3px;
+  }
+  .score-arrow {
+    flex-shrink: 0;
+    opacity: 0.7;
+    transition: transform 0.15s;
+  }
+  .final-score-link:hover .score-arrow {
+    transform: translateY(2px);
+  }
   @media (max-width: 640px) {
     .score-section {
       flex-direction: column;
@@ -234,4 +296,45 @@ function labelPos(cx: number, cy: number, r: number, start: number, end: number)
       });
     });
   });
+</script>
+
+<script is:inline>
+  // The risk-tier badge links to a <details> panel further down the page.
+  // A plain anchor jump would leave that panel collapsed, so open it first.
+  (function () {
+    function reveal(panel, smooth) {
+      if (!panel) return false;
+      panel.open = true;
+      var reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      panel.scrollIntoView({
+        behavior: smooth && !reduce ? 'smooth' : 'auto',
+        block: 'start',
+      });
+      return true;
+    }
+
+    function init() {
+      document.querySelectorAll('[data-opens-details]').forEach(function (link) {
+        link.addEventListener('click', function (e) {
+          var id = link.getAttribute('data-opens-details');
+          // No panel on this page? Leave the anchor to its default behaviour.
+          if (!reveal(document.getElementById(id), true)) return;
+          e.preventDefault();
+          history.replaceState(null, '', '#' + id);
+        });
+      });
+
+      // Arriving on /report/<slug>/#score-details should land open too.
+      var hash = decodeURIComponent(location.hash.slice(1));
+      if (!hash) return;
+      var target = document.getElementById(hash);
+      if (target && target.tagName === 'DETAILS') reveal(target, false);
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', init);
+    } else {
+      init();
+    }
+  })();
 </script>

--- a/src/lib/parseReport.ts
+++ b/src/lib/parseReport.ts
@@ -73,6 +73,32 @@ export interface HistoryEntry {
   notesHtml: string;
 }
 
+/** One category's written justification, pulled from "### Category Scores". */
+export interface ScoreRationale {
+  /** Long-form name from the heading, e.g. "Centralization & Control Risks". */
+  category: string;
+  weight: string;
+  /** null only when no score can be recovered from the heading, body, or table. */
+  score: number | null;
+  html: string;
+}
+
+/**
+ * The "## Risk Score Assessment" section, split into its parts so the page can
+ * show *why* each category scored what it did — the reasoning that
+ * `extractFullBody` deliberately drops.
+ */
+export interface ScoreDetails {
+  /** Preamble before the first "### " (the scoring-guidelines note). */
+  guidelinesHtml: string;
+  gatesHtml: string;
+  rationales: ScoreRationale[];
+  calculationHtml: string;
+  tierHtml: string;
+  /** Whole section, flat. Non-empty only when `rationales` is empty. */
+  fallbackHtml: string;
+}
+
 export interface ReportData extends ReportMeta {
   overviewHtml: string;
   scoreTable: CategoryScore[];
@@ -80,6 +106,8 @@ export interface ReportData extends ReportMeta {
   fullReportHtml: string;
   /** Chronological score history (oldest first). Synthesized from meta when the report has no table yet. */
   history: HistoryEntry[];
+  /** null when the report has no "## Risk Score Assessment" section at all. */
+  scoreDetails: ScoreDetails | null;
 }
 
 const TYPE_OVERRIDES: Record<string, "Protocol" | "Asset"> = {
@@ -242,6 +270,14 @@ function extractSection(content: string, heading: string): string {
   return lines.slice(1).join("\n").trim();
 }
 
+/** extractSection one heading level down: a "### " block inside a "## " section. */
+function extractSubsection(section: string, heading: string): string {
+  const parts = section.split(/(?=^### )/m);
+  const part = parts.find((s) => s.startsWith(`### ${heading}`));
+  if (!part) return "";
+  return part.split("\n").slice(1).join("\n").trim();
+}
+
 function parseScoreTable(content: string): CategoryScore[] {
   // Try standard table format: | Category | Score | Weight | Weighted |
   const tableMatch = content.match(
@@ -308,6 +344,8 @@ function extractFullBody(content: string): string {
     "Overview + Links",
     "Risk Summary",
     "Risk Score Assessment",
+    // Sibling-section variant of the tier block, surfaced in Score Details.
+    "Overall Risk Score",
     "Assessment History",
   ];
   const bodySections = sections
@@ -353,6 +391,84 @@ function parseHistory(content: string, meta: ReportMeta): HistoryEntry[] {
   ];
 }
 
+// "#### Category 2: Centralization & Control Risks (Weight: 30%)", with the
+// optional " — **3.5**" score suffix a minority of reports append.
+const CATEGORY_HEADING =
+  /^#### Category \d+:\s*(.+?)\s*\(Weight:\s*(\d+%)\)(?:\s*[—–-]+\s*\*\*([\d.]+)\*\*)?\s*$/;
+
+// A category block's score lines. Covers "**Score: 3.5/5**", "**Score: 1.5 / 5**"
+// and the computed "**Score: (1 + 1) / 2 = 1.0**" form — the optional group only
+// engages when a "=" appears before the number, and it cannot cross a "*", so it
+// never swallows a trailing "— (2.5 + 4.0) / 2 = …".
+// Some reports emit one of these per subcategory *and* a rollup for the category;
+// the rollup is always last, so the last match is the category's own score.
+const SCORE_LINE = /^\*\*Score:\s*(?:[^*]*?=\s*)?([\d.]+)\s*(?:\/\s*5)?/gm;
+
+/**
+ * Splits "## Risk Score Assessment" into gates, per-category justification, and
+ * the closing calculation/tier blocks. Reports vary in how they mark up
+ * subcategories, so only the "#### Category N: …" heading is relied on; the
+ * body under each is passed through as prose.
+ */
+function parseScoreDetails(
+  content: string,
+  scoreTable: CategoryScore[],
+): ScoreDetails | null {
+  // Trailing "---" rules separate this section from the next one; drop it so it
+  // does not render as a stray divider (or worse, a setext heading).
+  const section = extractSection(content, "Risk Score Assessment")
+    .replace(/\n+-{3,}\s*$/, "")
+    .trim();
+  if (!section) return null;
+
+  const md = (s: string) =>
+    s ? (marked.parse(s, { async: false }) as string) : "";
+
+  const rationales: ScoreRationale[] = [];
+  for (const block of extractSubsection(section, "Category Scores").split(
+    /(?=^#### )/m,
+  )) {
+    const heading = block.split("\n")[0].match(CATEGORY_HEADING);
+    if (!heading) continue;
+    const [, category, weight, headingScore] = heading;
+    // Score, most to least reliable: the heading suffix, the block's own
+    // "**Score:**" line, then the weighted table parsed elsewhere by position.
+    const lines = [...block.matchAll(SCORE_LINE)];
+    const raw = headingScore ?? lines[lines.length - 1]?.[1];
+    const parsed = raw != null ? parseFloat(raw) : NaN;
+    rationales.push({
+      category,
+      weight,
+      score: Number.isFinite(parsed)
+        ? parsed
+        : (scoreTable[rationales.length]?.score ?? null),
+      html: md(block.split("\n").slice(1).join("\n").trim()),
+    });
+  }
+
+  // Preamble before the first "### ". A zero-width split match at index 0 is
+  // ignored by String.split, so when the section opens straight into a
+  // subsection this first chunk *is* that subsection — not an empty preamble.
+  const first = section.split(/(?=^### )/m)[0];
+
+  return {
+    guidelinesHtml: first.startsWith("### ") ? "" : md(first.trim()),
+    gatesHtml: md(extractSubsection(section, "Critical Risk Gates")),
+    rationales,
+    calculationHtml: md(extractSubsection(section, "Final Score Calculation")),
+    // Four reports carry the tier in a sibling "## Overall Risk Score" section
+    // instead of a "### Risk Tier" subsection. extractFullBody skips that
+    // heading too, so it stays in exactly one place on the page.
+    tierHtml: md(
+      extractSubsection(section, "Risk Tier") ||
+        extractSection(content, "Overall Risk Score"),
+    ),
+    // A couple of reports have no "### Category Scores" block, so there is
+    // nothing to split into rows — render the section flat rather than empty.
+    fallbackHtml: rationales.length === 0 ? md(section) : "",
+  };
+}
+
 export function parseReport(slug: string, content: string): ReportData {
   const meta = parseMeta(slug, content);
 
@@ -369,5 +485,6 @@ export function parseReport(slug: string, content: string): ReportData {
     riskSummaryHtml: marked.parse(riskSummaryMd, { async: false }) as string,
     fullReportHtml: marked.parse(fullBodyMd, { async: false }) as string,
     history,
+    scoreDetails: parseScoreDetails(content, scoreTable),
   };
 }

--- a/src/pages/report/[slug].astro
+++ b/src/pages/report/[slug].astro
@@ -2,6 +2,7 @@
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import ScoreBadge from "../../components/ScoreBadge.astro";
 import ScoreTable from "../../components/ScoreTable.astro";
+import ScoreDetails from "../../components/ScoreDetails.astro";
 import { getAllSlugs, getReportBySlug } from "../../lib/reports";
 import { hasGraph } from "../../lib/graph";
 import { scoreTier } from "../../lib/colors";
@@ -217,8 +218,8 @@ const jsonLd = reviewSchema ? [articleSchema, reviewSchema] : [articleSchema];
     <div class="prose" set:html={report.riskSummaryHtml} />
   </section>
 
-  <details class="full-report">
-    <summary class="full-report-toggle">
+  <details class="disclosure">
+    <summary class="disclosure-toggle">
       <span>Full Report</span>
       <svg class="chevron" width="20" height="20" viewBox="0 0 20 20" fill="none">
         <path d="M6 8l4 4 4-4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
@@ -226,6 +227,20 @@ const jsonLd = reviewSchema ? [articleSchema, reviewSchema] : [articleSchema];
     </summary>
     <div class="prose" set:html={report.fullReportHtml} />
   </details>
+
+  {report.scoreDetails && (
+    <details class="disclosure">
+      <summary class="disclosure-toggle">
+        <span>Score Details</span>
+        <svg class="chevron" width="20" height="20" viewBox="0 0 20 20" fill="none">
+          <path d="M6 8l4 4 4-4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </summary>
+      <div class="disclosure-body">
+        <ScoreDetails details={report.scoreDetails} />
+      </div>
+    </details>
+  )}
 
   {report.history.length > 0 && (
     <section class="section">
@@ -429,12 +444,13 @@ const jsonLd = reviewSchema ? [articleSchema, reviewSchema] : [articleSchema];
     padding-bottom: 0.5rem;
     border-bottom: 1px solid var(--border);
   }
-  .full-report {
+  /* Shared by the "Full Report" and "Score Details" panels. */
+  .disclosure {
     margin-bottom: 2.5rem;
     border: 1px solid var(--border);
     border-radius: 8px;
   }
-  .full-report-toggle {
+  .disclosure-toggle {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -448,83 +464,25 @@ const jsonLd = reviewSchema ? [articleSchema, reviewSchema] : [articleSchema];
     background: var(--bg-secondary);
     border-radius: 8px;
   }
-  .full-report[open] .full-report-toggle {
+  .disclosure[open] .disclosure-toggle {
     border-radius: 8px 8px 0 0;
     border-bottom: 1px solid var(--border);
   }
-  .full-report-toggle::-webkit-details-marker {
+  .disclosure-toggle::-webkit-details-marker {
     display: none;
   }
-  .full-report-toggle .chevron {
+  .disclosure-toggle .chevron {
     transition: transform 0.2s ease;
     flex-shrink: 0;
   }
-  .full-report[open] .full-report-toggle .chevron {
+  .disclosure[open] .disclosure-toggle .chevron {
     transform: rotate(180deg);
   }
-  .full-report > .prose {
+  .disclosure > .prose,
+  .disclosure-body {
     padding: 1.25rem;
   }
-  .prose :global(p) {
-    margin-bottom: 0.75rem;
-  }
-  .prose :global(ul),
-  .prose :global(ol) {
-    margin-bottom: 0.75rem;
-    padding-left: 1.5rem;
-  }
-  .prose :global(li) {
-    margin-bottom: 0.25rem;
-  }
-  .prose :global(a) {
-    color: var(--brand-blue);
-  }
-  .prose :global(strong) {
-    color: var(--text-primary);
-  }
-  .prose :global(code) {
-    background: var(--bg-secondary);
-    padding: 0.15rem 0.35rem;
-    border-radius: 3px;
-    font-size: 0.85em;
-  }
-  .prose :global(pre) {
-    background: var(--bg-secondary);
-    padding: 1rem;
-    border-radius: 6px;
-    overflow-x: auto;
-    margin-bottom: 0.75rem;
-  }
-  .prose :global(pre code) {
-    background: none;
-    padding: 0;
-  }
-  .prose :global(h3) {
-    margin-top: 1.5rem;
-    margin-bottom: 0.5rem;
-    font-size: 1.05rem;
-  }
-  .prose :global(table) {
-    width: 100%;
-    border-collapse: collapse;
-    margin-bottom: 0.75rem;
-    font-size: 0.85rem;
-    display: block;
-    overflow-x: auto;
-  }
-  .prose :global(th),
-  .prose :global(td) {
-    padding: 0.4rem 0.6rem;
-    border-bottom: 1px solid var(--border);
-    text-align: left;
-  }
-  .prose :global(th) {
-    background: var(--bg-secondary);
-    color: var(--text-secondary);
-    font-weight: 600;
-    font-size: 0.75rem;
-    text-transform: uppercase;
-  }
+  /* .prose rules live in global.css — shared with ScoreDetails.astro. */
   .history-wrap {
     overflow-x: auto;
   }

--- a/src/pages/report/[slug].astro
+++ b/src/pages/report/[slug].astro
@@ -194,7 +194,11 @@ const jsonLd = reviewSchema ? [articleSchema, reviewSchema] : [articleSchema];
   {report.finalScore != null ? (
     <section class="section">
       <h2>Score Breakdown</h2>
-      <ScoreTable scores={report.scoreTable} finalScore={report.finalScore} />
+      <ScoreTable
+        scores={report.scoreTable}
+        finalScore={report.finalScore}
+        detailsId={report.scoreDetails ? "score-details" : undefined}
+      />
     </section>
   ) : (
     <section class="section">
@@ -229,7 +233,7 @@ const jsonLd = reviewSchema ? [articleSchema, reviewSchema] : [articleSchema];
   </details>
 
   {report.scoreDetails && (
-    <details class="disclosure">
+    <details class="disclosure" id="score-details">
       <summary class="disclosure-toggle">
         <span>Score Details</span>
         <svg class="chevron" width="20" height="20" viewBox="0 0 20 20" fill="none">
@@ -355,6 +359,8 @@ const jsonLd = reviewSchema ? [articleSchema, reviewSchema] : [articleSchema];
   .back-link {
     display: inline-block;
     margin-bottom: 1.5rem;
+    /* Separates it from the new/updated badge that follows on the same line. */
+    margin-right: 1rem;
     color: var(--text-secondary);
     font-size: 0.9rem;
   }
@@ -449,6 +455,8 @@ const jsonLd = reviewSchema ? [articleSchema, reviewSchema] : [articleSchema];
     margin-bottom: 2.5rem;
     border: 1px solid var(--border);
     border-radius: 8px;
+    /* Breathing room when the tier badge scrolls this panel into view. */
+    scroll-margin-top: 1rem;
   }
   .disclosure-toggle {
     display: flex;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -85,3 +85,77 @@ th {
   font-size: 0.75rem;
   letter-spacing: 0.05em;
 }
+
+/*
+ * Rendered-markdown blocks. Global rather than page-scoped because more than
+ * one component now sets:html report markdown (the report body and the score
+ * rationale panels) and they must render identically.
+ */
+.prose p {
+  margin-bottom: 0.75rem;
+}
+.prose ul,
+.prose ol {
+  margin-bottom: 0.75rem;
+  padding-left: 1.5rem;
+}
+.prose li {
+  margin-bottom: 0.25rem;
+}
+.prose a {
+  color: var(--brand-blue);
+}
+.prose strong {
+  color: var(--text-primary);
+}
+.prose code {
+  background: var(--bg-secondary);
+  padding: 0.15rem 0.35rem;
+  border-radius: 3px;
+  font-size: 0.85em;
+}
+.prose pre {
+  background: var(--bg-secondary);
+  padding: 1rem;
+  border-radius: 6px;
+  overflow-x: auto;
+  margin-bottom: 0.75rem;
+}
+.prose pre code {
+  background: none;
+  padding: 0;
+}
+.prose h3,
+.prose h4,
+.prose h5 {
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+  font-size: 1.05rem;
+}
+.prose blockquote {
+  border-left: 3px solid var(--border);
+  padding-left: 1rem;
+  margin-bottom: 0.75rem;
+  color: var(--text-secondary);
+}
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 0.75rem;
+  font-size: 0.85rem;
+  display: block;
+  overflow-x: auto;
+}
+.prose th,
+.prose td {
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+}
+.prose th {
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -102,6 +102,14 @@ th {
 .prose li {
   margin-bottom: 0.25rem;
 }
+/* GFM task lists (the critical-gate checklists) draw their own checkbox —
+   drop the bullet so the item carries one marker, not two. */
+.prose li:has(> input[type="checkbox"]) {
+  list-style: none;
+}
+.prose li > input[type="checkbox"] {
+  margin-right: 0.4rem;
+}
 .prose a {
   color: var(--brand-blue);
 }


### PR DESCRIPTION
## Context

A reader commented that report pages show scores at the top but never explain **how they were given**.

That information already exists in every report `.md` under `## Risk Score Assessment` (43/43 files) — critical-gate checks, per-category subcategory scoring, and the written justification for each number. It was being actively filtered out: `extractFullBody()` lists `"Risk Score Assessment"` in `skipHeadings`, so the site scraped that section for its `| Category | Score | Weight | Weighted |` table and discarded all the reasoning. A reader saw `Centralization & Control — 3.50` with no way to learn why, short of clicking through to GitHub.

This surfaces each report's **own** rationale. It deliberately does *not* add a generic methodology page from `reports/TEMPLATE.md` — that's a separate idea.

## What changed

A collapsed **"Score Details"** panel between Full Report and Assessment History, containing that section in its original order: scoring guidelines → critical risk gates → one expandable row per category → final score calculation → risk tier.

| File | Change |
|---|---|
| `src/lib/parseReport.ts` | `parseScoreDetails()` + `ScoreDetails` / `ScoreRationale` types |
| `src/components/ScoreDetails.astro` | new |
| `src/pages/report/[slug].astro` | panel wired in; `.full-report` → shared `.disclosure` |
| `src/styles/global.css` | `.prose` rules promoted from page-scoped, now that two components render report markdown |

### Parsing notes

Reports vary a lot in how they mark up subcategories (`**Subcategory A: Governance — 5.0**` vs a separate `**Governance Score: 3.5/5**` vs `**Subcategory A — Audits:** 1`), so the only structure relied on is the `#### Category N: <Name> (Weight: W%)` heading — consistent across 41 of 43 reports, its sole variation an optional ` — **3.5**` suffix. Each block's body is passed through as prose.

A category's score is resolved: heading suffix → the **last** `**Score:**` line in the block → the weighted table by position. Last, because reports that score each subcategory put the category rollup last.

The two reports with no `### Category Scores` block (`midas-mglobal`, `midas-mhyper`) render the section flat rather than showing an empty panel.

Four reports (`kinetiq-khype`, `stakedhype-sthype`, `unit-ubtc`, `reserve-ethplus`) keep the tier in a sibling `## Overall Risk Score` section instead of a `### Risk Tier` subsection. That heading is now also skipped by `extractFullBody`, so it lives in exactly one place on the page.

## Validation

- `astro build` passes — 108 pages.
- `npm test` — 19/19 pass.
- **43/43** report pages render the panel; **41** with full category rows, 2 on the intended fallback path.
- Panel scores were cross-checked against the top `ScoreTable` (two independently-parsed sources). This caught two bugs before merge:
  - **Wrong score per category** — taking the *first* `**Score:**` match picked up a subcategory value (`fx-fxusd` Category 1 showed 1.5 instead of 1.75).
  - **Gates block rendered twice** — JS `split` ignores a zero-width match at index 0, so for sections opening straight into `### Critical Risk Gates` the "preamble" chunk *was* that subsection.
- Additive to the top `ScoreTable`, `ScoreBadge`, OG images and `llms.txt` — none of those inputs changed.

Reports that are **Not Rated** (`buck`, `kerneldao-hgeth`, `resolv-rlp`, `resolv-wstusr`) render no top score table at all, so they previously showed no scoring information whatsoever; they now get the full gates-and-categories breakdown.

## Follow-ups (not in this PR)

Two reports contradict themselves between prose and their own table, so the page now shows both values:

- `bedrock-unibtc.md` — prose `**Score: 3.4/5**` vs table `3.375`
- `saturn-usdat.md` — prose `2.8` vs table `2.83`

Both are source-data fixes rather than code fixes.

## Note for reviewers

Branched from `origin/master`, so `flying-tulip.md` / `flying-tulip-ftusd.md` (in flight on `report/flying-tulip-234`) are not covered by the counts above. `buck.md` exercises the same heading-suffix variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
