### PR TITLE
reassess: Midas mHYPER (August 2026)

### DIFF
--- a/reports/graph/midas-mhyper.yaml
+++ b/reports/graph/midas-mhyper.yaml
@@ -10,277 +10,314 @@ categories:
   - id: governance
     label: Governance
   - id: infra
-    label: Protocol Infra
+    label: Protocol / Custody Infra
   - id: dependency
     label: External Dependency
 
 nodes:
-  # === Vault / token layer ===
-  - id: mHYPER
-    label: mHYPER (LYT)
+  - id: mhyper
+    label: mHYPER
     address: "0x9b5528528656DBC094765E2abB79F293c21191B9"
     category: vault
-    note: Subordinated debt instrument; TransparentUpgradeableProxy. ~29.5M supply (Jun 2026)
+    note: "Qualified subordinated debt token. Ethereum supply was 34.60M on August 19, 2026; current implementation is 0x3f0ec5b26ec6e50907abea87a798bf395189bcd5."
   - id: deposit-vault
     label: DepositVault
-    address: "0x6Be2f55816efd0d91f52720f096006d63c366e98"
-    category: vault
-    note: User-facing mint entry (USDC → mHYPER)
+    address: "0xbA9FD2850965053Ffab368Df8AA7eD2486f11024"
+    category: infra
+    note: User-facing USDC issuance vault; holds the mHYPER mint role.
   - id: redemption-vault
     label: RedemptionVaultWithSwapper
-    address: "0xbA9FD2850965053Ffab368Df8AA7eD2486f11024"
-    category: vault
-    note: Instant + standard redemption
-
-  # === Protocol infra ===
+    address: "0x6Be2f55816efd0d91f52720f096006d63c366e98"
+    category: infra
+    note: Instant and standard redemption path; holds the mHYPER burn role.
   - id: access-control
     label: MidasAccessControl
     address: "0x0312A9D1Ff2372DDEdCBB21e4B6389aFc919aC4B"
-    category: infra
-    note: Role-based permission system
+    category: governance
+    note: Default admins can change token and vault roles without the upgrade timelock.
   - id: oracle
-    label: MHyperCustomAggregatorFeed (NAV)
+    label: mHYPER NAV Oracle
     address: "0x43881B05C3BE68B2d33eb70aDdF9F666C5005f68"
     category: infra
-    note: "Admin-set NAV oracle (2x/week). Impl: 0xa19f5e16dc09641b17adf95bc950f71dbe5cb11b"
+    note: "Admin-set NAV oracle updated twice weekly; current implementation 0xa19f5e16dc09641b17adf95bc950f71dbe5cb11b."
   - id: data-feed
     label: mHYPER DataFeed
     address: "0x92004DCC5359eD67f287F32d12715A37916deCdE"
     category: infra
-    note: Feeds price data to vaults
+    note: Supplies oracle values to issuance and redemption vaults.
   - id: oft-adapter
     label: LayerZero OFT Adapter
     address: "0x148c86390a4ae6f7a02df5903bc0a89e8b4581a0"
     category: infra
-    note: Cross-chain bridge; holds MINT + BURN
-  - id: mint-burn-eoa
-    label: Mint/Burn Operator EOA
+    note: Cross-chain adapter with mHYPER mint and burn roles.
+  - id: mint-burn-operator
+    label: Mint / Burn Operator
     address: "0x5683de280d0c3967fba2f04d707fa1ef5a044e25"
     category: infra
-    note: Fordefi MPC; holds MINT/BURN/PAUSE/BLACKLIST/GREENLIST
-  - id: oracle-updater-eoa
-    label: Oracle Updater EOA
+    note: Fordefi MPC address with mint, burn, pause, blacklist, and greenlist authority.
+  - id: oracle-updater
+    label: Oracle Updater
     address: "0xd1e01471f3e1002d4eec1b39b7dbd7aff952a99f"
     category: infra
-    note: Single EOA, no timelock on price updates
-  - id: tokens-receiver
-    label: Tokens Receiver
-    address: "0xF356c5e9F69DaDB332Bb098C7Ed960Db1d3376DD"
-    category: infra
+    note: Can publish NAV without a timelock; each update is bounded to 0.35% movement.
 
-  # === Governance ===
   - id: admin-safe
     label: Admin Safe (1/3)
     address: "0xB60842E9DaBCd1C52e354ac30E82a97661cB7E89"
     category: governance
-    note: Gnosis Safe; DEFAULT_ADMIN + Timelock proposer/executor
-  - id: admin-eoa-fordefi
-    label: DEFAULT_ADMIN EOA (Fordefi MPC)
+    note: Direct DEFAULT_ADMIN holder and timelock proposer/executor; outer threshold is one of three.
+  - id: admin-fordefi
+    label: Fordefi DEFAULT_ADMIN
     address: "0xd4195cf4df289a4748c1a7b6ddbe770e27ba1227"
     category: governance
-    note: Bypasses timelock for role grants
+    note: Direct DEFAULT_ADMIN holder; role changes do not pass through the timelock.
   - id: timelock
-    label: MidasTimelockController (48h)
+    label: Upgrade Timelock (48h)
     address: "0xE3EEe3e0D2398799C884a47FC40C029C8e241852"
     category: governance
-    note: OZ TimelockController; gates proxy upgrades only
+    note: Owns the shared ProxyAdmin with a 172,800-second minimum delay.
   - id: proxy-admin
-    label: ProxyAdmin (shared)
+    label: Shared ProxyAdmin
     address: "0xbf25b58cB8DfaD688F7BcB2b87D71C23A6600AaC"
     category: governance
 
-  # === Strategy venues (June 2026 per SumCap) ===
-  - id: strat-unclassified
-    label: Unclassified (76.8%)
-    category: strategy
-    note: Likely non-Ethereum chains + offchain/CEX
-  - id: strat-fluid
-    label: Fluid (15.4%)
-    category: strategy
-  - id: strat-uniswapv4
-    label: Uniswap V4 (5.6%)
-    category: strategy
-  - id: strat-onchain-wallets
-    label: Onchain Wallets (1.5%)
-    category: strategy
-  - id: strat-merkl
-    label: Merkl (0.1%)
-    category: strategy
-  - id: strat-other
-    label: Other (Euler, Pendle V2, Morpho V2, Hyperliquid — each <0.01%)
-    category: strategy
+  - id: fordefi
+    label: Fordefi MPC / Policy Engine
+    category: dependency
+    link: https://web.fordefi.com/customer-stories/how-midas-brings-tokenized-investment-opportunities-on-chain-with-fordefis-defi-native-custody-2ti85
+    note: In-policy transactions may execute automatically; exceptions use Midas, manager, and independent-signer governance. Current thresholds are not public onchain.
+  - id: fordefi2
+    label: Fordefi2 Allocator
+    address: "0x68e7E72938db36a5CBbCa7b52c71DBBaaDfB8264"
+    category: infra
+    note: Current Morpho V2 and most idle-wallet positions are attributed directly to this wallet.
+  - id: fordefi3
+    label: Fordefi3 Allocator
+    address: "0xcd0673721a489B1CeA0E2580FA304Bcb6ccA3186"
+    category: infra
+    note: Current Hypercore spot, perpetual, and staking positions are attributed directly to this wallet.
+  - id: fordefi4
+    label: Fordefi4 Allocator
+    address: "0x17B504247b0D8c1856e541a70495dd622023c7D2"
+    category: infra
+    note: Most current Fluid assets and liabilities are attributed directly to this wallet.
+  - id: safe1
+    label: Fund Safe1 (1/1)
+    address: "0xe7c241B82c2cd7e96E6ea656b08752f8C01DEc9a"
+    category: governance
+    note: Ethereum Safe solely owned by Fordefi2. No material current Delta Y allocation is attributed to it.
+  - id: safe2
+    label: Fund Safe2 (1/1)
+    address: "0xb81Eb60fA132535346eA93D46916A52a8c3dd475"
+    chain: hyperevm
+    category: governance
+    note: HyperEVM Safe solely owned by Fordefi2. No material current Delta Y allocation is attributed to it.
+  - id: safe3
+    label: Fund Safe3 (2/2)
+    address: "0xA4E16cEdBBaF9c35d2adC4eaD2e87343C3cec5eA"
+    category: governance
+    note: Genuine two-of-two Safe owned by Fordefi2 and 0xFB663cB839A9b44808AaC2cF8C2B3ca43b461D8B. No material current Delta Y allocation is attributed to it.
 
-  # === Attestation Engine (March 2026) ===
-  - id: keystone-forwarder
-    label: KeystoneForwarder (Chainlink DON)
-    address: "0x0b93082D9b3C7C97fAcd250082899BAcf3af3885"
-    category: infra
-  - id: save-cre-receiver
-    label: SaveCreReceiverProxy
-    address: "0xC50102b6598924Aa8deB201c757bFb9a3dBdB9b6"
-    category: infra
+  - id: morpho
+    label: Morpho V2 (42.72%)
+    category: strategy
+    link: https://midas.deltay.xyz/mhyper
+    note: USDC positions on Monad and Ethereum. The public API does not identify the exact vault.
+  - id: hypercore
+    label: Hypercore (32.20%)
+    category: strategy
+    link: https://midas.deltay.xyz/mhyper
+    note: Hyperliquid spot, perpetual, and staking balances.
+  - id: fluid
+    label: Fluid (11.72%)
+    category: strategy
+    link: https://midas.deltay.xyz/mhyper
+    note: Leveraged positions with $36.85M of assets and $32.23M of liabilities at assessment time.
+  - id: unclassified
+    label: Unclassified (7.48%)
+    category: strategy
+    link: https://midas.deltay.xyz/mhyper
+    note: Residual under Delta Y's max-of-supply-NAV and tracked-wallet-NAV methodology; not a specific identified asset.
+  - id: wallets
+    label: Idle Wallets (3.22%)
+    category: strategy
+    link: https://midas.deltay.xyz/mhyper
+    note: Predominantly idle USDC in tracked allocator wallets.
+  - id: liquidity
+    label: Redemption Liquidity (2.59%)
+    category: strategy
+    link: https://midas.deltay.xyz/mhyper
+    note: Midas redemption-vault assets plus the strategy liquidity buffer.
+
   - id: save-registry
-    label: MidasSaveRegistryWithClaim
+    label: SAVE Hash Registry
     address: "0x2D6e9F608807436DE5D9603B00Abe3FEd1Bc809d"
     category: infra
-    note: Onchain proof / attestation registry
-
-  # === External dependencies ===
+    note: Stores proof, claim, verification hashes and timestamps; does not enforce oracle updates or minting.
+  - id: save-verifiers
+    label: SAVE Verification Pipeline
+    category: dependency
+    link: https://docs.midas.app/transparency/the-midas-attestation-engine
+    note: Offchain source collection, third-party verification, notarization, and Chainlink CRE publication.
   - id: hyperithm
-    label: Hyperithm (Strategy Manager)
+    label: Hyperithm
     category: dependency
-    note: Offchain fund manager; AUM $300M+
-  - id: fordefi
-    label: Fordefi MPC Custody
-    category: dependency
-    note: Tri-party MPC custody (Midas + Hyperithm + Independent)
-  - id: llamarisk-canary
-    label: LlamaRisk + Canary (Verifiers)
-    category: dependency
-    note: Attestation Engine third-party verifiers
-  - id: vlayer
-    label: vlayer (Notarization)
-    category: dependency
+    link: https://www.hyperithm.com/
+    note: Discretionary strategy manager; Fordefi policies are the principal disclosed transaction-control layer.
 
 edges:
-  # === Governance ===
   - from: admin-safe
     to: timelock
     kind: proposes-on
-    label: PROPOSER + EXECUTOR (1/3)
+    label: PROPOSER and EXECUTOR (1/3)
   - from: timelock
     to: proxy-admin
     kind: controls
-    label: owner (48h delay)
+    label: owner; 48-hour delay
   - from: proxy-admin
-    to: mHYPER
+    to: mhyper
     kind: manages
-    label: upgradeable proxy
+    label: proxy upgrades
   - from: proxy-admin
     to: deposit-vault
     kind: manages
+    label: proxy upgrades
   - from: proxy-admin
     to: redemption-vault
     kind: manages
+    label: proxy upgrades
   - from: proxy-admin
     to: oracle
     kind: manages
-  - from: proxy-admin
-    to: access-control
-    kind: manages
+    label: proxy upgrades
   - from: admin-safe
     to: access-control
     kind: holds-role
-    label: DEFAULT_ADMIN (no timelock)
-  - from: admin-eoa-fordefi
+    label: DEFAULT_ADMIN_ROLE; no role-change timelock
+  - from: admin-fordefi
     to: access-control
     kind: holds-role
-    label: DEFAULT_ADMIN (no timelock)
+    label: DEFAULT_ADMIN_ROLE; no role-change timelock
   - from: access-control
-    to: mHYPER
-    kind: manages
-    label: gates mint/burn/pause/blacklist
-  - from: oracle-updater-eoa
+    to: mhyper
+    kind: controls
+    label: mint, burn, pause, blacklist, and greenlist roles
+  - from: oracle-updater
     to: oracle
     kind: holds-role
-    label: M_HYPER_CUSTOM_AGGREGATOR_FEED_ADMIN_ROLE (no timelock)
+    label: NAV update role; no timelock
 
-  # === Mint/burn authority on mHYPER ===
   - from: deposit-vault
-    to: mHYPER
+    to: mhyper
     kind: mints
     label: M_HYPER_MINT_OPERATOR_ROLE
-  - from: deposit-vault
-    to: mHYPER
+  - from: redemption-vault
+    to: mhyper
     kind: holds-role
     label: M_HYPER_BURN_OPERATOR_ROLE
-  - from: mint-burn-eoa
-    to: mHYPER
+  - from: mint-burn-operator
+    to: mhyper
     kind: mints
-    label: MINT + BURN (no collateral check)
+    label: MINT and BURN; no collateral check
   - from: oft-adapter
-    to: mHYPER
+    to: mhyper
     kind: mints
-    label: cross-chain MINT + BURN
-
-  # === Internal flow ===
+    label: cross-chain MINT and BURN
   - from: deposit-vault
-    to: mHYPER
+    to: mhyper
     kind: routes-through
-    label: USDC → mHYPER
-  - from: redemption-vault
-    to: mHYPER
+    label: USDC issuance
+  - from: mhyper
+    to: redemption-vault
     kind: routes-through
-    label: mHYPER → USDC
+    label: mHYPER redemption
   - from: oracle
     to: data-feed
-    kind: manages
-    label: NAV price feed
+    kind: routes-through
+    label: NAV price
   - from: data-feed
     to: deposit-vault
     kind: manages
-    label: price at deposit
+    label: issuance price
   - from: data-feed
     to: redemption-vault
     kind: manages
-    label: price at redeem
+    label: redemption price
 
-  # === Capital flow: vault → custody → strategies (June 2026) ===
-  - from: mHYPER
+  - from: mhyper
+    to: morpho
+    kind: allocates-to
+    label: "42.72%"
+  - from: mhyper
+    to: hypercore
+    kind: allocates-to
+    label: "32.20%"
+  - from: mhyper
+    to: fluid
+    kind: allocates-to
+    label: "11.72%"
+  - from: mhyper
+    to: unclassified
+    kind: allocates-to
+    label: "7.48%"
+  - from: mhyper
+    to: wallets
+    kind: allocates-to
+    label: "3.22%"
+  - from: mhyper
+    to: liquidity
+    kind: allocates-to
+    label: "2.59%"
+  - from: fordefi2
+    to: morpho
+    kind: deposits-into
+    label: tracked allocator wallet
+  - from: fordefi2
+    to: wallets
+    kind: deposits-into
+    label: predominantly USDC
+  - from: fordefi3
+    to: hypercore
+    kind: deposits-into
+    label: spot, perps, and staking
+  - from: fordefi4
+    to: fluid
+    kind: deposits-into
+    label: leveraged positions
+  - from: hyperithm
     to: fordefi
     kind: routes-through
-    label: tri-party MPC custody
+    label: strategy instructions subject to policy
   - from: fordefi
-    to: hyperithm
-    kind: routes-through
-    label: offchain strategy execution
-  - from: hyperithm
-    to: strat-unclassified
-    kind: allocates-to
-    label: "76.8%"
-  - from: hyperithm
-    to: strat-fluid
-    kind: allocates-to
-    label: "15.4%"
-  - from: hyperithm
-    to: strat-uniswapv4
-    kind: allocates-to
-    label: "5.6%"
-  - from: hyperithm
-    to: strat-onchain-wallets
-    kind: allocates-to
-    label: "1.5%"
-  - from: hyperithm
-    to: strat-merkl
-    kind: allocates-to
-    label: "0.1%"
-  - from: hyperithm
-    to: strat-other
-    kind: allocates-to
-    label: "<0.1%"
+    to: fordefi2
+    kind: controls
+    label: MPC and transaction policies
+  - from: fordefi
+    to: fordefi3
+    kind: controls
+    label: MPC and transaction policies
+  - from: fordefi
+    to: fordefi4
+    kind: controls
+    label: MPC and transaction policies
+  - from: fordefi2
+    to: safe1
+    kind: controls
+    label: sole owner; 1/1
+  - from: fordefi2
+    to: safe2
+    kind: controls
+    label: sole owner; 1/1
+  - from: fordefi2
+    to: safe3
+    kind: controls
+    label: one of two required owners
 
-  # === Attestation Engine (NAV verification pipeline) ===
-  - from: keystone-forwarder
-    to: save-cre-receiver
-    kind: routes-through
-    label: onReport()
-  - from: save-cre-receiver
+  - from: save-verifiers
     to: save-registry
     kind: routes-through
-    label: setAttestation()
+    label: attestation, claim, and verification hashes
   - from: save-registry
     to: oracle
-    kind: manages
-    label: NAV hash anchor
-  - from: llamarisk-canary
-    to: keystone-forwarder
     kind: routes-through
-    label: verifier signatures
-  - from: vlayer
-    to: keystone-forwarder
-    kind: routes-through
-    label: cryptographic notarization
-  - from: tokens-receiver
-    to: deposit-vault
-    kind: routes-through
-    label: USDC receiver
+    label: evidence only; not an enforcement gate

--- a/reports/graph/midas-mhyper.yaml
+++ b/reports/graph/midas-mhyper.yaml
@@ -19,7 +19,7 @@ nodes:
     label: mHYPER
     address: "0x9b5528528656DBC094765E2abB79F293c21191B9"
     category: vault
-    note: "Qualified subordinated debt token. Ethereum supply was 34.60M on August 19, 2026; current implementation is 0x3f0ec5b26ec6e50907abea87a798bf395189bcd5."
+    note: "Qualified subordinated debt token. Ethereum supply was 34.55M at block 25,788,517 on August 19, 2026; current implementation is 0x3f0ec5b26ec6e50907abea87a798bf395189bcd5."
   - id: deposit-vault
     label: DepositVault
     address: "0xbA9FD2850965053Ffab368Df8AA7eD2486f11024"

--- a/reports/graph/midas-mhyper.yaml
+++ b/reports/graph/midas-mhyper.yaml
@@ -59,7 +59,7 @@ nodes:
     label: Oracle Updater
     address: "0xd1e01471f3e1002d4eec1b39b7dbd7aff952a99f"
     category: infra
-    note: Can publish NAV without a timelock; each update is bounded to 0.35% movement.
+    note: Can publish NAV without a timelock. The optional safe setter applies a 0.35% deviation limit, but the direct setter bypasses it and enforces only $0.10–$1,000 absolute bounds.
 
   - id: admin-safe
     label: Admin Safe (1/3)

--- a/reports/report/midas-mhyper.md
+++ b/reports/report/midas-mhyper.md
@@ -241,6 +241,7 @@ Both teams are public and established, documentation is substantial, and Hyperit
 | March 20, 2026 | 3.2 | [PR #103](https://github.com/yearn/risk-score/pull/103) |
 | April 13, 2026 | 2.9 | [PR #133](https://github.com/yearn/risk-score/pull/133) |
 | June 13, 2026 | 2.9 | [PR #248](https://github.com/yearn/risk-score/pull/248) |
+| August 19, 2026 | 2.8 | [PR #417](https://github.com/yearn/risk-score/pull/417) |
 
 ## Appendix: Current Control Summary
 

--- a/reports/report/midas-mhyper.md
+++ b/reports/report/midas-mhyper.md
@@ -14,8 +14,8 @@ The strategy is materially onchain but not contractually tied to the token. Hype
 
 **Current statistics (August 19, 2026):**
 
-- **NAV:** $39.41M ([NAV endpoint](https://api-midas.deltay.xyz/vaults/mHYPER/nav)); **price:** $1.121519 ([price endpoint](https://api-midas.deltay.xyz/prices)); **APY:** 5.73% ([APY endpoint](https://api-midas.deltay.xyz/apy))
-- **Ethereum supply:** 34.60M mHYPER, verified through the token's [`totalSupply()`](https://etherscan.io/token/0x9b5528528656dbc094765e2abb79f293c21191b9)
+- **NAV:** $39.41M ([NAV endpoint](https://api-midas.deltay.xyz/vaults/mHYPER/nav)); **price:** $1.121519 ([price endpoint](https://api-midas.deltay.xyz/vaults/mHYPER/prices)); **APY:** 5.73% ([APY endpoint](https://api-midas.deltay.xyz/vaults/mHYPER/apy))
+- **Ethereum supply:** 34.55M mHYPER, verified through the token's [`totalSupply()`](https://etherscan.io/token/0x9b5528528656dbc094765e2abb79f293c21191b9) at [block 25,788,517](https://etherscan.io/block/25788517)
 - **Tracked holders:** 954 across the dashboard's indexed chains ([Delta Y](https://midas.deltay.xyz/mhyper))
 - **Midas platform TVL:** $128.82M ([DeFiLlama](https://defillama.com/protocol/midas-rwa))
 - **KYC:** required; transfers are subject to Midas greenlist/blacklist controls
@@ -221,6 +221,17 @@ Both teams are public and established, documentation is substantial, and Hyperit
 | Operational Risk | 1.8 | 5% | 0.09 |
 | **Final Score** | | | **2.82 ≈ 2.8/5.0** |
 
+### Risk Tier
+
+| Final Score | Risk Tier | Recommendation |
+| --- | --- | --- |
+| **1.0-1.5** | **Minimal Risk** | Approved, high confidence |
+| **1.5-2.5** | **Low Risk** | Approved with standard monitoring |
+| **2.5-3.5** | **Medium Risk** | Approved with enhanced monitoring |
+| **3.5-4.5** | **Elevated Risk** | Limited approval, strict limits |
+| **4.5-5.0** | **High Risk** | Not recommended |
+| **N/A** | **Not Rated** | Terminal — do not use (exploited or wound down) |
+
 **Final Risk Tier: Medium Risk (2.8/5.0).** Approved with enhanced monitoring and conservative exposure limits.
 
 ## Reassessment Triggers
@@ -235,13 +246,13 @@ Both teams are public and established, documentation is substantial, and Hyperit
 
 ## Assessment History
 
-| Date | Score | Report |
+| Date | Score | Notes |
 | --- | ---: | --- |
-| February 7, 2026 | 3.3 | [PR #31](https://github.com/yearn/risk-score/pull/31) |
-| March 20, 2026 | 3.2 | [PR #103](https://github.com/yearn/risk-score/pull/103) |
-| April 13, 2026 | 2.9 | [PR #133](https://github.com/yearn/risk-score/pull/133) |
-| June 13, 2026 | 2.9 | [PR #248](https://github.com/yearn/risk-score/pull/248) |
-| August 19, 2026 | 2.8 | [PR #417](https://github.com/yearn/risk-score/pull/417) |
+| [February 7, 2026](https://github.com/yearn/risk-score/pull/31) | 3.3 | Initial assessment |
+| [March 20, 2026](https://github.com/yearn/risk-score/pull/103) | 3.2 | Attestation Engine reassessment |
+| [April 13, 2026](https://github.com/yearn/risk-score/pull/133) | 2.9 | Controls and provability reassessment |
+| [June 13, 2026](https://github.com/yearn/risk-score/pull/248) | 2.9 | Allocation and role reassessment |
+| [August 19, 2026](https://github.com/yearn/risk-score/pull/417) | 2.8 | Custody, allocation, and control reassessment |
 
 ## Appendix: Current Control Summary
 

--- a/reports/report/midas-mhyper.md
+++ b/reports/report/midas-mhyper.md
@@ -1,652 +1,270 @@
 # Protocol Risk Assessment: Midas mHYPER
 
-- **Assessment Date:** February 7, 2026 (Updated: June 13, 2026)
+- **Assessment Date:** February 7, 2026 (Updated: August 19, 2026)
 - **Token:** mHYPER
-- **Chain:** Ethereum (also deployed on Monad, Plasma, Katana)
+- **Chain:** Ethereum (also deployed on Monad, Plasma, and Katana)
 - **Token Address:** [`0x9b5528528656DBC094765E2abB79F293c21191B9`](https://etherscan.io/token/0x9b5528528656dbc094765e2abb79f293c21191b9)
-- **Final Score: 2.9/5.0**
+- **Final Score: 2.8/5.0**
 
 ## Overview + Links
 
-mHYPER is a tokenized certificate (Liquid Yield Token / LYT) issued by Midas Software GmbH, a German-incorporated tokenization platform. It references the performance of **market-neutral, stablecoin-focused strategies** managed by [Hyperithm](https://www.hyperithm.com/), a digital asset management firm based in Tokyo and Seoul.
+mHYPER is a yield-bearing tokenized certificate issued by Midas Software GmbH. Its price references a stablecoin-focused, market-neutral portfolio managed by [Hyperithm](https://www.hyperithm.com/). Yield accrues through the token price rather than rebasing. mHYPER is legally a qualified subordinated debt claim against the German issuer, not a direct ownership interest in strategy assets or a bankruptcy-remote vehicle.
 
-mHYPER is **not** a stablecoin — its value floats based on strategy performance. Yield is auto-compounded into the token price (NAV), updated onchain twice per week via a custom oracle (see [oracle history](https://etherscan.io/address/0x43881B05C3BE68B2d33eb70aDdF9F666C5005f68)). The token has appreciated from $1.00 at inception to ~$1.1031 as of June 2026 (per [Midas app](https://midas.app/mhyper)).
+The strategy is materially onchain but not contractually tied to the token. Hyperithm deploys capital through Midas/Fordefi-controlled allocator wallets, Midas publishes an admin-set NAV price, and minting is not limited by an onchain proof-of-reserves check. The [Delta Y transparency dashboard](https://midas.deltay.xyz/mhyper) and [Midas Attestation Engine](https://docs.midas.app/transparency/the-midas-attestation-engine) provide meaningful visibility and independent checks, but wallet attribution and source data remain offchain assertions.
 
-The yield strategy includes:
+**Current statistics (August 19, 2026):**
 
-- Leveraged USDe positions on **Aave**
-- Stablecoin farming on **Pendle**
-- Basis trading on **Hyperliquid**
-- Liquidity provision on **Morpho** vaults
-- Carry trades, liquidation arbitrage, reward farming
+- **NAV:** $39.41M ([NAV endpoint](https://api-midas.deltay.xyz/vaults/mHYPER/nav)); **price:** $1.121519 ([price endpoint](https://api-midas.deltay.xyz/prices)); **APY:** 5.73% ([APY endpoint](https://api-midas.deltay.xyz/apy))
+- **Ethereum supply:** 34.60M mHYPER, verified through the token's [`totalSupply()`](https://etherscan.io/token/0x9b5528528656dbc094765e2abb79f293c21191b9)
+- **Tracked holders:** 954 across the dashboard's indexed chains ([Delta Y](https://midas.deltay.xyz/mhyper))
+- **Midas platform TVL:** $128.82M ([DeFiLlama](https://defillama.com/protocol/midas-rwa))
+- **KYC:** required; transfers are subject to Midas greenlist/blacklist controls
 
-Legally, mHYPER tokens are structured as **subordinated debt instruments** of Midas Software GmbH. Midas operates [two issuance structures](https://docs.midas.app/legal/legal-structure): a **Luxembourg securitisation** vehicle with statutory asset segregation and bankruptcy remoteness, and a **German GmbH** structure. mHYPER uses the **German GmbH structure**.
+**Primary links:**
 
-**Key Stats:**
-
-- **mHYPER Market Cap / TVL:** ~$36.17M per [Midas app](https://midas.app/mhyper) (June 13, 2026; total supply 32,651,929 mHYPER × $1.1031)
-- **Total Supply:** 32,651,929 mHYPER across 4 chains per [attestation PDF](https://drive.google.com/file/d/1hYCD-3ypY71xbbVmy0JLz_0HaXIsZXKl/view) (June 12, 2026): Ethereum 29,463,808, Monad 2,693,208, Plasma 494,909, Katana 4. Ethereum [onchain supply](https://etherscan.io/token/0x9b5528528656DBC094765E2abB79F293c21191B9): ~29,512,770
-- **Holders:** ~467 addresses (Ethereum only, [last verified April 2026](https://etherscan.io/token/0x9b5528528656DBC094765E2abB79F293c21191B9))
-- **APY:** 10.46% per [Midas app](https://midas.app/mhyper) (June 13, 2026)
-- **Midas Platform TVL:** ~$78.7M Ethereum [DeFiLlama](https://defillama.com/protocol/midas-rwa) (June 13, 2026; DeFiLlama does not count all Midas positions — total platform TVL ~$110M per [SumCap](https://midas.sumcap.xyz/), down from ~$216.6M in April 2026)
-- **KYC Required:** Yes (greenlist enforced onchain)
-
-**Links:**
-
-- [Midas Documentation](https://docs.midas.app/)
-- [Midas App - mHYPER](https://midas.app/mhyper)
-- [Hyperithm Website](https://www.hyperithm.com/)
-- [Legal Documents](https://docs.midas.app/resources/legal-product-documentation/mhyper)
-- [mHYPER Transparency Page](https://midas.app/transparency?token=mhyper)
+- [Midas mHYPER product page](https://midas.app/mhyper)
+- [Midas documentation](https://docs.midas.app/)
+- [mHYPER legal documents](https://docs.midas.app/resources/legal-product-documentation/mhyper)
+- [Delta Y mHYPER transparency](https://midas.deltay.xyz/mhyper)
+- [Hyperithm](https://www.hyperithm.com/)
 
 ## Contract Addresses
 
-All contracts use OpenZeppelin's `TransparentUpgradeableProxy` pattern with a shared `ProxyAdmin`.
+The core Ethereum contracts use OpenZeppelin transparent proxies with a shared `ProxyAdmin`.
 
+| Contract | Proxy | Current implementation |
+| --- | --- | --- |
+| mHYPER token | [`0x9b5528528656DBC094765E2abB79F293c21191B9`](https://etherscan.io/address/0x9b5528528656DBC094765E2abB79F293c21191B9) | [`0x3f0ec5b26ec6e50907abea87a798bf395189bcd5`](https://etherscan.io/address/0x3f0ec5b26ec6e50907abea87a798bf395189bcd5) |
+| mHYPER/USD oracle | [`0x43881B05C3BE68B2d33eb70aDdF9F666C5005f68`](https://etherscan.io/address/0x43881B05C3BE68B2d33eb70aDdF9F666C5005f68) | [`0xa19f5e16dc09641b17adf95bc950f71dbe5cb11b`](https://etherscan.io/address/0xa19f5e16dc09641b17adf95bc950f71dbe5cb11b) |
+| mHYPER DataFeed | [`0x92004DCC5359eD67f287F32d12715A37916deCdE`](https://etherscan.io/address/0x92004DCC5359eD67f287F32d12715A37916deCdE) | [`0xE3240302aCEc5922b8549509615c16a97C05654A`](https://etherscan.io/address/0xE3240302aCEc5922b8549509615c16a97C05654A) |
+| DepositVault | [`0xbA9FD2850965053Ffab368Df8AA7eD2486f11024`](https://etherscan.io/address/0xbA9FD2850965053Ffab368Df8AA7eD2486f11024) | [`0xd2B5f8f1DED3D6e00965b8215b57A33c21101c63`](https://etherscan.io/address/0xd2B5f8f1DED3D6e00965b8215b57A33c21101c63) |
+| RedemptionVaultWithSwapper | [`0x6Be2f55816efd0d91f52720f096006d63c366e98`](https://etherscan.io/address/0x6Be2f55816efd0d91f52720f096006d63c366e98) | [`0x570C15bC5faF98531A8b351d69E22E41e3505E47`](https://etherscan.io/address/0x570C15bC5faF98531A8b351d69E22E41e3505E47) |
+| MidasAccessControl | [`0x0312A9D1Ff2372DDEdCBB21e4B6389aFc919aC4B`](https://etherscan.io/address/0x0312A9D1Ff2372DDEdCBB21e4B6389aFc919aC4B) | [`0xDd5a54bA2ab379a5e642c58f98ad793a183960e2`](https://etherscan.io/address/0xDd5a54bA2ab379a5e642c58f98ad793a183960e2) |
+| Shared ProxyAdmin | [`0xbf25b58cB8DfaD688F7BcB2b87D71C23A6600AaC`](https://etherscan.io/address/0xbf25b58cB8DfaD688F7BcB2b87D71C23A6600AaC) | N/A |
+| LayerZero OFT adapter | [`0x148c86390a4ae6f7a02df5903bc0a89e8b4581a0`](https://etherscan.io/address/0x148c86390a4ae6f7a02df5903bc0a89e8b4581a0) | N/A |
 
-| Contract                                     | Proxy Address                                                                                                         | Implementation Address                                                                                                |
-| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| **mHYPER Token**                             | [0x9b5528528656DBC094765E2abB79F293c21191B9](https://etherscan.io/address/0x9b5528528656DBC094765E2abB79F293c21191B9) | [0xE4386180dF7285E7D78794148E1B31c9EDfb0689](https://etherscan.io/address/0xE4386180dF7285E7D78794148E1B31c9EDfb0689) |
-| **mHYPER/USD Oracle** ([MHyperCustomAggregatorFeed](https://etherscan.io/address/0xa19f5e16dc09641b17adf95bc950f71dbe5cb11b)) | [0x43881B05C3BE68B2d33eb70aDdF9F666C5005f68](https://etherscan.io/address/0x43881B05C3BE68B2d33eb70aDdF9F666C5005f68) | [0xa19f5e16dc09641b17adf95bc950f71dbe5cb11b](https://etherscan.io/address/0xa19f5e16dc09641b17adf95bc950f71dbe5cb11b) |
-| **mHYPER DataFeed**                          | [0x92004DCC5359eD67f287F32d12715A37916deCdE](https://etherscan.io/address/0x92004DCC5359eD67f287F32d12715A37916deCdE) | [0xE3240302aCEc5922b8549509615c16a97C05654A](https://etherscan.io/address/0xE3240302aCEc5922b8549509615c16a97C05654A) |
-| **DepositVault**                             | [0x6Be2f55816efd0d91f52720f096006d63c366e98](https://etherscan.io/address/0x6Be2f55816efd0d91f52720f096006d63c366e98) | [0x570C15bC5faF98531A8b351d69E22E41e3505E47](https://etherscan.io/address/0x570C15bC5faF98531A8b351d69E22E41e3505E47) |
-| **RedemptionVaultWithSwapper**               | [0xbA9FD2850965053Ffab368Df8AA7eD2486f11024](https://etherscan.io/address/0xbA9FD2850965053Ffab368Df8AA7eD2486f11024) | [0xd2B5f8f1DED3D6e00965b8215b57A33c21101c63](https://etherscan.io/address/0xd2B5f8f1DED3D6e00965b8215b57A33c21101c63) |
-| **MidasAccessControl**                       | [0x0312A9D1Ff2372DDEdCBB21e4B6389aFc919aC4B](https://etherscan.io/address/0x0312A9D1Ff2372DDEdCBB21e4B6389aFc919aC4B) | [0xDd5a54bA2ab379a5e642c58f98ad793a183960e2](https://etherscan.io/address/0xDd5a54bA2ab379a5e642c58f98ad793a183960e2) |
-| **ProxyAdmin** (shared)                      | [0xbf25b58cB8DfaD688F7BcB2b87D71C23A6600AaC](https://etherscan.io/address/0xbf25b58cB8DfaD688F7BcB2b87D71C23A6600AaC) | N/A                                                                                                                   |
-| **Tokens Receiver**                          | [0xF356c5e9F69DaDB332Bb098C7Ed960Db1d3376DD](https://etherscan.io/address/0xF356c5e9F69DaDB332Bb098C7Ed960Db1d3376DD) | N/A                                                                                                                   |
-| **Deployer**                                 | [0xa0819ae43115420beb161193b8d8ba64c9f9facc](https://etherscan.io/address/0xa0819ae43115420beb161193b8d8ba64c9f9facc) | N/A                                                                                                                   |
+The token implementation was [upgraded on August 13, 2026](https://etherscan.io/tx/0xc9d222894a1bb6a4a49bebf6fb26782a56058bd23cdd9f7e2d7c3f692c7fcb9c). The verified source refactors the inherited base token and exposes `burnGoverned()` for privileged burning. The effective privileged-burn authority is broadly consistent with the earlier implementation, but no published audit on the [Midas audit page](https://docs.midas.app/resources/audits) identifies this exact implementation.
 
+## Audits and Historical Track Record
 
-**Other Chain Deployments:**
+Midas publishes ten audits and contests from Hacken, Côme, and Sherlock covering the shared token, vault, access-control, oracle, and bridge infrastructure from 2023 through 2025. Earlier findings include centralized administration, excessive vault permissions, and a permissive burn role; several findings were acknowledged or accepted rather than removed. Midas also advertises $1M of active bounty capacity split between [Sherlock](https://audits.sherlock.xyz/bug-bounties/122) and [Cantina](https://cantina.xyz/bounties/d77405e5-99ce-4ba5-846c-885820b030e1).
 
-- **mHYPER (Monad):** [`0xd90f6bfed23ffde40106fc4498dd2e9edb95e4e7`](https://monadscan.com/address/0xd90f6bfed23ffde40106fc4498dd2e9edb95e4e7)
-- **mHYPER (Plasma):** `0xb31bea5c2a43f942a3800558b1aa25978da75f8a`
-- **mHYPER (Katana):** [`0x926a8a63Fa1e1FDBBEb811a0319933B1A0F1EDbb`](https://katanascan.com/address/0x926a8a63Fa1e1FDBBEb811a0319933B1A0F1EDbb)
-
-## Audits and Due Diligence Disclosures
-
-- [Midas Audits](https://docs.midas.app/resources/audits)
-- [Hacken Audit Report](https://hacken.io/audits/midas/sca-midas-vault-dec2023/)
-- [Sherlock Audit Contest #1 (May 2024)](https://audits.sherlock.xyz/contests/332)
-- [Sherlock Audit Contest #2 (Aug 2024)](https://github.com/sherlock-audit/2024-08-midas-minter-redeemer-judging)
-
-**Audit Status:** Extensive — 10 audits across 2023-2025 cover the Midas core contracts (vaults, tokens, access control, bridges, oracles). mHYPER is an implementation of these audited contracts. The 2025 audits cover the current core contracts.
-
-**2025 Audits:**
-
-| Audit | Firm | Scope | Link |
-|-------|------|-------|------|
-| Midas Core Contracts (2025) | **Côme** | Core contracts | [Report](https://docs.midas.app/resources/audits/come-midas-core-contracts-2025) |
-| Midas Core Contracts Contest (2025) | **Sherlock** | Core contracts | [Contest](https://docs.midas.app/resources/audits/sherlock-midas-core-contracts-2025) |
-
-**2024 Audits:**
-
-| Audit | Firm | Scope | Link |
-|-------|------|-------|------|
-| Midas Core Contracts (2024) | **Hacken** | Core contracts | [Report](https://docs.midas.app/resources/audits/hacken-midas-core-contracts-2024) |
-| Midas Core Contracts Contest (2024) | **Sherlock** | DepositVault, RedemptionVault, MidasAccessControl, DataFeed | [Contest](https://docs.midas.app/resources/audits/sherlock-midas-core-contracts-2024) |
-| Issuance & Redemption Vaults | **Sherlock** | Instant mint/redeem, BUIDL integration, new oracles | [Contest](https://docs.midas.app/resources/audits/sherlock-issuance-redemption-2024) |
-| Bridge Integrations | **Sherlock** | LayerZero & Axelar bridge integrations | [Contest](https://docs.midas.app/resources/audits/sherlock-bridge-integrations-2024) |
-| Oracle System | **Sherlock** | Oracle infrastructure | [Contest](https://docs.midas.app/resources/audits/sherlock-oracle-system-2024) |
-| Legacy Tokens & Vaults | **Sherlock** | Legacy components | [Contest](https://docs.midas.app/resources/audits/sherlock-legacy-tokens-2024) |
-| Midas Contracts (2024) | **Côme** | Contracts | [Report](https://docs.midas.app/resources/audits/come-midas-contracts-2024) |
-
-**2023 Audits:**
-
-| Audit | Firm | Scope | Link |
-|-------|------|-------|------|
-| Midas Contracts (2023) | **Hacken** | mTBILL token, DepositVault, RedemptionVault, ManageableVault, access control (15 contracts) | [Report](https://docs.midas.app/resources/audits/hacken-midas-contracts-2023) |
-
-**Hacken Audit Results (Dec 2023):**
-
-- Security Score: 10/10 (post-fix). 100% branch coverage
-- 0 Critical, 1 High (Accepted — USD tokens with custom decimals), 2 Medium (1 fixed: missing oracle refresh; 1 accepted: 1:1 price assumption), 1 Low (permissive role for token burning — accepted), 4 Observations
-- **Critical note:** Auditors explicitly flagged the protocol as **"highly centralized"** with system admins controlling all critical roles
-
-**Sherlock Core Contracts Contest (2024):**
-
-- 1 High (blacklist bypass via `renounceRole` — acknowledged), 2 Medium (corruptible upgradability pattern — fixed; excessive vault admin permissions — acknowledged)
-
-**Sherlock Issuance & Redemption Contest (2024):**
-
-- 1 High (reclassified to Medium — RedemptionVaultWithBUIDL initialization DoS), 6 Medium (BUIDL balance handling, standard redemption allowance gaps, spec/code discrepancies)
-
-**Smart Contract Complexity:** Low-Moderate
-
-- mHYPER extends mTBILL (simple ERC-20 with pausable, role-controlled mint/burn)
-- Standard OpenZeppelin TransparentUpgradeableProxy pattern
-- **Custom oracle (MHyperCustomAggregatorFeed) wrapping Chainlink's AggregatorV3 interface — **not** a Chainlink data feed
-- Access control via shared MidasAccessControl contract (`M_HYPER_CUSTOM_AGGREGATOR_FEED_ADMIN_ROLE`)
-
-### Bug Bounty
-
-- **$1,000,000 USD** total allocated across two platforms ([Midas docs](https://docs.midas.app/security/smart-contract-security)):
-  - **[Sherlock Bug Bounty](https://audits.sherlock.xyz/bug-bounties/122)** — Live since March 31, 2026. Max payout: $500,000 USDC. Tiers: Critical $25K-$500K (10% of affected funds), High $5K-$25K, Medium $5K, Low $500-$1K. Covers Ethereum (`contracts/**/*.sol`) and Solana (`programs/**/*.rs`)
-  - **[Cantina Bug Bounty](https://cantina.xyz/bounties/d77405e5-99ce-4ba5-846c-885820b030e1)** — Live since March 23, 2026. Max payout: $500,000. Tiers: Critical $500K, High $25K, Medium $5K, Low $1K
-
-## Historical Track Record
-
-- **Production History:** mHYPER token created on Ethereum [July 15, 2025](https://etherscan.io/tx/0x8dd0b1216e7970be06bd897ed57ebfba3f4213ec63d68aa622740608e93ffd5f) (~9 months in production). Midas platform launched with mTBILL in mid-2024 (~22 months total)
-- **TVL Growth:** Midas grew from ~$4M (July 2024) to a peak of ~$925M (September 2025, DeFiLlama), declining to ~$78.7M Ethereum / ~$110M platform (June 2026). See [DeFiLlama](https://defillama.com/protocol/midas-rwa)
-- **mHYPER Market Cap:** ~$36.0M (June 2026), down from ~$50.7M (April 2026)
-- **Price History:** mHYPER has traded between $1.024 (ATL, Sep 2025) and $1.10312 (ATH, Jun 2026) — steady appreciation consistent with yield accrual. Oracle price: $1.10312 (round 97, last updated June 12, 2026 [onchain](https://etherscan.io/address/0x43881B05C3BE68B2d33eb70aDdF9F666C5005f68)). Per [attestation PDF](https://drive.google.com/file/d/1hYCD-3ypY71xbbVmy0JLz_0HaXIsZXKl/view): Market Neutral Strategy $35.67M, Settlement Reserve $337K, Funds in Process $12K, Total assets $36.02M at price $1.10312380
-
-**Hyperithm Track Record:**
-
-- Founded January 2018 (7+ years operating history)
-- Co-founded by Sangrok Oh (ex-Morgan Stanley) and Woojun Lloyd Lee (Forbes 30 Under 30)
-- Backed by Coinbase Ventures, Samsung Next, Hashed, Kakao, Naver. $11M Series B (Aug 2021)
-- Dual regulatory registration: SPBQII in Japan (FSA), VASP in South Korea (KoFIU)
+- **mHYPER production history:** since July 15, 2025 ([deployment transaction](https://etherscan.io/tx/0x8dd0b1216e7970be06bd897ed57ebfba3f4213ec63d68aa622740608e93ffd5f))
+- **Midas platform history:** since mid-2024; DeFiLlama records a $4.08M starting TVL and a $927.76M peak ([DeFiLlama](https://defillama.com/protocol/midas-rwa))
+- **Price history:** $1.00 at inception to $1.121519; the current oracle is round 113 and was updated August 18, 2026 ([oracle](https://etherscan.io/address/0x43881B05C3BE68B2d33eb70aDdF9F666C5005f68))
+- **Known smart-contract loss:** none identified for mHYPER
 
 ## Funds Management
 
-Hyperithm is the strategy manager for mHYPER, deploying funds across multiple DeFi protocols using market-neutral, stablecoin-focused strategies. Funds remain under Midas control via Fordefi custody.
+Hyperithm has operated since 2018 and describes itself as a 60+ person digital-asset manager focused on algorithmic, high-frequency, and market-neutral strategies. The current Japanese Financial Services Agency list of Specially Permitted Businesses for Qualified Institutional Investors includes `HYPERITHM`, corporate number `8010001189312`, for private placement and investment management. The FSA explicitly cautions that this notification regime is not an endorsement and is principally for professional-investor business ([FSA registry](https://www.fsa.go.jp/menkyo/menkyoj/tokurei.html)). Hyperithm is not present in the FSA's current cessation or uncontactable-business lists.
 
-- **Fund Manager:** Hyperithm (Tokyo/Seoul, founded 2018, AUM $300M+)
-- **Strategy:** Multi-chain stablecoin yield — leveraged USDe on Aave, farming on Pendle, basis trading on Hyperliquid, Morpho vault liquidity, carry trades, liquidation arbitrage. **Previous allocation snapshot** ([transparency page](https://midas.app/transparency?token=mhyper), April 10, 2026): Fluid 28.7%, Aave 21.6%, Kamino 19.3% (Solana lending), Morpho 15.0%, Pendle 14.7%, Wallet 0.7%, Hyperliquid/Lighter <0.1%. Total NAV ~$49.6M. **Current allocation (June 13, 2026) per [SumCap tracker](https://midas.sumcap.xyz/mhyper):** Fluid 15.4% ($5.55M), Uniswap V4 5.6% ($2.02M), Onchain Wallets 1.5% ($548K), Assets to be Deployed 0.4% ($153K), Liquidity Buffer 0.1% ($37K), Merkl 0.1% ($30K), others <0.01%. **76.8% of mHYPER NAV ($27.7M) is classified as "Unclassified" by SumCap** — likely positions on non-Ethereum chains (Kamino/Solana, Monad, Plasma, Katana) that SumCap does not index, or offchain/CEX allocations. The strategy landscape has shifted materially from the April snapshot: Aave, Kamino, Morpho, and Pendle are no longer individually visible in onchain tracked positions, and total mHYPER NAV has declined ~27% (from $49.6M to $36.0M). **The Midas transparency page is Cloudflare-gated and the [attestation PDF](https://drive.google.com/file/d/1hYCD-3ypY71xbbVmy0JLz_0HaXIsZXKl/view) (June 12, 2026) only reports a single "Market Neutral Strategy" line ($35.67M) without protocol-level breakdown**
-- **Strategy Execution:** Offchain by Hyperithm with discretionary investment decisions
-- **Custody:** Fordefi MPC custody with tri-party quorum per [Fordefi case study](https://web.fordefi.com/customer-stories/how-midas-brings-tokenized-investment-opportunities-on-chain-with-fordefis-defi-native-custody-2ti85) (Midas + Hyperithm + independent signer — operations outside predefined rules require all three parties). Blockaid co-signer provides automated onchain transaction monitoring and threat protection (per Midas). Fordefi is the primary custodian for LYT products; Midas also uses Fireblocks for other product lines
-- **Monitoring:** NAV updates provided by Hyperithm, reviewed by Midas, then published onchain twice per week
+Midas's launch disclosure described Hyperithm as managing more than $300M, but Hyperithm's current public site does not publish live AUM. The manager has discretionary strategy authority inside Fordefi transaction policies; no smart contract restricts protocol selection, leverage, or concentration.
 
-### Accessibility
+### Current allocation
 
-- **KYC Required:** Yes — users must complete KYC/AML screening (1-4 business days). Once approved, added to onchain greenlist via `Greenlistable` contract. Chainalysis Oracle integration for sanctions screening
-- **Minting:** Deposit USDC, receive mHYPER tokens. Default mode is instant issuance
-- **Redemption:** Two modes:
-  - **Instant:** Atomic onchain at oracle price when liquidity is available, **0.50% instant redemption fee.**
-  - **Standard:** 1-3 business day queue (fallback when instant capacity is insufficient). Subject to Risk Manager setting aside funds
-- **Fees:** 0% management fee, 20% performance fee (from yield, earned by Midas), 0% standard mint/redeem fees, 0.50% instant redemption fee (earned by the mHYPER portfolio itself to compensate for cash drag from keeping redemption liquidity idle)
-- **Geographic Restrictions:** Not available to US persons, UK, China, and sanctioned countries.
+Delta Y reports the following net allocations against $39.41M NAV. Its methodology uses the higher of onchain supply multiplied by oracle price and the sum of tracked allocator-wallet NAV. Consequently, `Unclassified` is a residual rather than proof of a specific offchain asset, and wallet-to-product attribution is maintained by the dashboard rather than enforced onchain.
 
-### Collateralization
+| Allocation | Net value | NAV share | Main location / risk |
+| --- | ---: | ---: | --- |
+| Morpho V2 | $16.84M | 42.72% | USDC positions on Monad and Ethereum; exact vault is not identified by the public API |
+| Hypercore | $12.69M | 32.20% | Hyperliquid spot, perpetual, and staking balances |
+| Fluid | $4.62M | 11.72% | Leveraged positions across Ethereum, Arbitrum, and Plasma |
+| Unclassified residual | $2.95M | 7.48% | Difference under the dashboard's max-NAV methodology |
+| Onchain wallets | $1.27M | 3.22% | Predominantly idle USDC |
+| Midas redemption vault | $0.74M | 1.88% | USDC available in the redemption path |
+| Liquidity buffer | $0.28M | 0.70% | Additional backing-side liquidity |
+| Other | $0.03M | 0.08% | Assets to deploy, Ethena, Kamino, Merkl, and dust |
 
-- **Backing Model:** Offchain / hybrid — mHYPER is a **subordinated debt instrument** of Midas Software GmbH, not a direct claim on underlying assets
-- **Collateral Quality:** Strategies target stablecoin-focused, market-neutral positions across Aave (blue-chip), Pendle (established), Hyperliquid (newer, centralized perps DEX), Morpho (established), Kamino (Solana). Includes leveraged positions and basis trading
-- **Verifiability:** Mostly onchain — per Midas, ~96% of mHYPER strategy positions are held onchain and visible via the [transparency page](https://midas.app/transparency?token=mhyper); ~4% are held on CEX/offchain venues. Wallet-to-product attribution and the offchain component still depend on Midas/Hyperithm reporting and the Attestation Engine; the link between those wallets and mHYPER is not enforced by smart contracts
-- **Risk Curation:** Hyperithm has discretion over allocation within the broad strategy framework. Midas enforces policy limits via Fordefi policy engine (address, asset, contract method, notional size)
-- **Tri-Party Governance (via Fordefi):** Per [Fordefi case study](https://web.fordefi.com/customer-stories/how-midas-brings-tokenized-investment-opportunities-on-chain-with-fordefis-defi-native-custody-2ti85): Midas Treasury + Hyperithm (Asset Manager) + Independent Oversight Signer. Operations within predefined rules clear automatically; anything outside routes to tri-party quorum. No single group can act unilaterally for custody operations
-- **Legal Structure:** LYT holders are **subordinate creditors** of Midas Software GmbH. mHYPER uses the German GmbH issuance structure — no statutory asset segregation or bankruptcy remoteness. Midas's Luxembourg securitisation vehicle offers these protections but is used for other products, not mHYPER
+The current portfolio has two large venue concentrations: Morpho V2 and Hypercore total 74.9% of NAV. Delta Y reports portfolio-wide gross leverage of approximately 1.82x. Fluid alone has approximately $36.85M of assets and $32.23M of liabilities, or about 7.97x assets/net equity. A public strategy notice also permits up to 10% of mHYPER AUM in the Hyperithm Degen Vault, which can supply a whitelisted mHYPER/USDC Morpho market and introduces recursive lending/rehypothecation risk. The public allocation API does not establish that all reported Morpho exposure is in that vault.
 
-### Provability
+### Custody and multisig assessment
 
-- **Reserve Transparency:** Hybrid. Strategy wallets are partially onchain, but full portfolio composition requires offchain reporting. The [Midas Attestation Engine](https://docs.midas.app/transparency/the-midas-attestation-engine) (SAVE, introduced March 2026) adds a multi-party verification layer via three contracts: [KeystoneForwarder](https://etherscan.io/address/0x0b93082D9b3C7C97fAcd250082899BAcf3af3885) (Chainlink DON router), [SaveCreReceiverProxy](https://etherscan.io/address/0xC50102b6598924Aa8deB201c757bFb9a3dBdB9b6) (receiver), and [MidasSaveRegistryWithClaim](https://etherscan.io/address/0x2D6e9F608807436DE5D9603B00Abe3FEd1Bc809d) (registry). The registry is a hash-only store: it records proof IDs, attestation hashes, claim hashes, verifier hashes, timestamps, and attestor/verifier addresses. It does **not** expose the actual reserve data, wallet balances, document content, or an onchain URI/CID that lets users retrieve the source artifact from the registry alone. Midas docs state that notarized source material is stored on IPFS, while public weekly PDF reports are available on [Google Drive](https://drive.google.com/drive/folders/1MJi_xq8aR0TaL0DJw6Q91SFxM_z0OcYZ). The onchain registry proves that a specific hash was attested and independently verified, but interpreting the underlying NAV/reserve data still depends on offchain-disclosed artifacts and links
-- **NAV/Price Updates:** Token price updated **twice per week** by Midas via a privileged role on the `MHyperCustomAggregatorFeed` oracle (implementation upgraded to [`0xa19f5e16dc09641b17adf95bc950f71dbe5cb11b`](https://etherscan.io/address/0xa19f5e16dc09641b17adf95bc950f71dbe5cb11b), June 2026). Current price: ~$1.10312 (round 97, 8 decimals, last updated June 12, 2026). The oracle enforces onchain bounds: `maxAnswerDeviation` of 0.35% per update (35000000 in 8-decimal precision), `minAnswer` of $0.10, and `maxAnswer` of $1,000 — providing tight deviation control per update. The oracle price is deterministic onchain at deposit time (users know the exact token amount). For standard redemptions, the price may update before processing — this ensures the payout accurately reflects current NAV, avoiding over/under-payment to either the redeemer or remaining holders. The Attestation Engine separately verifies and anchors NAV source-data hashes, but does not currently enforce oracle update correctness onchain
-- **Verification Agent:** [The Attestation Engine](https://docs.midas.app/transparency/the-midas-attestation-engine) introduces **LlamaRisk** and **Canary Protocol** as independent third-party verifiers that confirm data origins, processes, and handling meet defined criteria
-- **Third-Party Verification:** For Morpho integration, eOracle independently verifies and publishes pricing. Steakhouse applies market discounts for liquidation optimization. The Attestation Engine publishes verified hashes onchain via **Chainlink Runtime Environment**, replacing the previous self-generated attestation reports. The oracle wraps the Chainlink AggregatorV3 interface but the underlying price feed is **not** a Chainlink data feed
+[Fordefi's Midas case study](https://web.fordefi.com/customer-stories/how-midas-brings-tokenized-investment-opportunities-on-chain-with-fordefis-defi-native-custody-2ti85) describes a policy engine that checks destination, asset, method, and notional. Transactions inside a pre-approved policy can execute automatically; exceptions route to Midas treasury, the asset manager, and an independent signer. Midas retains an administrative share and the manager retains an MPC share. This is a meaningful operational control, but the policy thresholds and current configuration are not publicly inspectable onchain.
+
+The current dashboard identifies the following primary allocator wallets:
+
+| Wallet | Current use |
+| --- | --- |
+| [`0x68e7...8264`](https://etherscan.io/address/0x68e7E72938db36a5CBbCa7b52c71DBBaaDfB8264) (Fordefi2) | Morpho V2 and most idle wallet assets |
+| [`0xcd06...3186`](https://etherscan.io/address/0xcd0673721a489B1CeA0E2580FA304Bcb6ccA3186) (Fordefi3) | Hypercore / Hyperliquid |
+| [`0x17B5...c7D2`](https://etherscan.io/address/0x17B504247b0D8c1856e541a70495dd622023c7D2) (Fordefi4) | Most Fluid positions |
+
+The three dashboard-labeled Safe wallets do not establish a blanket multisig over current fund management:
+
+- [`0xe7c2...Ec9a`](https://app.safe.global/home?safe=eth:0xe7c241B82c2cd7e96E6ea656b08752f8C01DEc9a) (Safe1) is **1-of-1**, solely owned by Fordefi2. Its 68 recorded transactions each require one confirmation.
+- [`0xb81E...d475`](https://hyperevmscan.io/address/0xb81Eb60fA132535346eA93D46916A52a8c3dd475) (Safe2) is **1-of-1**, solely owned by Fordefi2 on HyperEVM.
+- [`0xA4E1...c5eA`](https://app.safe.global/home?safe=eth:0xA4E16cEdBBaF9c35d2adC4eaD2e87343C3cec5eA) (Safe3) is a genuine **2-of-2** between Fordefi2 and a second owner. Its sole recorded transaction required both confirmations.
+
+Delta Y does not currently attribute material strategy NAV to Safe1, Safe2, or Safe3. Most visible NAV is instead attributed directly to Fordefi2, Fordefi3, and Fordefi4. The appropriate positive control is therefore Fordefi's MPC and policy-based governance, plus the isolated 2-of-2 Safe—not a claim that the current portfolio as a whole is protected by an onchain multisig quorum.
+
+### Collateralization and legal claim
+
+- mHYPER is a qualified subordinated debt obligation of Midas Software GmbH. Holders have no direct title to allocator-wallet assets, statutory segregation, or bankruptcy remoteness under this German GmbH structure ([legal structure](https://docs.midas.app/legal/legal-structure)).
+- Midas's [qualified-subordination disclosure](https://docs.midas.app/legal/qualified-subordination) states that claims may be unenforceable before formal insolvency if payment would cause insolvency and that total loss is possible.
+- The portfolio is stablecoin-focused but includes protocol, bridge, oracle, leverage, counterparty, and Hyperliquid execution risks.
+- Administrators can grant mint authority without an onchain collateral check.
+
+### Provability and attestations
+
+The Delta Y dashboard classifies 92.5% of current NAV, a substantial level of observable detail. Its public API exposes wallet metadata, positions, assets, liabilities, chain allocations, and calculation methodology. The main limitations are the 7.48% residual, unidentified exact Morpho vaults, offchain wallet attribution, and lack of a contract-enforced reconciliation to token supply.
+
+The [SAVE registry](https://etherscan.io/address/0x2D6e9F608807436DE5D9603B00Abe3FEd1Bc809d) has continued operating. The latest mHYPER attestation was posted August 18, 2026, with two claims and two verifier records. The registry stores hashes, actors, and timestamps; it does not store the underlying balances or expose a retrievable source URI. SAVE therefore provides tamper-evident, multi-party evidence, but it neither proves live solvency by itself nor gates minting or oracle updates.
 
 ## Liquidity Risk
 
-- **DEX Liquidity:** Negligible — ~$11.5K total on Uniswap V4 (mHYPER/USDC 0.2% pool). 24h volume effectively $0. Not a viable exit for any position size. DEX liquidity has declined ~64% since February 2026
-- **Primary Exit:** Via Midas redemption vaults (instant or standard mode)
-- **Instant Redemption:** 1-2% target capacity, topped up multiple times per day
-- **Standard Redemption:** 1-3 business day queue when instant capacity is insufficient
-- **Pendle:** ~$10.14M TVL in mHYPER Pendle pools across 5 markets (yield tokenization, not direct swap liquidity). Up from ~$5.53M in February. **As of June 2026, Pendle V2 has <0.01% of mHYPER NAV per [SumCap](https://midas.sumcap.xyz/mhyper)**, suggesting Pendle liquidity is likely from other holders, not the primary strategy wallet
-- **Stress Test:** mHYPER processed $150M+ in redemptions in 48 hours when Stream Finance unwound its $75M leveraged position. This is a positive signal for the redemption mechanism but required standard (non-instant) processing and active coordination
-- **Large Holder Impact:** With ~467 holders and $36.0M market cap, average position is ~$77K. Large holders likely face multi-day standard redemption queues
+- **Primary exit:** Midas offers instant redemption when vault liquidity is available, subject to a 0.50% fee. Standard redemption depends on the risk manager setting funds aside; the product page says this is usually completed after two price updates but gives no binding completion time or execution price guarantee ([mHYPER product page](https://midas.app/mhyper)).
+- **Backing-side liquidity:** the redemption-vault balance and liquidity buffer total approximately $1.02M, or 2.59% of NAV.
+- **Direct DEX liquidity:** the GeckoTerminal-indexed mHYPER/USDC pool has effectively zero reserves and volume, so it is not a practical exit route ([GeckoTerminal](https://www.geckoterminal.com/eth/pools/0x8df7e5d4d7f09b1cb516443f49a165747a503462)).
+- **Integrations:** DeFiLlama identifies approximately $1.33M in a Pendle mHYPER pool, $0.92M across Morpho mHYPER markets, and $1.16M in Strata tranches. These integrations improve utility but are not equivalent to spot redemption depth ([DeFiLlama Yields](https://defillama.com/yields)).
+
+Liquidity remains dependent on active Midas/Hyperithm unwinds and redemption operations. The limited liquid buffer and strategy concentration make a large synchronized exit vulnerable to delay and price movement.
 
 ## Centralization & Control Risks
 
 ### Governance
 
-- **Contract Upgradeability:** Yes — all contracts use `TransparentUpgradeableProxy` with a shared `ProxyAdmin` at [`0xbf25b58cB8DfaD688F7BcB2b87D71C23A6600AaC`](https://etherscan.io/address/0xbf25b58cB8DfaD688F7BcB2b87D71C23A6600AaC)
-- **ProxyAdmin Owner:** [`MidasTimelockController`](https://etherscan.io/address/0xE3EEe3e0D2398799C884a47FC40C029C8e241852) — a verified OpenZeppelin `TimelockController` with a **48-hour minimum delay**. Contract upgrades must be proposed, wait 48 hours, then executed
-- **Timelock Proposer/Executor:** Gnosis Safe [`0xB60842E9DaBCd1C52e354ac30E82a97661cB7E89`](https://etherscan.io/address/0xB60842E9DaBCd1C52e354ac30E82a97661cB7E89) — **1/3 onchain threshold** (any single Safe owner can propose/execute). The practical signer setup is stronger than a plain 1/3 EOA Safe, but part of that protection is offchain:
-  - [`0x8003544D32eE074aA8A1fb72129Fa8Ef7fe02E5f`](https://etherscan.io/address/0x8003544D32eE074aA8A1fb72129Fa8Ef7fe02E5f) — EOA onchain. Per Midas, controlled by a Fordefi MPC policy with 3/n approvers — not verifiable onchain
-  - [`0x82B30194bEae06D991Bc71850F949ec8cB7E0CB7`](https://etherscan.io/address/0x82B30194bEae06D991Bc71850F949ec8cB7E0CB7) — Nested Gnosis Safe (3/7)
-  - [`0xC50BD8430545C80a681C7cb33E6560fB0Bd86880`](https://etherscan.io/address/0xC50BD8430545C80a681C7cb33E6560fB0Bd86880) — EOA onchain. Per Midas, controlled by a Fireblocks MPC policy with 3/n approvers — not verifiable onchain
-- **Access Control:** Role-based via `MidasAccessControl` ([`0x0312A9D1Ff2372DDEdCBB21e4B6389aFc919aC4B`](https://etherscan.io/address/0x0312A9D1Ff2372DDEdCBB21e4B6389aFc919aC4B))
-- **DEFAULT_ADMIN_ROLE holders:** Two addresses hold `DEFAULT_ADMIN_ROLE` on MidasAccessControl — **role changes (mint/burn/pause/blacklist grants) bypass the timelock** and can be executed immediately:
-  - The 1/3 Gnosis Safe ([`0xB60842E9DaBCd1C52e354ac30E82a97661cB7E89`](https://etherscan.io/address/0xB60842E9DaBCd1C52e354ac30E82a97661cB7E89))
-  - [`0xd4195cf4df289a4748c1a7b6ddbe770e27ba1227`](https://etherscan.io/address/0xd4195cf4df289a4748c1a7b6ddbe770e27ba1227) — EOA onchain. [Per Midas](https://docs.midas.app/security/smart-contract-security#midas-controller), Fordefi MPC (3/n) — not verifiable onchain
-  - ⚠️ **Reduced from 3 to 2** since April 2026: [`0x875c06a295c41c27840b9c9dfda7f3d819d8bc6a`](https://etherscan.io/address/0x875c06a295c41c27840b9c9dfda7f3d819d8bc6a) no longer holds `DEFAULT_ADMIN_ROLE` (verified onchain June 13, 2026). This address was originally granted the role at [block 18691340](https://etherscan.io/tx/0x45a857fa7949fec06c1cc124a26a199ff2a4d3f6b4665a7830db7b4a7c3c729c) (Dec 2023) alongside 7 other roles but was effectively removed through a past implementation upgrade (no `RoleRevoked` event onchain)
-  - **Either of the two remaining admins can grant/revoke any role with no timelock.** Midas states they are working on gating specific functions behind a timelock
-- **Governance Model:** No onchain governance. Midas controls all admin functions
-- **Privileged Roles:**
-  1. **`M_HYPER_MINT_OPERATOR_ROLE`** (`0xe6046a6e8c55ddf579e30dbcefd2018a368c8b9d4836e839e4858921fb6305d7`) — Can mint unlimited mHYPER tokens. **The `mint()` function has no onchain collateral check** — it only verifies the caller has the mint role, then calls OpenZeppelin `_mint()` directly. Currently held by:
-    - [`0x5683de280d0c3967fba2f04d707fa1ef5a044e25`](https://etherscan.io/address/0x5683de280d0c3967fba2f04d707fa1ef5a044e25) — EOA onchain. Per Midas, Fordefi MPC (3/n) used for operational processes — not verifiable onchain. Also holds BURN, PAUSE, BLACKLIST, and GREENLIST roles (5 total, all mHYPER-only). Nonce 0 (never sent a transaction). **Not listed as a mint role holder in [Midas security docs](https://docs.midas.app/security/smart-contract-security#role-based-access-control)** (docs only mention DepositVault and OFT bridge). All roles [granted](https://etherscan.io/tx/0x4254a910f7133d2ef54913662f19a0af1f9974d33391ca84ca8c60dffa025301) in a single batch on July 16, 2025
-    - [`0xbA9FD2850965053Ffab368Df8AA7eD2486f11024`](https://etherscan.io/address/0xbA9FD2850965053Ffab368Df8AA7eD2486f11024) — DepositVault (mints when users deposit USDC)
-    - [`0x148c86390a4ae6f7a02df5903bc0a89e8b4581a0`](https://etherscan.io/address/0x148c86390a4ae6f7a02df5903bc0a89e8b4581a0) — LayerZero OFT adapter (cross-chain bridge)
-  2. **`M_HYPER_BURN_OPERATOR_ROLE`** — Can burn mHYPER tokens from any address. **Changed since April 2026:** RedemptionVault was removed, DepositVault was added. Currently held by:
-    - [`0x5683de280d0c3967fba2f04d707fa1ef5a044e25`](https://etherscan.io/address/0x5683de280d0c3967fba2f04d707fa1ef5a044e25) — same EOA as above (Fordefi MPC)
-    - [`0x6Be2f55816efd0d91f52720f096006d63c366e98`](https://etherscan.io/address/0x6Be2f55816efd0d91f52720f096006d63c366e98) — DepositVault (🆕 added)
-    - [`0x148c86390a4ae6f7a02df5903bc0a89e8b4581a0`](https://etherscan.io/address/0x148c86390a4ae6f7a02df5903bc0a89e8b4581a0) — LayerZero OFT adapter (cross-chain bridge)
-  3. **`M_HYPER_PAUSE_OPERATOR_ROLE`** — Can pause/unpause the contract (freezing all transfers)
-  4. **`DEFAULT_ADMIN_ROLE`** — Can grant/revoke all other roles (held by 1/3 Safe + two standalone EOAs, no timelock). A compromised admin can grant itself the MINT role and mint unbacked tokens in two transactions
-  5. **ProxyAdmin owner** — Can upgrade all contract implementations (via 48hr timelock)
-  6. **Oracle updater** — Can set the NAV price via `MHyperCustomAggregatorFeed` (implementation upgraded from `CustomAggregatorFeed` to [`0xa19f5e16dc09641b17adf95bc950f71dbe5cb11b`](https://etherscan.io/address/0xa19f5e16dc09641b17adf95bc950f71dbe5cb11b) since April 2026). The new implementation uses `M_HYPER_CUSTOM_AGGREGATOR_FEED_ADMIN_ROLE` (previously `UPDATER_ROLE`) for access control via MidasAccessControl. Currently held by EOA [`0xd1e01471f3e1002d4eec1b39b7dbd7aff952a99f`](https://etherscan.io/address/0xd1e01471f3e1002d4eec1b39b7dbd7aff952a99f) — a single EOA with no timelock on price updates. The new implementation has both [`setRoundData`](https://etherscan.io/address/0xa19f5e16dc09641b17adf95bc950f71dbe5cb11b#code) and `setRoundDataSafe` functions. Onchain bounds unchanged: max 0.35% deviation per update, price range $0.10-$1,000
-  7. **Blacklist operator** — Can blacklist addresses from interacting with the token
-- **Fund Seizure / Unbacked Minting:** The mint operator can create tokens without depositing collateral (no onchain backing check). The burn operator can burn from any address (now includes DepositVault in addition to the EOA and OFT adapter). The blacklist/pause operators can freeze activity. Role grants bypass the timelock — either of the two `DEFAULT_ADMIN_ROLE` holders can grant themselves these roles immediately and unilaterally. `renounceRole` is disabled (always reverts)
-- **Audit Assessment:** Hacken auditors explicitly flagged the protocol as **"highly centralized"** with system admins controlling all critical roles
+- The shared [`ProxyAdmin`](https://etherscan.io/address/0xbf25b58cB8DfaD688F7BcB2b87D71C23A6600AaC) is owned by a 48-hour [`MidasTimelockController`](https://etherscan.io/address/0xE3EEe3e0D2398799C884a47FC40C029C8e241852).
+- `DEFAULT_ADMIN_ROLE` has two direct holders: a [`1-of-3 Safe`](https://app.safe.global/home?safe=eth:0xB60842E9DaBCd1C52e354ac30E82a97661cB7E89) and Fordefi MPC address [`0xd419...1227`](https://etherscan.io/address/0xd4195cf4df289a4748c1a7b6ddbe770e27ba1227). Each can grant or revoke operational roles without the timelock.
+- The admin Safe's owners include a nested [`3-of-7 Safe`](https://app.safe.global/home?safe=eth:0x82B30194bEae06D991Bc71850F949ec8cB7E0CB7), but its outer threshold remains one.
+- Mint holders are the DepositVault, LayerZero adapter, and operator [`0x5683...4e25`](https://etherscan.io/address/0x5683de280d0c3967fba2f04d707fa1ef5a044e25). Burn holders are the RedemptionVault, LayerZero adapter, and the same operator.
+- The oracle updater [`0xd1e0...a99f`](https://etherscan.io/address/0xd1e01471f3e1002d4eec1b39b7dbd7aff952a99f) can publish NAV without a timelock. Per-update movement is bounded to 0.35%, with absolute bounds of $0.10 and $1,000.
 
 ### Programmability
 
-- **System Operations:** Primarily offchain. Strategy execution, NAV calculation, and redemption processing are handled by Midas/Hyperithm offchain
-- **Oracle/NAV Updates:** The `CustomAggregatorFeed` is updated twice per week by a privileged role. The Attestation Engine adds a programmatic verification layer via Chainlink CRE, but the onchain price update itself is still admin-triggered
-- **PPS Definition:** The oracle price IS the PPS. It is updated by an admin role, not computed onchain from reserves. NAV source data is now independently checked through the Attestation Engine pipeline, but oracle updates are not computed or enforced by that registry
-- **Off-Chain Dependencies:** Critical
-  - Hyperithm's strategy execution and NAV reporting
-  - Midas's redemption processing
-  - KYC/AML verification (greenlist management)
-  - Fordefi for MPC custody and transaction signing
+Strategy selection, leverage, NAV calculation, standard redemptions, KYC, and wallet attribution are offchain processes. The token price is admin-published rather than computed from reserves. SAVE attestation and the price update are separate processes: a valid registry record is not required before the oracle changes. The token can be paused, accounts can be blacklisted, and role holders can burn governed balances.
 
-### External Dependencies
+### External dependencies
 
-- **Hyperithm (Critical):** Strategy management, NAV calculation, risk monitoring. Single external dependency for core value proposition. If Hyperithm fails or misreports, token holders have no onchain recourse
-- **Fordefi (Critical):** MPC custody of underlying assets with tri-party MPC governance. All fund movements depend on it
-- **Strategy Counterparties (Critical, June 13, 2026 per [SumCap](https://midas.sumcap.xyz/mhyper)):**
-  - **Unclassified** — 76.8% ($27.7M) of mHYPER NAV is untracked by SumCap. Likely includes positions on non-Ethereum chains (Kamino/Solana, Monad, Plasma) and offchain/CEX allocations. **This opacity is a material risk increase from April 2026**, when most positions were individually identifiable
-  - **Fluid** — 15.4% ($5.55M), borrow/lend
-  - **Uniswap V4** — 5.6% ($2.02M), liquidity provision
-  - **Onchain Wallets** — 1.5% ($548K), idle capital
-  - **Merkl** — 0.1% ($30K), reward farming
-  - **Euler, Pendle V2, Morpho V2, Hyperliquid** — each <0.01%, near-zero positions
-  - ⚠ **Aave, Kamino, Morpho, Pendle** — previously major counterparties (April 2026), now either unwound or untracked on non-Ethereum chains. The loss of visible diversification is notable
-- **Stablecoin Dependencies:** USDC, USDe (Ethena) — depegging events could impact strategy performance
-- **Oracle:** NAV reported via custom contract, now with independent verification through the Midas Attestation Engine (Chainlink CRE, LlamaRisk, Canary Protocol, vlayer)
-- **MPC wallet platform (Critical):** Midas holds distributed backup shares for the Fordefi workspace, allowing them to recover and secure key material in case of counterparty failure. Dual controls are enforced in all recovery procedures, preventing any single point of failure.
+Critical dependencies include Hyperithm, Midas, Fordefi, USDC and other stablecoins, Morpho, Hyperliquid/Hypercore, Fluid, relevant bridges, the NAV/attestation pipeline, and the legal issuer. The portfolio's current Morpho and Hypercore concentration makes those venues especially important.
+
+The LayerZero bridge configuration remains the existing assessed 4-of-4 verification setup with 1,200 confirmations; its owner is the same 1-of-3 admin Safe. No bridge-record change is required for this reassessment.
 
 ## Operational Risk
 
-- **Team Transparency:** Fully doxxed. Dennis Dinkelmeyer (CEO, ex-Goldman Sachs), Fabrice Grinda (Executive Chairman, co-founded OLX, FJ Labs), Romain Bourgois (CPO, ex-Ondo Finance). Team includes alumni from Goldman Sachs, Anchorage Digital, Capital Group
-- **Investors:** Framework Ventures (lead), BlockTower, HV Capital, Coinbase Ventures, GSR, Hack VC, Cathay Ledger, 6th Man Ventures, FJ Labs, Lattice Capital. $8.75M seed (March 2024)
-- **Documentation Quality:** Comprehensive docs at docs.midas.app covering token mechanics, fees, risk management, smart contracts. [Base Prospectus](https://content.gitbook.com/content/MndxFHqGeA4nzBBeKDTV/blobs/gEQxhKLOMjDS4tRW2my1/Midas_Prospectus_Update_2025.pdf) publicly available (approved by FMA Liechtenstein, July 17, 2025, valid until July 17, 2026 — succeeding the original July 2024 prospectus). [mHYPER Final Terms](https://content.gitbook.com/content/MndxFHqGeA4nzBBeKDTV/blobs/Rh0tXsofDB8UQWaklyuE/Midas_Final_Terms_mHYPER_2025.pdf) and [KID](https://content.gitbook.com/content/MndxFHqGeA4nzBBeKDTV/blobs/0mtdYQ1fSELYbNqAP9jd/KID_mHYPER.pdf) available
-- **Legal Structure:** Midas Software GmbH, Pappelallee 78/79, 10437 Berlin, Germany (HRB 254645, LEI 984500BB00BN6D2B7C48). Incorporated June 2023. The issuer is **neither licensed nor registered** with the Liechtenstein FMA or any other supervisory authority. Midas operates [two issuance structures](https://docs.midas.app/legal/legal-structure)
-- **Incident Response:** During the Stream Finance incident, Midas/Hyperithm processed $150M+ in redemptions within 48 hours and communicated publicly. Demonstrated operational capability under stress
+Midas and Hyperithm are identified teams with institutional investors and multi-year operating histories. Midas publishes extensive technical, legal, risk, and transparency documentation. Hyperithm's current Japanese SPBQII filing and absence from adverse FSA status lists are positive regulatory evidence, but the notification framework is not a prudential license or regulator endorsement.
+
+The current public legal-document page still exposes the July 17, 2025 base prospectus, which states a validity period ending July 17, 2026, and the 2025 mHYPER Final Terms. No replacement prospectus was found on that page as of this assessment. The product page continues to describe a public offer under the EU Prospectus Regulation. This is a documentation/control gap, not evidence that the product is operating unlawfully.
 
 ## Monitoring
 
-1. **Oracle/NAV Updates (CRITICAL)**
-  - **Contract:** [0x43881B05C3BE68B2d33eb70aDdF9F666C5005f68](https://etherscan.io/address/0x43881B05C3BE68B2d33eb70aDdF9F666C5005f68) (MHyperCustomAggregatorFeed, impl [0xa19f5e16dc09641b17adf95bc950f71dbe5cb11b](https://etherscan.io/address/0xa19f5e16dc09641b17adf95bc950f71dbe5cb11b))
-  - **Monitor:** `AnswerUpdated` events, `latestRoundData()` values, `setRoundData`/`setRoundDataSafe` calls
-  - **Alert:** Price decrease >1%, stale price (>10 days without update), unexpected large price jumps
-  - **Frequency:** Hourly
-2. **Access Control Changes (CRITICAL)**
-  - **Contract:** [0x0312A9D1Ff2372DDEdCBB21e4B6389aFc919aC4B](https://etherscan.io/address/0x0312A9D1Ff2372DDEdCBB21e4B6389aFc919aC4B) (MidasAccessControl)
-  - **Monitor:** `RoleGranted`, `RoleRevoked` events
-  - **Alert:** Any role change
-  - **Frequency:** On event
-3. **Contract Upgrades (CRITICAL)**
-  - **Contract:** [0xbf25b58cB8DfaD688F7BcB2b87D71C23A6600AaC](https://etherscan.io/address/0xbf25b58cB8DfaD688F7BcB2b87D71C23A6600AaC) (ProxyAdmin)
-  - **Monitor:** `Upgraded` events on all proxy contracts
-  - **Alert:** Any implementation change
-  - **Frequency:** Hourly
-4. **Token Supply & Transfers (RECOMMENDED)**
-  - **Contract:** [0x9b5528528656DBC094765E2abB79F293c21191B9](https://etherscan.io/address/0x9b5528528656DBC094765E2abB79F293c21191B9) (mHYPER)
-  - **Monitor:** `Paused`/`Unpaused` events, large mint/burn events, `Blacklisted` events
-  - **Alert:** Pause events, mints >$1M, any blacklist changes
-  - **Frequency:** On event
-5. **Vault Activity (RECOMMENDED)**
-  - **Contract:** [0x6Be2f55816efd0d91f52720f096006d63c366e98](https://etherscan.io/address/0x6Be2f55816efd0d91f52720f096006d63c366e98) (DepositVault)
-  - **Contract:** [0xbA9FD2850965053Ffab368Df8AA7eD2486f11024](https://etherscan.io/address/0xbA9FD2850965053Ffab368Df8AA7eD2486f11024) (RedemptionVaultWithSwapper)
-  - **Monitor:** Large deposits/redemptions, vault USDC balance
-  - **Alert:** Redemptions >$5M, vault balance <$100K
-  - **Frequency:** Hourly
-6. **External Protocol Health (RECOMMENDED)**
-  - Monitor Aave, Pendle, Hyperliquid, Morpho, and Ethena (USDe) for incidents that could impact mHYPER's underlying positions
+1. Monitor oracle `AnswerUpdated` events, staleness beyond the expected twice-weekly cadence, and any price decrease or repeated maximum-deviation updates.
+2. Alert on every `RoleGranted`, `RoleRevoked`, pause, blacklist, mint, burn, and proxy `Upgraded` event.
+3. Reconcile total cross-chain supply, oracle price, Delta Y NAV, classified wallet NAV, and SAVE timestamps at least weekly.
+4. Monitor the $1.02M redemption liquidity, standard-redemption completion times, and any change to fees or eligibility.
+5. Track Morpho, Hyperliquid/Hypercore, and Fluid health, including borrowing utilization, liquidation thresholds, and bridge dependencies.
+6. Track Fordefi policy/custody disclosures and any allocator-wallet or Safe owner/threshold change.
 
 ## Risk Summary
 
-### Key Strengths
+### Key strengths
 
-- **Doxxed team with institutional backing** — Goldman Sachs / Morgan Stanley alumni, backed by Coinbase Ventures, Framework Ventures, BlockTower
-- **Institutional-grade custody** — Fordefi MPC with tri-party MPC governance prevents unilateral fund access
-- **Regulatory compliance** — FMA-approved Base Prospectus (July 2025, valid until July 2026), German GmbH legal structure, KYC enforcement onchain
-- **Proven redemption capacity** — Processed $150M+ in redemptions within 48 hours under stress (Stream Finance incident)
-- **Extensive audits + active bug bounty** — 10 audits across 2023-2025 (Hacken, Côme, Sherlock) covering core contracts, vaults, bridges, and oracles. $1M bug bounty across Sherlock + Cantina. Clean track record (~9 months mHYPER, ~22 months Midas platform)
+- 92.5% of NAV is classified in a detailed public dashboard, with continuing multi-party SAVE attestations.
+- Fordefi MPC custody includes policy limits and multi-party exception handling; Safe3 adds a genuine 2-of-2 control for its isolated flow.
+- Ten published audits/contests, active $1M bounty capacity, and no identified mHYPER contract loss.
+- A 48-hour timelock protects proxy upgrades, and the oracle limits per-update price movement.
+- Hyperithm has an eight-year history and a current Japanese SPBQII notification.
 
-### Key Risks
+### Key risks
 
-- **NAV reporting trust assumptions** — Hyperithm reports NAV, which is now checked through the [Attestation Engine](https://docs.midas.app/transparency/the-midas-attestation-engine) (LlamaRisk + Canary verify, vlayer notarizes, Chainlink CRE publishes hashes onchain). This is a significant improvement over previous single-party reporting, but source artifacts and full portfolio composition remain offchain, and the oracle update itself is still admin-triggered
-- **Negligible onchain liquidity** — ~$11.5K on Uniswap (down from ~$32K), effectively $0 daily volume. Exit is entirely dependent on Midas's redemption infrastructure (1-3 days). There is limited instant liquidity 1-2% of total supply to mitigate this
-- **Weak access control and partial timelock** — While contract upgrades have a 48-hour timelock, `DEFAULT_ADMIN_ROLE` is held by two direct addresses: the 1/3 Gnosis Safe and one EOA (reduced from three, June 2026). The Safe owner set includes two Midas-claimed MPC-controlled EOAs and one nested 3/7 Safe, but the single direct admin EOA is a separate control plane. Any direct admin can grant mint/burn/pause/blacklist roles and seize or freeze user funds without delay. The oracle price is also controlled by a single EOA with no timelock
-- **Unbacked minting** - tokens can be minted without collateral by the admin
-
----
+- mHYPER is an unsecured, qualified subordinated issuer claim with no statutory asset segregation.
+- Morpho and Hypercore account for 74.9% of NAV; the portfolio is leveraged and Fluid is highly levered on a net-equity basis.
+- The major current positions are in direct Fordefi allocator wallets, not behind a publicly verifiable onchain multisig quorum.
+- Admins can change roles and the oracle without the upgrade timelock; minting is not reserve-gated.
+- Direct DEX liquidity is negligible and primary redemptions depend on active offchain operations.
+- The exact August 2026 token implementation is not named in the published audit list, and the displayed base prospectus has passed its stated validity date.
 
 ## Risk Score Assessment
 
-**Scoring Guidelines:**
+### Critical risk gates
 
-- Be conservative: when uncertain between two scores, choose the higher (riskier) one
-- Use decimals (e.g., 2.5) when a subcategory falls between scores
-- Prioritize onchain evidence over documentation claims
+- **No audit:** PASS — broad audit coverage exists, although it does not identify the latest token implementation.
+- **Unverifiable reserves:** PASS — most NAV is position-level and onchain-classified, supplemented by SAVE attestations; material offchain attribution assumptions remain.
+- **Total centralization:** PASS — upgrades are timelocked and custody uses MPC policy controls, although role and oracle controls remain highly centralized.
 
-### Critical Risk Gates
+### Category scoring
 
-- **No audit** → **PASS** — 10 audits (Hacken, Côme, Sherlock, 2023-2025) cover the shared vault infrastructure, bridges, and oracles
-- **Unverifiable reserves** → **PASS** — Reserves are managed offchain by Hyperithm. NAV is admin-reported but now checked through the Midas Attestation Engine: LlamaRisk and Canary Protocol verify data origins and processes, vlayer provides cryptographic notarization, and attestation hashes are published onchain. Full portfolio composition still requires offchain trust and the source artifacts are not retrievable from the registry alone, but the multi-party verification pipeline provides meaningful independent oversight
-- **Total centralization** → **PASS** — Role-based access control, tri-party MPC governance via Fordefi, 48-hour timelock on contract upgrades. However, the 1/3 Safe threshold and role changes bypass the timelock
+#### 1. Audits & Historical Track Record (20%): 1.8/5
 
-**Result:** Protocol passes critical gates. Proceeding to category scoring.
+Ten audits/contests, two active bounty programs, more than one year of mHYPER operation, and no identified loss are strong positives. The latest token implementation was deployed after the published audit set and is not explicitly covered, preventing a lower score.
 
----
+#### 2. Centralization & Control Risks (30%): 3.5/5
 
-### Category Scoring (1-5 scale, 1 = safest)
+- **Governance: 3.0** — upgrades have a 48-hour timelock, but either direct default admin can change operational roles immediately; the admin Safe is 1-of-3.
+- **Programmability: 4.0** — reserves, strategy, leverage, NAV, and standard redemptions are not enforced end-to-end onchain.
+- **External dependencies: 3.5** — Hyperithm, Midas, Fordefi, the issuer, price/attestation operators, stablecoins, and concentrated DeFi venues are critical.
 
-#### 1. Audits & Historical Track Record (Weight: 20%)
+`(3.0 + 4.0 + 3.5) / 3 = 3.5`
 
-**Audits:**
+#### 3. Funds Management (30%): 2.9/5
 
-- 10 audits across 3 years (2023-2025): 2 Hacken + 2 Côme + 6 Sherlock contests
-- Broad coverage: core contracts, vaults, bridges (LayerZero/Axelar), oracle system, legacy components
-- 2025 audits (Côme + Sherlock) cover current core contracts — no longer stale
-- mHYPER is an implementation of the audited Midas core contracts
-- Several findings accepted rather than fixed in earlier audits
+- **Collateralization: 3.5** — assets are observable and policy-controlled, but holders have a subordinated issuer claim; concentration, leverage, recursive lending risk, discretionary management, and unbacked-mint authority remain.
+- **Provability: 2.25** — 92.5% is classified at position level and SAVE has sustained current attestations. The 7.5% residual, exact-vault gaps, hash-only registry, offchain wallet attribution, and lack of onchain reconciliation prevent a stronger score.
 
-**Bug Bounty:** $1M total allocated across [Sherlock](https://audits.sherlock.xyz/bug-bounties/122) ($500K max, Critical $25K-$500K) and [Cantina](https://cantina.xyz/bounties/d77405e5-99ce-4ba5-846c-885820b030e1) ($500K max). Active since March 2026.
+`(3.5 + 2.25) / 2 = 2.875`, rounded to **2.9**.
 
-**Time in Production:**
+#### 4. Liquidity Risk (15%): 3.0/5
 
-- mHYPER: ~9 months (July 2025)
-- Midas platform: ~22 months
-- TVL ~$45M for mHYPER, ~$216.6M for Midas total
-- No security incidents
+Midas provides instant and standard redemption paths, but direct secondary liquidity is negligible, the immediately identified backing-side buffer is only 2.59% of NAV, and standard execution has no binding timing or price guarantee.
 
-**Score: 1.5/5** — Extensive audit coverage (10 audits, 3 firms, 2023-2025) including 2025 audits on current core contracts. mHYPER is an implementation of these audited contracts. Some findings accepted not fixed in earlier audits. Strong $1M bug bounty across two platforms (Sherlock + Cantina) with defined tiers. Clean operational record (~9 months mHYPER, ~22 months platform).
+#### 5. Operational Risk (5%): 1.8/5
 
-#### 2. Centralization & Control Risks (Weight: 30%)
+Both teams are public and established, documentation is substantial, and Hyperithm has current Japanese regulatory-notification evidence. The subordinated issuer structure and absence of a publicly posted replacement for the expired displayed prospectus add material operational/legal-documentation risk.
 
-**Subcategory A: Governance — 3.0**
+### Final score
 
-- Upgradeable proxy contracts with **48-hour timelock** on upgrades via `MidasTimelockController` — users have time to react to proposed upgrades
-- However, role changes (mint/burn/pause/blacklist grants) bypass the timelock entirely
-- `DEFAULT_ADMIN_ROLE` is held by **three direct addresses**: the 1/3 Gnosis Safe plus two standalone EOAs. Any direct admin can grant/revoke any role with no timelock. The Safe's owner set is partially mitigated by Midas-claimed Fordefi/Fireblocks MPC signers and one nested 3/7 Safe, but those mitigations apply to the Safe owner set, not to the two direct admin EOAs unless Midas separately confirms their control setup
-- Oracle price updated by a single EOA with no timelock
-- Admin controls all critical roles (flagged by auditors as "highly centralized")
-- Tri-party MPC custody (Fordefi) is a positive but applies only to fund movements, not contract administration
+| Category | Score | Weight | Weighted |
+| --- | ---: | ---: | ---: |
+| Audits & Historical | 1.8 | 20% | 0.36 |
+| Centralization & Control | 3.5 | 30% | 1.05 |
+| Funds Management | 2.9 | 30% | 0.87 |
+| Liquidity Risk | 3.0 | 15% | 0.45 |
+| Operational Risk | 1.8 | 5% | 0.09 |
+| **Final Score** | | | **2.82 ≈ 2.8/5.0** |
 
-**Subcategory B: Programmability — 4.0**
-
-- Strategy execution fully offchain (Hyperithm)
-- NAV/oracle admin-updated twice per week. The Attestation Engine adds programmatic verification and onchain hash publication via Chainlink CRE, but the onchain price update is still admin-triggered and not contractually gated by the attestation
-- PPS is admin-reported, not computed onchain from reserves. NAV source data is independently checked through the Attestation Engine, but price updates are not computed or enforced by the registry
-- Redemption partially offchain (standard redemptions processed by Midas team)
-- Users cannot independently compute the exchange rate onchain; the registry does not expose the source document or a retrievable URI/CID
-- No smart contract restrictions on how the funds are managed, owner has full control. Tokens can be minted without backing
-
-**Subcategory C: External Dependencies — 3.5**
-
-- Hyperithm: single critical dependency for strategy management and NAV calculation
-- Strategy counterparties: Aave (blue-chip), Pendle (established), Hyperliquid (newer), Morpho (established), Kamino
-- Stablecoin exposure: sUSDai, USDe, sNUSD (carries its own depeg risk)
-- Distributed backup shares for the Fordefi workspace, allowing Midas to recover and secure key material in case of counterparty failure. Dual controls are enforced in all recovery procedures, preventing any single point of failure.
-
-**Centralization Score = (3.0 + 4.0 + 3.5) / 3 ≈ 3.5**
-
-**Score: 3.5/5** — High centralization driven by EOAs with `DEFAULT_ADMIN_ROLE`, offchain operations. The Attestation Engine adds a programmatic verification layer (Chainlink CRE) but the onchain registry only stores hashes, not proof content. The 48-hour timelock on upgrades is a meaningful positive, but role changes bypass it entirely. Tri-party MPC custody (Fordefi) partially mitigates fund movement risks. High concern is that tokens can be minted without backing
-
-#### 3. Funds Management (Weight: 30%)
-
-**Subcategory A: Collateralization — 3.5**
-
-- Tokens are subordinated debt instruments — not direct claims on collateral
-- Strategies are stablecoin-focused but managed offchain with discretionary authority by Hyperithm
-- Includes leveraged positions across multiple protocols
-- No onchain collateral verification in smart contracts, admin can mint tokens without backing
-- Tri-party MPC custody via Fordefi should prevent unilateral fund access
-
-**Subcategory B: Provability — 3.0**
-
-- NAV reported by Hyperithm, now independently checked through the Midas Attestation Engine with hashes published onchain
-- Multi-party verification pipeline: LlamaRisk + Canary Protocol verify data origins and processes, vlayer provides cryptographic notarization, Chainlink CRE publishes hashes onchain with BFT consensus. Midas docs state that source artifacts are stored on IPFS, but the registry does not expose a retrievable CID/URI
-- Reserve transparency is hybrid: per Midas, ~96% of mHYPER strategy positions are onchain and ~4% are CEX/offchain. The attestation engine provides tamper-evident hash records but does not make all underlying positions fully transparent or enforce wallet-to-product attribution onchain
-
-**Funds Management Score = (3.5 + 3.0) / 2 = 3.25 ≈ 3.3**
-
-**Score: 3.3/5** — Offchain funds management with subordinated debt structure. The Attestation Engine (March 2026) significantly improves provability by introducing multi-party verification (LlamaRisk, Canary, vlayer) and onchain attestation-hash publishing via Chainlink CRE, replacing the previous self-generated attestation reports. Full portfolio composition still requires some offchain trust; per Midas, most funds are in onchain wallets while ~4% are CEX/offchain. Leveraged strategy positions add risk. NAV verification will have delay compared to onchain data, and admin-controlled minting can break accounting between reported NAV and token supply.
-
-#### 4. Liquidity Risk (Weight: 15%)
-
-- **Exit Mechanism:** Instant redemption at oracle price (0.50% fee) when available, otherwise standard redemption in 1-3 business days
-- **DEX Liquidity:** Negligible — ~$11.5K total on Uniswap V4 (down ~64% from ~$32K in February), effectively $0 daily volume. Not viable for any position size
-- **Instant Redemption Capacity:** Liquidity target is 1-2% of circulating supply, but can have additional fees
-- **Pendle:** ~$10.14M TVL in mHYPER pools across 5 markets (yield tokenization, not direct exit liquidity)
-- **Stress Performance:** Processed $150M+ in 48 hours during Stream Finance incident, but via standard redemption requiring active coordination
-- **Large Holder Impact:** ~467 holders, average ~$96K. Significant exits require multi-day standard redemption path
-
-**Score: 3.0/5** — Redemption mechanism works, but entirely dependent on Midas infrastructure. No meaningful secondary market — DEX liquidity has declined significantly to ~$11.5K. Instant redemption vault should provide some liquidity. Standard redemptions take up to 3 business days.
-
-#### 5. Operational Risk (Weight: 5%)
-
-- **Team:** Fully doxxed with strong institutional backgrounds (Goldman Sachs, Morgan Stanley, Ondo Finance, OLX). Well-funded ($8.75M from top crypto VCs)
-- **Hyperithm:** Established fund manager (founded 2018), backed by Coinbase Ventures, Samsung Next. Dual-registered (Japan FSA, South Korea KoFIU). Concerns around co-CEO's TRUMP meme coin position and alleged regulatory filing failure
-- **Documentation:** Comprehensive docs, publicly available prospectus, weekly reports
-- **Legal:** Two issuance structures per [Midas docs](https://docs.midas.app/legal/legal-structure): Luxembourg securitisation (bankruptcy-remote) and German GmbH. mHYPER uses the German GmbH structure — no statutory asset segregation. FMA-approved Base Prospectus (July 2025). Issuer is neither licensed nor registered with FMA per the prospectus
-
-**Score: 1.5/5** — Strong team transparency and institutional credibility. Well-documented and regulated. Minor concerns about Hyperithm regulatory compliance and the thinly capitalized legal entity.
-
-### Final Score
-
-| Category                 | Score | Weight | Weighted    |
-| ------------------------ | ----- | ------ | ----------- |
-| Audits & Historical      | 1.5   | 20%    | 0.30        |
-| Centralization & Control | 3.5   | 30%    | 1.05        |
-| Funds Management         | 3.3   | 30%    | 0.99        |
-| Liquidity Risk           | 3.0   | 15%    | 0.45        |
-| Operational Risk         | 1.5   | 5%     | 0.075       |
-| **Final Score**          |       |        | **2.9/5.0** |
-
-
-### Risk Tier
-
-| Final Score | Risk Tier       | Recommendation                        |
-| ----------- | --------------- | ------------------------------------- |
-| 1.0-1.5     | Minimal Risk    | Approved, high confidence             |
-| 1.5-2.5     | Low Risk        | Approved with standard monitoring     |
-| **2.5-3.5** | **Medium Risk** | **Approved with enhanced monitoring** |
-| 3.5-4.5     | Elevated Risk   | Limited approval, strict limits       |
-| 4.5-5.0     | High Risk       | Not recommended                       |
-
-
-**Final Risk Tier: Medium Risk (2.9/5.0)**
-
-**Recommendation:** Approved with **enhanced monitoring** and strict exposure limits.
-
-**Required Conditions:**
-
-1. **Limited Exposure** — Cap allocation at 10-15% of vault with gradual ramp-up
-2. **Enhanced Monitoring** — Real-time alerts on oracle updates, role changes, contract upgrades, and vault activity (see Monitoring section)
-3. **Verify Multisig Configuration** — Confirm the ProxyAdmin owner and role holder multisig setup before deployment
-4. **Monthly NAV Cross-Check** — Independently estimate NAV from known strategy positions where possible
-5. **Quarterly Reassessment** — Given the offchain nature and evolving regulatory landscape
-
-**Key Concerns Driving the Score:**
-
-- Offchain strategy execution with NAV determined offchain (verification pipeline improves trust but does not eliminate offchain dependency)
-- Role changes (mint/burn/pause/blacklist grants) bypass the 48-hour timelock. `DEFAULT_ADMIN_ROLE` is now held by two addresses (the 1/3 Safe and one direct EOA), reduced from three in April 2026. The Safe owner set has one nested 3/7 Safe and two Midas-claimed MPC signers, but the single direct admin EOA's offchain controls cannot be confirmed onchain
-- Negligible secondary market liquidity, relying on Midas to keep instant redemption vault at 1-2% of total supply
-- Dependency on Hyperithm for strategy execution (NAV verification now multi-party via Attestation Engine)
-- No smart contract restrictions on how the funds are managed. Tokens can be minted without backing
-
-**Mitigating Factors:**
-
-- Strong team and institutional backing
-- Clean ~9-month track record (mHYPER) / ~22-month (Midas platform)
-- Proven redemption under stress ($150M+ in 48 hours)
-- Institutional-grade custody (Fordefi tri-party MPC)
-- 10 audits (2023-2025) on shared infrastructure + $1M bug bounty across Sherlock + Cantina
-- Attestation Engine (March 2026) with multi-party verification: LlamaRisk, Canary Protocol, vlayer cryptographic notarization, Chainlink CRE onchain publishing
-
----
+**Final Risk Tier: Medium Risk (2.8/5.0).** Approved with enhanced monitoring and conservative exposure limits.
 
 ## Reassessment Triggers
 
-- **Time-based**: Reassess in 3 months (July 2026) — approaching
-- **TVL-based**: Reassess if mHYPER market cap changes by more than 50%. Current mHYPER market cap ~$32.5M (down ~36% from ~$50.7M in April 2026). Midas platform TVL declined ~49% to ~$110M — approaching but not yet triggering
-- **Incident-based**: Reassess after any exploit, NAV discrepancy, governance change, contract upgrade, or regulatory action
-- **Hyperithm regulatory outcome**: Reassess when South Korean regulatory filing matter is resolved
-- **Timelock expansion**: If Midas extends the 48-hour timelock to cover role changes (not just upgrades). Partially addressed: `DEFAULT_ADMIN_ROLE` reduced from 3 to 2 holders (Fireblocks EOA revoked, June 2026)
-- **Minting**: If Midas removes the option to mint unbacked tokens — no change
-- **Audit**: If new audit covering current mHYPER contracts is published, reassess. Note: Oracle implementation upgraded since last report
-- **Attestation Engine maturity**: If the Attestation Engine demonstrates sustained operation and expanded coverage (e.g., real-time attestations, additional verifiers), reassess for potential Provability score improvement
-- **Oracle upgrade**: The Oracle implementation was upgraded from `CustomAggregatorFeed` to `MHyperCustomAggregatorFeed` ([`0xa19f5e16dc09641b17adf95bc950f71dbe5cb11b`](https://etherscan.io/address/0xa19f5e16dc09641b17adf95bc950f71dbe5cb11b)) — this is a material contract change warranting monitoring of the new code path
+- Any exploit, NAV discrepancy, delayed redemption, role change, proxy upgrade, allocator-wallet change, or regulatory action.
+- Morpho or Hypercore exceeding 50% individually, portfolio gross leverage exceeding 2.0x, or unclassified NAV exceeding 15%.
+- Redemption liquidity falling below 1% of NAV or a standard redemption remaining incomplete beyond two scheduled price updates.
+- Publication of an audit covering the August 2026 token implementation.
+- Publication or regulatory approval of a replacement base prospectus.
+- A publicly verifiable change to Fordefi policies or Safe thresholds that materially changes unilateral fund-movement risk.
+- Routine reassessment by November 19, 2026.
 
----
+## Assessment History
 
-## Appendix: Contract Architecture
+| Date | Score | Report |
+| --- | ---: | --- |
+| February 7, 2026 | 3.3 | [PR #31](https://github.com/yearn/risk-score/pull/31) |
+| March 20, 2026 | 3.2 | [PR #103](https://github.com/yearn/risk-score/pull/103) |
+| April 13, 2026 | 2.9 | [PR #133](https://github.com/yearn/risk-score/pull/133) |
+| June 13, 2026 | 2.9 | [PR #248](https://github.com/yearn/risk-score/pull/248) |
 
+## Appendix: Current Control Summary
+
+```text
+Users ──USDC──> DepositVault (MINT) ──> mHYPER
+Users <─USDC── RedemptionVault (BURN) <─ mHYPER
+                         │
+                  admin-set NAV oracle
+
+Midas/Hyperithm ── Fordefi MPC policy layer
+                         │
+          ┌──────────────┼──────────────┐
+       Fordefi2       Fordefi3       Fordefi4
+       Morpho/idle    Hypercore      Fluid
+          │
+     Safe1 1/1 ─ Safe2 1/1 ─ Safe3 2/2
+     (no material current dashboard allocation to these Safes)
+
+Admin Safe 1/3 ──> 48h Timelock ──> ProxyAdmin ──> upgrades
+Admin Safe 1/3 ─┐
+Fordefi admin ──┴──> AccessControl ──> roles without timelock
+Oracle updater ─────> NAV oracle without timelock
+
+Delta Y positions + offchain source data
+          └──> SAVE verifiers/attestor ──> hash registry
+                (evidence layer; does not enforce NAV or minting)
 ```
-┌─────────────────────────────────────────────────────────────────────┐
-│                     USER INTERACTION LAYER                           │
-│                                                                     │
-│  ┌───────────────────────────┐    ┌──────────────────────────────┐  │
-│  │  DepositVault             │    │  RedemptionVaultWithSwapper   │  │
-│  │  (TransparentProxy)       │    │  (TransparentProxy)          │  │
-│  │  0x6Be2f558..e98          │    │  0xbA9FD285..024             │  │
-│  │                           │    │                              │  │
-│  │  User deposits USDC ──────┼───▶│  User redeems mHYPER        │  │
-│  │  Vault calls mint()       │    │  Vault calls burn()          │  │
-│  │  Has: MINT_OPERATOR_ROLE  │    │  Has: BURN_OPERATOR_ROLE     │  │
-│  └─────────────┬─────────────┘    └──────────────┬───────────────┘  │
-│                │ mints                           │ burns             │
-│                ▼                                 ▼                   │
-│  ┌──────────────────────────────────────────────────────────────┐   │
-│  │  mHYPER Token (TransparentProxy)                             │   │
-│  │  0x9b5528528656DBC094765E2abB79F293c21191B9                  │   │
-│  │  impl: 0xE4386180dF7285E7D78794148E1B31c9EDfb0689            │   │
-│  │                                                              │   │
-│  │  mint(to, amount) ── only role check, NO collateral check    │   │
-│  │  burn(from, amount) ── can burn from any address             │   │
-│  │  pause() / unpause() / blacklist()                           │   │
-│  └──────────────────────────────────────────────────────────────┘   │
-│                                                                     │
-│  ┌──────────────────────────┐    ┌───────────────────────────────┐  │
-│  │  CustomAggregatorFeed    │    │  mHYPER DataFeed              │  │
-│  │  (Oracle / NAV)          │    │  (TransparentProxy)           │  │
-│  │  0x43881B05..f68         │    │  0x92004DCC..dE               │  │
-│  │                          │    │                               │  │
-│  │  Weekly admin-set price  │    │  Feeds price data to vaults   │  │
-│  │  Current: $1.1031 (r97)  │    │                               │  │
-│  └──────────────────────────┘    └───────────────────────────────┘  │
-│                                                                     │
-│  ┌──────────────────────────────────────────────────────────────┐   │
-│  │  MidasLzMintBurnOFTAdapter (LayerZero)                       │   │
-│  │  0x148c86390a4ae6f7a02df5903bc0a89e8b4581a0                  │   │
-│  │  Cross-chain bridge: has MINT + BURN roles                   │   │
-│  └──────────────────────────────────────────────────────────────┘   │
-│                                                                     │
-└─────────────────────────────────────────────────────────────────────┘
-
-┌─────────────────────────────────────────────────────────────────────┐
-│                     ACCESS CONTROL LAYER                             │
-│                                                                     │
-│  ┌──────────────────────────────────────────────────────────────┐   │
-│  │  MidasAccessControl (TransparentProxy)                       │   │
-│  │  0x0312A9D1Ff2372DDEdCBB21e4B6389aFc919aC4B                  │   │
-│  │                                                              │   │
-│  │  All token/vault operations check roles via this contract    │   │
-│  │  grantRole() / revokeRole() ── admin can change any role     │   │
-│  │  renounceRole() ── DISABLED (always reverts)                 │   │
-│  └──────────────────────────────────────────────────────────────┘   │
-│                                                                     │
-│  ┌──────────────────────────┐    ┌───────────────────────────────┐  │
-│  │  ProxyAdmin              │    │  MidasTimelockController      │  │
-│  │  0xbf25b58c..AaC         │◀───│  0xE3EEe3e0..852             │  │
-│  │                          │    │                               │  │
-│  │  Can upgrade all proxy   │    │  48-hour minimum delay        │  │
-│  │  implementations         │    │  Proposer/Executor: 1/3 Safe │  │
-│  └──────────────────────────┘    └───────────────────────────────┘  │
-│                                                                     │
-└─────────────────────────────────────────────────────────────────────┘
-
-┌─────────────────────────────────────────────────────────────────────┐
-│                     OFF-CHAIN DEPENDENCIES                          │
-│                                                                     │
-│  ┌──────────────────────────┐    ┌───────────────────────────────┐  │
-│  │  Hyperithm               │    │  Fordefi MPC Custody          │  │
-│  │  (Strategy Manager)      │    │  (Tri-party quorum)          │  │
-│  │                          │    │                               │  │
-│  │  Executes strategies:    │    │  Midas + Hyperithm +          │  │
-│  │  Aave, Pendle,           │    │  Independent signer           │  │
-│  │  Hyperliquid, Morpho     │    │                               │  │
-│  │  Reports NAV offchain   │    │  Holds underlying assets      │  │
-│  └──────────────────────────┘    └───────────────────────────────┘  │
-│                                                                     │
-│  ┌──────────────────────────────────────────────────────────────┐   │
-│  │  Attestation Engine (March 2026)                             │   │
-│  │  LlamaRisk + Canary Protocol verify → vlayer notarizes       │   │
-│  │  → Chainlink CRE publishes hashes onchain                   │   │
-│  └──────────────────────────────────────────────────────────────┘   │
-│                                                                     │
-└─────────────────────────────────────────────────────────────────────┘
-
-┌─────────────────────────────────────────────────────────────────────┐
-│                        GOVERNANCE                                   │
-│                                                                     │
-│  DEFAULT_ADMIN_ROLE (2 holders, can grant/revoke ANY role):         │
-│  ├─ 0xd4195cf4df289a4748c1a7b6ddbe770e27ba1227 (Fordefi MPC?)      │
-│  └─ 1/3 Gnosis Safe 0xB60842E9DaBCd1C52e354ac30E82a97661cB7E89    │
-│     ├─ EOA 0x8003544D32eE074aA8A1fb72129Fa8Ef7fe02E5f (Fordefi?)  │
-│     ├─ 3/7 Safe 0x82B30194bEae06D991Bc71850F949ec8cB7E0CB7        │
-│     └─ EOA 0xC50BD8430545C80a681C7cb33E6560fB0Bd86880 (Fireblocks?)│
-│                                                                     │
-│  └─ ⚠ 0x875c06a295c41c27840b9c9dfda7f3d819d8bc6a (Fireblocks) ── REVOKED │
-│                                                                     │
-│  Mint/Burn Operator EOA (holds BOTH roles):                         │
-│  └─ 0x5683de280d0c3967fba2f04d707fa1ef5a044e25                     │
-│                                                                     │
-│  Additional BURN holders:                                           │
-│  ├─ DepositVault 0x6Be2f55816efd0d91f52720f096006d63c366e98 (🆕)   │
-│  └─ LayerZero OFT Adapter 0x148c86390a4ae6f7a02df5903bc0a89e8b4581a0│
-│                                                                     │
-│  Oracle Updater EOA (sets NAV price, no timelock):                  │
-│  └─ 0xd1e01471f3e1002d4eec1b39b7dbd7aff952a99f                     │
-│                                                                     │
-│  ⚠ Role changes bypass timelock (only upgrades go through 48h)     │
-│  ⚠ mint() has no onchain collateral check                         │
-│  ⚠ Either of 2 remaining DEFAULT_ADMIN can grant MINT → unbacked  │
-│                                                                     │
-└─────────────────────────────────────────────────────────────────────┘
-
-Data flow: User deposits USDC → DepositVault mints mHYPER at oracle
-price. Funds go to Hyperithm via Fordefi custody for offchain strategy
-execution. NAV updated 2x/week by oracle updater EOA. User redeems via
-RedemptionVault (instant if liquidity available) or standard queue.
-```
-
-### Attestation Engine (SAVE)
-
-- [Attestation Engine Documentation](https://docs.midas.app/transparency/the-midas-attestation-engine)
-- [Midas Attestation Engine Blog Post](https://midas.app/blog/introducing-the-midas-attestation-engine/)
-
-The Midas Attestation Engine uses three onchain contracts:
-
-
-| Contract                   | Address                                                                                                                 | Role                                                                                                                                                             |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| KeystoneForwarder          | [`0x0b93082D9b3C7C97fAcd250082899BAcf3af3885`](https://etherscan.io/address/0x0b93082D9b3C7C97fAcd250082899BAcf3af3885) | Chainlink DON router — validates oracle signatures, forwards reports                                                                                             |
-| SaveCreReceiverProxy       | [`0xC50102b6598924Aa8deB201c757bFb9a3dBdB9b6`](https://etherscan.io/address/0xC50102b6598924Aa8deB201c757bFb9a3dBdB9b6) | Midas receiver — parses Chainlink report, calls `setAttestation()`                                                                                               |
-| MidasSaveRegistryWithClaim | [`0x2D6e9F608807436DE5D9603B00Abe3FEd1Bc809d`](https://etherscan.io/address/0x2D6e9F608807436DE5D9603B00Abe3FEd1Bc809d) | Registry — stores proof metadata. Owner: [`0x8003544D32eE074aA8A1fb72129Fa8Ef7fe02E5f`](https://etherscan.io/address/0x8003544D32eE074aA8A1fb72129Fa8Ef7fe02E5f) |
-
-
-**Flow** (example [tx](https://etherscan.io/tx/0x48fe8eebeb1c23963a521b45255fec0c5a1073d459aeb6e3067da1133a109f42)):
-
-```
-EOA 0xdE7E.. → report() on KeystoneForwarder (validates 4 Chainlink DON signatures)
-  → onReport() on SaveCreReceiverProxy
-    → setAttestation(proofId, hash) on Registry
-```
-
-**What IS stored onchain** (verify with `cast call 0x2D6e9F608807436DE5D9603B00Abe3FEd1Bc809d`):
-
-
-| Function                              | Returns                         | Example                                                     |
-| ------------------------------------- | ------------------------------- | ----------------------------------------------------------- |
-| `proofExists(bytes32)`                | `true/false`                    | `true`                                                      |
-| `proofIdToName(bytes32)`              | proof label                     | `"mhyper-por"`                                              |
-| `proofIdToLatestAttestation(bytes32)` | hash + attestor + timestamp     | hash `0x4188041f..`, attestor `0xC501..`, April 10 15:19 UTC |
-| `getClaimsForProofId(bytes32)`        | claim IDs                       | 1 claim from provider `0xc024..`                            |
-| `getAllVerifications(bytes32)`        | verification hashes + verifiers | 2 verifications (EOA `0xF16C..` + proxy `0xc82f..`)         |
-
-
-Proof ID for mHYPER: `0xac9a528065afb4290ab62fb0ee1a9110d48ed834454d2d04ab369b4832bbda7a`
-
-**What is NOT stored onchain:**
-
-- No actual reserve data (amounts, balances, NAV, wallet addresses)
-- No ABI-exposed IPFS CID or URI getter — a `proofIdToUri()` call reverts
-- No document content or protocol-level breakdown
-
-**Where the actual data lives:**
-
-Midas docs state that source artifacts are stored on IPFS, while public weekly PDF reports are available on [Google Drive](https://drive.google.com/drive/folders/1MJi_xq8aR0TaL0DJw6Q91SFxM_z0OcYZ). Each PDF contains total supply per chain, collateral breakdown (strategy + settlement reserve + funds in process), and price. The registry anchors hashes onchain, but users need offchain-disclosed artifacts or links to retrieve and interpret the underlying NAV/reserve data.

--- a/reports/report/midas-mhyper.md
+++ b/reports/report/midas-mhyper.md
@@ -4,7 +4,7 @@
 - **Token:** mHYPER
 - **Chain:** Ethereum (also deployed on Monad, Plasma, and Katana)
 - **Token Address:** [`0x9b5528528656DBC094765E2abB79F293c21191B9`](https://etherscan.io/token/0x9b5528528656dbc094765e2abb79f293c21191b9)
-- **Final Score: 2.8/5.0**
+- **Final Score: 2.9/5.0**
 
 ## Overview + Links
 
@@ -131,7 +131,7 @@ Liquidity remains dependent on active Midas/Hyperithm unwinds and redemption ope
 - `DEFAULT_ADMIN_ROLE` has two direct holders: a [`1-of-3 Safe`](https://app.safe.global/home?safe=eth:0xB60842E9DaBCd1C52e354ac30E82a97661cB7E89) and Fordefi MPC address [`0xd419...1227`](https://etherscan.io/address/0xd4195cf4df289a4748c1a7b6ddbe770e27ba1227). Each can grant or revoke operational roles without the timelock.
 - The admin Safe's owners include a nested [`3-of-7 Safe`](https://app.safe.global/home?safe=eth:0x82B30194bEae06D991Bc71850F949ec8cB7E0CB7), but its outer threshold remains one.
 - Mint holders are the DepositVault, LayerZero adapter, and operator [`0x5683...4e25`](https://etherscan.io/address/0x5683de280d0c3967fba2f04d707fa1ef5a044e25). Burn holders are the RedemptionVault, LayerZero adapter, and the same operator.
-- The oracle updater [`0xd1e0...a99f`](https://etherscan.io/address/0xd1e01471f3e1002d4eec1b39b7dbd7aff952a99f) can publish NAV without a timelock. Per-update movement is bounded to 0.35%, with absolute bounds of $0.10 and $1,000.
+- The oracle updater [`0xd1e0...a99f`](https://etherscan.io/address/0xd1e01471f3e1002d4eec1b39b7dbd7aff952a99f) can publish NAV without a timelock. The current [implementation](https://etherscan.io/address/0xa19f5e16dc09641b17adf95bc950f71dbe5cb11b#code) exposes two paths: `setRoundDataSafe()` enforces a 0.35% deviation limit and a one-hour interval, but the same updater can call `setRoundData()` directly, bypassing both checks. The direct path enforces only the broad $0.10–$1,000 absolute bounds.
 
 ### Programmability
 
@@ -151,7 +151,7 @@ The current public legal-document page still exposes the July 17, 2025 base pros
 
 ## Monitoring
 
-1. Monitor oracle `AnswerUpdated` events, staleness beyond the expected twice-weekly cadence, and any price decrease or repeated maximum-deviation updates.
+1. Monitor oracle `AnswerUpdated` events and calls to both `setRoundData()` and `setRoundDataSafe()`. Alert on any use of the direct setter, unexpected price change, or staleness beyond the expected twice-weekly cadence.
 2. Alert on every `RoleGranted`, `RoleRevoked`, pause, blacklist, mint, burn, and proxy `Upgraded` event.
 3. Reconcile total cross-chain supply, oracle price, Delta Y NAV, classified wallet NAV, and SAVE timestamps at least weekly.
 4. Monitor the $1.02M redemption liquidity, standard-redemption completion times, and any change to fees or eligibility.
@@ -165,7 +165,7 @@ The current public legal-document page still exposes the July 17, 2025 base pros
 - 92.5% of NAV is classified in a detailed public dashboard, with continuing multi-party SAVE attestations.
 - Fordefi MPC custody includes policy limits and multi-party exception handling; Safe3 adds a genuine 2-of-2 control for its isolated flow.
 - Ten published audits/contests, active $1M bounty capacity, and no identified mHYPER contract loss.
-- A 48-hour timelock protects proxy upgrades, and the oracle limits per-update price movement.
+- A 48-hour timelock protects proxy upgrades.
 - Hyperithm has an eight-year history and a current Japanese SPBQII notification.
 
 ### Key risks
@@ -175,6 +175,7 @@ The current public legal-document page still exposes the July 17, 2025 base pros
 - Morpho and Hypercore account for 74.9% of NAV; the portfolio is leveraged and Fluid is highly levered on a net-equity basis.
 - The major current positions are in direct Fordefi allocator wallets, not behind a publicly verifiable onchain multisig quorum.
 - Admins can change roles and the oracle without the upgrade timelock; minting is not reserve-gated.
+- The oracle updater can bypass the optional 0.35% safe-setter check and move the published price anywhere within the $0.10–$1,000 absolute range in one transaction.
 - Direct DEX liquidity is negligible and primary redemptions depend on active offchain operations.
 - The exact August 2026 token implementation is not named in the published audit list, and the displayed base prospectus has passed its stated validity date.
 
@@ -192,13 +193,13 @@ The current public legal-document page still exposes the July 17, 2025 base pros
 
 Ten audits/contests, two active bounty programs, more than one year of mHYPER operation, and no identified loss are strong positives. The latest token implementation was deployed after the published audit set and is not explicitly covered, preventing a lower score.
 
-#### 2. Centralization & Control Risks (30%): 3.5/5
+#### 2. Centralization & Control Risks (30%): 3.8/5
 
-- **Governance: 3.0** — upgrades have a 48-hour timelock, but either direct default admin can change operational roles immediately; the admin Safe is 1-of-3.
+- **Governance: 4.0** — upgrades have a 48-hour timelock, but either direct default admin can change operational roles immediately, the admin Safe is 1-of-3, and a single oracle updater can bypass the optional deviation check to publish any price within the broad absolute bounds.
 - **Programmability: 4.0** — reserves, strategy, leverage, NAV, and standard redemptions are not enforced end-to-end onchain.
 - **External dependencies: 3.5** — Hyperithm, Midas, Fordefi, the issuer, price/attestation operators, stablecoins, and concentrated DeFi venues are critical.
 
-`(3.0 + 4.0 + 3.5) / 3 = 3.5`
+`(4.0 + 4.0 + 3.5) / 3 = 3.83`, rounded to **3.8**.
 
 #### 3. Funds Management (30%): 2.9/5
 
@@ -220,11 +221,11 @@ Both teams are public and established, documentation is substantial, and Hyperit
 | Category | Score | Weight | Weighted |
 | --- | ---: | ---: | ---: |
 | Audits & Historical | 1.8 | 20% | 0.36 |
-| Centralization & Control | 3.5 | 30% | 1.05 |
+| Centralization & Control | 3.8 | 30% | 1.14 |
 | Funds Management | 2.9 | 30% | 0.87 |
 | Liquidity Risk | 3.0 | 15% | 0.45 |
 | Operational Risk | 1.8 | 5% | 0.09 |
-| **Final Score** | | | **2.82 ≈ 2.8/5.0** |
+| **Final Score** | | | **2.91 ≈ 2.9/5.0** |
 
 ### Risk Tier
 
@@ -237,7 +238,7 @@ Both teams are public and established, documentation is substantial, and Hyperit
 | **4.5-5.0** | **High Risk** | Not recommended |
 | **N/A** | **Not Rated** | Terminal — do not use (exploited or wound down) |
 
-**Final Risk Tier: Medium Risk (2.8/5.0).** Approved with enhanced monitoring and conservative exposure limits.
+**Final Risk Tier: Medium Risk (2.9/5.0).** Approved with enhanced monitoring and conservative exposure limits.
 
 ## Reassessment Triggers
 
@@ -257,7 +258,7 @@ Both teams are public and established, documentation is substantial, and Hyperit
 | [March 20, 2026](https://github.com/yearn/risk-score/pull/103) | 3.2 | Attestation Engine reassessment |
 | [April 13, 2026](https://github.com/yearn/risk-score/pull/133) | 2.9 | Controls and provability reassessment |
 | [June 13, 2026](https://github.com/yearn/risk-score/pull/248) | 2.9 | Allocation and role reassessment |
-| [August 19, 2026](https://github.com/yearn/risk-score/pull/417) | 2.8 | Custody, allocation, and control reassessment |
+| [August 19, 2026](https://github.com/yearn/risk-score/pull/417) | 2.9 | Custody, allocation, and oracle-control reassessment |
 
 ## Appendix: Current Control Summary
 

--- a/reports/report/midas-mhyper.md
+++ b/reports/report/midas-mhyper.md
@@ -10,6 +10,8 @@
 
 mHYPER is a yield-bearing tokenized certificate issued by Midas Software GmbH. Its price references a stablecoin-focused, market-neutral portfolio managed by [Hyperithm](https://www.hyperithm.com/). Yield accrues through the token price rather than rebasing. mHYPER is legally a qualified subordinated debt claim against the German issuer, not a direct ownership interest in strategy assets or a bankruptcy-remote vehicle.
 
+**mHYPER is not principal-protected.** Negative strategy performance—including losses caused by poor allocation, hedging, leverage, liquidation, or counterparty decisions—can reduce portfolio NAV and the token's redemption value without any hack or smart-contract incident. Market-neutral positioning is a risk-management objective, not a guarantee against loss.
+
 The strategy is materially onchain but not contractually tied to the token. Hyperithm deploys capital through Midas/Fordefi-controlled allocator wallets, Midas publishes an admin-set NAV price, and minting is not limited by an onchain proof-of-reserves check. The [Delta Y transparency dashboard](https://midas.deltay.xyz/mhyper) and [Midas Attestation Engine](https://docs.midas.app/transparency/the-midas-attestation-engine) provide meaningful visibility and independent checks, but wallet attribution and source data remain offchain assertions.
 
 **Current statistics (August 19, 2026):**
@@ -97,6 +99,8 @@ The three dashboard-labeled Safe wallets do not establish a blanket multisig ove
 
 Delta Y does not currently attribute material strategy NAV to Safe1, Safe2, or Safe3. Most visible NAV is instead attributed directly to Fordefi2, Fordefi3, and Fordefi4. The appropriate positive control is therefore Fordefi's MPC and policy-based governance, plus the isolated 2-of-2 Safe—not a claim that the current portfolio as a whole is protected by an onchain multisig quorum.
 
+These custody controls address transaction authorization, not investment quality. A trade can comply with Fordefi policy or receive every required signature and still lose money because of poor strategy selection, hedge execution, leverage, liquidation, market liquidity, or counterparty performance. Multisig and MPC controls therefore do not protect mHYPER holders from ordinary fund-management losses.
+
 ### Collateralization and legal claim
 
 - mHYPER is a qualified subordinated debt obligation of Midas Software GmbH. Holders have no direct title to allocator-wallet assets, statutory segregation, or bankruptcy remoteness under this German GmbH structure ([legal structure](https://docs.midas.app/legal/legal-structure)).
@@ -166,6 +170,7 @@ The current public legal-document page still exposes the July 17, 2025 base pros
 
 ### Key risks
 
+- mHYPER is not principal-protected: ordinary management losses can reduce NAV and redemption value without a hack, including through poor allocation, hedging, leverage, liquidation, or counterparty decisions.
 - mHYPER is an unsecured, qualified subordinated issuer claim with no statutory asset segregation.
 - Morpho and Hypercore account for 74.9% of NAV; the portfolio is leveraged and Fluid is highly levered on a net-equity basis.
 - The major current positions are in direct Fordefi allocator wallets, not behind a publicly verifiable onchain multisig quorum.


### PR DESCRIPTION
## Summary

- refresh mHYPER NAV, allocations, leverage, liquidity, contracts, roles, attestations, and legal/regulatory evidence
- distinguish Fordefi policy-based MPC custody from the three onchain fund Safes: two are 1-of-1 and one is 2-of-2, with no material current NAV attributed to the Safes
- correct the oracle assessment: setRoundData() bypasses the optional 0.35% safe-setter check and is constrained only by the $0.10-$1,000 absolute bounds
- update the dependency graph with current allocator wallets, Safe thresholds, strategy concentrations, and oracle authority
- retain the 2.9 Medium Risk score after raising Centralization & Control to 3.8

## Validation

- npm run build

Closes #407