### PR TITLE
Reassess: Midas mGLOBAL (3.43 → 3.42) — oracle resumed, liquidity up, oracle guards bypassable

### DIFF
--- a/reports/graph/midas-mglobal.yaml
+++ b/reports/graph/midas-mglobal.yaml
@@ -20,7 +20,7 @@ nodes:
     label: mGLOBAL (LYT Stablecoin)
     address: "0x7433806912Eae67919e66aea853d46Fa0aef98A8"
     category: vault
-    note: Subordinated debt instrument; TransparentUpgradeableProxy. ~52.63M supply @ $1.00 (Jun 23 2026, block 25382793)
+    note: Subordinated debt instrument; TransparentUpgradeableProxy. 68.10M supply @ $1.01664609 = ~$69.23M NAV (Aug 24 2026, block 25822232)
   - id: deposit-vault
     label: MGlobalDepositVaultWithAave
     address: "0xce29c36c6d4556f2d01d79414c1354b968dddef1"
@@ -30,12 +30,17 @@ nodes:
     label: RedemptionVaultWithAave
     address: "0xa0fc8bdfb1e6a705c1375810989b1d70a982b01b"
     category: vault
-    note: Primary redemption vault. Idle capital → Aave
+    note: Primary redemption vault. Holds $6,237,620 aUSDC (~9.0% of NAV) — verifiable instant-redemption float. 2M/day cap, 50 bps fee
   - id: redemption-vault-swapper
     label: RedemptionVaultWithSwapper
     address: "0x1e0fd66753198c7b8ba64edee8d41d8628bf20d7"
     category: vault
-    note: Secondary redemption vault with swapper
+    note: Secondary redemption vault. Holds 2,000,001.74 mGLOBAL swap inventory. 2M/day cap, 50 bps fee
+  - id: redemption-vault-swapper-2
+    label: 2nd SwapperVault (staged)
+    address: "0xdbd621e67d9cffffcdcd316a27285f657c178e76"
+    category: vault
+    note: "Holds M_GLOBAL_BURN_OPERATOR_ROLE (granted Aug 12 2026) but is unfunded and unconfigured: sentinel 0xFFfF..FFfF addresses, 0 fee, uncapped daily limit"
 
   # === Protocol infra ===
   - id: access-control
@@ -47,7 +52,7 @@ nodes:
     label: MGlobalCustomAggregatorFeedGrowth (NAV)
     address: "0x66aa9fcd63df74e1f67a9452e6e59fbc67f75e38"
     category: infra
-    note: "Admin-set NAV oracle. Price $1.00. maxAnswerDeviation=100% (very loose). Impl: 0x96ac55...5e49"
+    note: "Admin-set NAV oracle. Price $1.01664609 (round 5, Aug 20 2026). maxAnswerDeviation=100% and NOT enforced on the admin-callable setRoundData path; onlyUp=true blocks markdowns on the guarded path. Impl: 0x96ac55...5e49"
   - id: oracle-raised
     label: PriceRaised Feed (inactive)
     address: "0x494f142c35167cfbdd3887e8d7897822e63c9618"
@@ -72,24 +77,24 @@ nodes:
     label: Mint/Burn/Pause Operator EOA
     address: "0x76e350c5a674db787918e5f728466c7356d4d361"
     category: infra
-    note: Fordefi MPC (nonce 3); holds MINT/BURN/PAUSE/BLACKLIST/GREENLIST
+    note: Fordefi MPC (nonce 8); holds MINT/BURN/PAUSE/BLACKLIST/GREENLIST
   - id: oracle-updater-eoa
     label: Oracle Updater EOA
     address: "0x088a74de7df74e6a6eb832d28878a9f134ee4f05"
     category: infra
-    note: Single EOA, no timelock on price updates (nonce 4)
+    note: Single EOA, no timelock (nonce 12). Via setRoundData can set any price in $0.10-$1,000 in one tx, bypassing deviation cap and onlyUp
   - id: greenlist-blacklist-eoa
     label: Greenlist/Blacklist Operator EOA
     address: "0x9ba8c38ae60e6e6311d53f8a85e5cf4004d3c987"
     category: infra
-    note: Generic GREENLIST_OP + BLACKLIST_OP. Nonce 0 — never transacted
+    note: One of 53 EOAs holding both GREENLIST_OPERATOR_ROLE and BLACKLIST_OPERATOR_ROLE platform-wide. Any one can freeze a holder, untimelocked
 
   # === Governance ===
   - id: admin-safe
     label: Admin Safe (1/3)
     address: "0xB60842E9DaBCd1C52e354ac30E82a97661cB7E89"
     category: governance
-    note: Gnosis Safe; DEFAULT_ADMIN + Timelock proposer/executor
+    note: Gnosis Safe 1-of-3; DEFAULT_ADMIN + Timelock proposer/executor/canceller
   - id: admin-eoa-fordefi
     label: DEFAULT_ADMIN EOA (Fordefi MPC)
     address: "0xd4195cf4df289a4748c1a7b6ddbe770e27ba1227"
@@ -124,7 +129,7 @@ nodes:
   - id: fasanara
     label: Fasanara Capital (Strategy Mgr)
     category: dependency
-    note: "$4B+ AUM, 15yr, London, MIFIDPRU. 88.61% of NAV Unclassified"
+    note: "$4B+ AUM, 15yr, London, MIFIDPRU, FCA FRN 551020. 97.03% of NAV Unclassified"
   - id: fordefi
     label: Fordefi MPC Custody
     category: dependency
@@ -141,22 +146,22 @@ nodes:
     label: vlayer (Notarization)
     category: dependency
   - id: infinifi
-    label: InfiniFi (~58% holder — renewed)
-    address: "0xf4ea3ec87b1c254f17a2fb68164db0caf6c4cecf"
+    label: InfiniFi RWAEscrowRouter (30.29%)
+    address: "0x7912Eaff92B2f5Bc64Cdd21C76d79FFC12eA855E"
     category: dependency
-    note: "Original farm matured Jun 15 2026 and renewed into new MidasFarm (0xf4ea3ec, maturity Jul 21 2026). $30.49M position (57.94%), 4.5/5 internal risk"
+    note: "Largest holder: 20,627,291.44 mGLOBAL (30.29%). MidasFarm 0xf4ea3ec transferred the whole position here Aug 17 2026; core()=InfiniFiCore, keeper()=RWAEscrowRateManager. Marked offchain, liquidity()=0, and no maturity date — an exit would give no advance notice"
   - id: aave-horizon
     label: Aave Horizon (collateral mkt)
     address: "0xAe05Cd22df81871bc7cC2a04BeCfb516bFe332C8"
     category: dependency
-    note: "mGLOBAL listed as collateral reserve (Jun 2026). $19.85M supplied (37.71%); LTV 0.05% — near-zero credit. aMGLOBAL 0x49d3...B985"
+    note: "Collateral reserve SATURATED at its cap: 29,999,999 of 30,000,000 (44.05% of supply). Cap cut 50M -> 30M on Jul 2 2026. LTV 0.05% / LT 0.10% — near-zero credit. aMGLOBAL 0x49d3...B985"
 
 edges:
   # === Governance chain ===
   - from: admin-safe
     to: timelock
     kind: proposes-on
-    label: PROPOSER + EXECUTOR (1/3)
+    label: PROPOSER + EXECUTOR + CANCELLER (1/3)
   - from: timelock
     to: proxy-admin
     kind: controls
@@ -173,6 +178,9 @@ edges:
     kind: manages
   - from: proxy-admin
     to: redemption-vault-swapper
+    kind: manages
+  - from: proxy-admin
+    to: redemption-vault-swapper-2
     kind: manages
   - from: proxy-admin
     to: oracle
@@ -220,6 +228,10 @@ edges:
     to: mGLOBAL
     kind: holds-role
     label: M_GLOBAL_BURN_OPERATOR_ROLE
+  - from: redemption-vault-swapper-2
+    to: mGLOBAL
+    kind: holds-role
+    label: M_GLOBAL_BURN_OPERATOR_ROLE (staged, unconfigured)
 
   # === Oracle → vault flow ===
   - from: oracle
@@ -268,7 +280,7 @@ edges:
   - from: fasanara
     to: fasanara
     kind: allocates-to
-    label: "100% (TODO: verify allocation)"
+    label: "97.03% Unclassified (TODO: verify allocation)"
 
   # === Aave integration (idle capital in vaults) ===
   - from: deposit-vault
@@ -278,7 +290,7 @@ edges:
   - from: redemption-vault-aave
     to: aave
     kind: deposits-into
-    label: idle USDC → aUSDC
+    label: $6,237,620 aUSDC (~9.0% of NAV)
 
   # === Redemption flow ===
   - from: redemption-vault-aave
@@ -326,10 +338,10 @@ edges:
   - from: infinifi
     to: mGLOBAL
     kind: manages
-    label: 57.94% holder ($30.49M). Renewed; new maturity Jul 21 2026
+    label: 30.29% holder (20.63M mGLOBAL, ~$21M). No maturity date
 
   # === Aave Horizon collateral listing ===
   - from: aave-horizon
     to: mGLOBAL
     kind: manages
-    label: 37.71% holder ($19.85M supplied as collateral; LTV 0.05%)
+    label: 44.05% holder (30M supplied; at cap; LTV 0.05%)

--- a/reports/report/midas-mglobal.md
+++ b/reports/report/midas-mglobal.md
@@ -1,31 +1,35 @@
 # Protocol Risk Assessment: Midas mGLOBAL
 
-- **Assessment Date:** June 23, 2026
+- **Assessment Date:** June 17, 2026 (Updated: August 24, 2026)
 - **Token:** mGLOBAL
 - **Chain:** Ethereum
 - **Token Address:** [`0x7433806912Eae67919e66aea853d46Fa0aef98A8`](https://etherscan.io/token/0x7433806912Eae67919e66aea853d46Fa0aef98A8)
-- **Final Score: 3.43/5.0**
+- **Final Score: 3.42/5.0**
 
 ## Overview + Links
 
-mGLOBAL is a tokenized certificate (Liquid Yield Token / LYT) issued by Midas Software GmbH, a German-incorporated tokenization platform. It references the performance of **stablecoin-focused strategies** managed by [Fasanara Capital](https://www.fasanara.com/), a London-based asset management firm. Unlike mHYPER (a floating-NAV growth token), mGLOBAL is a **stable/pegged token** targeting a $1.00 price with yield auto-compounded into the token price.
+mGLOBAL is a tokenized certificate (Liquid Yield Token / LYT) issued by Midas Software GmbH, a German-incorporated tokenization platform. It references the performance of **stablecoin-focused strategies** managed by [Fasanara Capital](https://www.fasanara.com/), a London-based asset management firm. mGLOBAL is an **accruing (growth) token**: it launched at $1.00 and yield is compounded into the token price rather than distributed, so the price ratchets upward with each NAV publication.
 
-The token price is maintained at ~$1.00000000 via a custom oracle (`MGlobalCustomAggregatorFeedGrowth`) updated by Midas. mGLOBAL's DepositVault and primary RedemptionVault integrate with **Aave** for idle capital management.
+The price is set by a custom oracle (`MGlobalCustomAggregatorFeedGrowth`) updated by Midas. mGLOBAL's DepositVault and primary RedemptionVault integrate with **Aave** for idle capital management.
 
 **Key Stats:**
 
-- **mGLOBAL Market Cap / TVL:** ~$52.63M (June 23, 2026; total supply ~52,628,653 mGLOBAL × $1.00) — **up ~40% from ~$37.6M on June 17**, driven largely by Aave Horizon adoption
-- **Total Supply:** ~52,628,652.70 mGLOBAL — 18 decimals, verified onchain via `totalSupply()` on [token contract](https://etherscan.io/address/0x7433806912Eae67919e66aea853d46Fa0aef98A8) at block 25,382,793 (all tracked supply on Ethereum; no non-Ethereum mGLOBAL deployment identified)
-- **Decimals:** 18 (verified onchain, not 6 as typical for Midas tokens)
+- **mGLOBAL Market Cap / NAV:** ~$69.23M (August 24, 2026; 68,097,489.96 mGLOBAL × $1.01664609), corroborated by [SumCap / Delta Y](https://midas.sumcap.xyz/mglobal) at $69,231,046.91
+- **Total Supply:** 68,097,489.96 mGLOBAL — 18 decimals, via `totalSupply()` on the [token contract](https://etherscan.io/address/0x7433806912Eae67919e66aea853d46Fa0aef98A8) at block 25,822,232. All supply is on Ethereum; no non-Ethereum mGLOBAL deployment exists
+- **Token Price:** $1.01664609 (oracle round 5, [set August 20, 2026](https://etherscan.io/tx/0x7600447f1393f66f7403c04c4b746e47efce5e7d2451596d04f74a07e6b5f6db)). Realized return since the $1.00 launch price is **+1.6646%**, an annualized ~6.3% over the accruing period; SumCap reports a trailing **7.13% APY**
+- **Decimals:** 18 (not 6 as typical for Midas tokens)
 - **Token Name:** "Midas Fasanara Global" — explicitly naming Fasanara as the strategy partner
-- **Holders (verified onchain June 23, 2026):**
-  - ⚠ **[MidasFarm / InfiniFi (renewed)](https://etherscan.io/address/0xf4ea3ec87b1c254f17a2fb68164db0caf6c4cecf):** **57.94%** ($30.49M) — InfiniFi's original MidasFarm ([`0x7373…1679`](https://etherscan.io/address/0x7373A7ce3C023C56Cb66747AFbdF827627D31679)) matured June 15, 2026 and **did not redeem**. On June 18 it transferred its entire $30,490,833 position into a **new** MidasFarm contract ([`0xf4ea3ec…`](https://etherscan.io/address/0xf4ea3ec87b1c254f17a2fb68164db0caf6c4cecf), deployed June 16, verified `MidasFarm`). The new farm's `maturity()` is **July 21, 2026** — so the maturity/exit trigger is deferred ~1 month, not eliminated. Concentration in this single holder eased from 81% → ~58% as supply grew. Per the [InfiniFi report](https://github.com/yearn/risk-score/blob/master/reports/report/infinifi.md), this represents InfiniFi depositor funds; a full redemption at maturity would still strain mGLOBAL's near-zero vault liquidity
-  - **[Aave Horizon aMGLOBAL](https://etherscan.io/address/0x49d3cdE03813eE32DFD47F6aA3957d5F9CbAB985):** **37.71%** ($19.85M) — mGLOBAL supplied as collateral on the permissioned [Aave Horizon RWA market](https://app.aave.com/reserve-overview/?underlyingAsset=0x7433806912eae67919e66aea853d46fa0aef98a8&marketName=proto_horizon_v3). New, independent institutional demand that did not exist at the prior assessment
-  - **[Gnosis Safe](https://etherscan.io/address/0xaB05c0DB9D26e96A9dcEDCAFCA23341316F6fe6F):** **4.35%** (~$2.29M) — 3/4 multisig (likely treasury); position grew slightly
-  - The prior EOA holder ([`0x882C…EDb7`](https://etherscan.io/address/0x882C825405fBBE45DCc1ad52b639aFbC4592EDb7), formerly 10.46%) and prior BeaconProxy holder ([`0xD36f…B621`](https://etherscan.io/address/0xD36f095556d5717fd9231a2091e8e98bEb7cB621), formerly 1.77%) now hold **0**
-- **Creation:** [Block 24798265](https://etherscan.io/tx/0xacc1f08c1f1ea036fa35444b67328ae3d3098d6cbbc520eacc81116156eb7772) (April 3, 2026, ~11.5 weeks in production)
-- **Midas Platform TVL:** ~$112.7M per [DeFiLlama](https://defillama.com/protocol/midas-rwa) (June 23, 2026)
-- **KYC Required:** Yes (greenlist enforced onchain — confirmed via GREENLISTED_ROLE / GREENLIST_OPERATOR_ROLE)
+- **Holders (16 addresses hold a non-zero balance):**
+  - **[Aave Horizon aMGLOBAL](https://etherscan.io/address/0x49d3cdE03813eE32DFD47F6aA3957d5F9CbAB985):** **44.05%** (29,999,999.00 mGLOBAL) — mGLOBAL supplied as collateral on the permissioned [Aave Horizon RWA market](https://app.aave.com/reserve-overview/?underlyingAsset=0x7433806912eae67919e66aea853d46fa0aef98a8&marketName=proto_horizon_v3). The reserve sits **exactly at its 30M supply cap**, so this holder cannot grow further
+  - ⚠ **[InfiniFi RWAEscrowRouter](https://etherscan.io/address/0x7912Eaff92B2f5Bc64Cdd21C76d79FFC12eA855E):** **30.29%** (20,627,291.44 mGLOBAL) — InfiniFi's exposure. On [August 17, 2026](https://etherscan.io/tx/0xb4d8d9c153c8242adc6701c987709f9a372e29ea538f4990902d95ebad32abde) InfiniFi's `MidasFarm` ([`0xf4ea…cecf`](https://etherscan.io/address/0xf4ea3ec87b1c254f17a2fb68164db0caf6c4cecf)) transferred its entire position into this `RWAEscrowRouter`, which reports `core()` = [`InfiniFiCore`](https://etherscan.io/address/0xF6d48735EcCf12bDC1DF2674b1ce3fcb3bD25490) and `keeper()` = [`RWAEscrowRateManager`](https://etherscan.io/address/0x11F6FAb3f4D8635880C3e80cbae8AEF8136D4189). The router values the position offchain (`totalAssets()` = 21,075,436.16 USDC) and reports `liquidity()` = 0. See the [InfiniFi report](https://github.com/yearn/risk-score/blob/master/reports/report/infinifi.md)
+  - **[EOA `0x0dfa…8319`](https://etherscan.io/address/0x0dfa220249fccc15fd19e7c7fa3198f4742b8319):** **14.48%** (9,863,541.98 mGLOBAL) — externally owned account with nonce 0 (has never sent a transaction), consistent with a custodied or omnibus position
+  - **[Gnosis Safe `0xaB05…fe6F`](https://etherscan.io/address/0xaB05c0DB9D26e96A9dcEDCAFCA23341316F6fe6F):** **3.58%** (2,435,957.20 mGLOBAL) — 3-of-n multisig
+  - **[RedemptionVaultWithSwapper](https://etherscan.io/address/0x1e0fd66753198c7b8ba64edee8d41d8628bf20d7):** **2.94%** (2,000,001.74 mGLOBAL) — protocol-held swap inventory
+  - Unwrapping the Aave Horizon aToken to its underlying suppliers, the largest **beneficial** owner is InfiniFi at 30.29%, followed by [`0x882C…EDb7`](https://etherscan.io/address/0x882C825405fBBE45DCc1ad52b639aFbC4592EDb7) at 26.11% (619,305.39 held directly plus 17,164,227.35 supplied to Horizon) and [`0x0dfa…8319`](https://etherscan.io/address/0x0dfa220249fccc15fd19e7c7fa3198f4742b8319) at 14.48%
+- **KYC'd addresses:** 98 hold `M_GLOBAL_GREENLISTED_ROLE`, added continuously since April 2026
+- **Creation:** [Block 24798265](https://etherscan.io/tx/0xacc1f08c1f1ea036fa35444b67328ae3d3098d6cbbc520eacc81116156eb7772) (April 3, 2026 — ~4.7 months in production)
+- **Midas Platform TVL:** ~$152.9M per [DeFiLlama](https://defillama.com/protocol/midas-rwa) (August 24, 2026); mGLOBAL is ~45% of it
+- **KYC Required:** Yes (greenlist enforced onchain via `GREENLISTED_ROLE` / `M_GLOBAL_GREENLISTED_ROLE`)
 
 **Links:**
 
@@ -53,8 +57,11 @@ All contracts use OpenZeppelin's `TransparentUpgradeableProxy` pattern with a sh
 | **DepositVault** (MGlobalDepositVaultWithAave) | [`0xce29c36c6d4556f2d01d79414c1354b968dddef1`](https://etherscan.io/address/0xce29c36c6d4556f2d01d79414c1354b968dddef1) | [`0x08e4432f84e660235821c63764fb2ffcc7e2b477`](https://etherscan.io/address/0x08e4432f84e660235821c63764fb2ffcc7e2b477) |
 | **RedemptionVaultWithAave** | [`0xa0fc8bdfb1e6a705c1375810989b1d70a982b01b`](https://etherscan.io/address/0xa0fc8bdfb1e6a705c1375810989b1d70a982b01b) | [`0xf687e76e3d62d62fe6f6a7f66ce9fae21df6438d`](https://etherscan.io/address/0xf687e76e3d62d62fe6f6a7f66ce9fae21df6438d) |
 | **RedemptionVaultWithSwapper** | [`0x1e0fd66753198c7b8ba64edee8d41d8628bf20d7`](https://etherscan.io/address/0x1e0fd66753198c7b8ba64edee8d41d8628bf20d7) | [`0xe98a4fb7a2e87ad888ccef0587dc820cf1a7cabb`](https://etherscan.io/address/0xe98a4fb7a2e87ad888ccef0587dc820cf1a7cabb) |
+| **Second RedemptionVaultWithSwapper** (staged, unfunded) | [`0xdbd621e67d9cffffcdcd316a27285f657c178e76`](https://etherscan.io/address/0xdbd621e67d9cffffcdcd316a27285f657c178e76) | [`0xe98a4fb7a2e87ad888ccef0587dc820cf1a7cabb`](https://etherscan.io/address/0xe98a4fb7a2e87ad888ccef0587dc820cf1a7cabb) |
 
-**Cross-chain status:** No non-Ethereum mGLOBAL deployment was identified. [RWA.xyz](https://app.rwa.xyz/assets/mGLOBAL) lists only Ethereum as the mGLOBAL network, and current mGLOBAL mint/burn roles are held only by the operator EOA, DepositVault, and RedemptionVaults listed in [Token Mint Authority](#token-mint-authority).
+**Second swapper vault (staged):** [`0xdbd621e6…8e76`](https://etherscan.io/address/0xdbd621e67d9cffffcdcd316a27285f657c178e76) shares the RedemptionVaultWithSwapper implementation and was granted `M_GLOBAL_BURN_OPERATOR_ROLE` on [August 12, 2026](https://etherscan.io/tx/0x8cff72082df0ec3a239cde44bc40efd1fe608945bae172e347f62bd0f3a91524). It holds no USDC and no mGLOBAL, and it is **not configured for production**: `mTbillRedemptionVault()` and `liquidityProvider()` both return the sentinel `0xFFfF…FFfF`, `instantFee()` is 0, and `instantDailyLimit()` is `type(uint256).max` (versus 50 bps and a 2,000,000-token daily cap on the two live vaults). It is unpaused. A burn-authorized contract left in an unhardened, uncapped state is a live surface that should either be configured or have its burn role revoked — see [Monitoring](#monitoring).
+
+**Cross-chain status:** mGLOBAL is Ethereum-only. The token address holds no code on Base, Arbitrum, Polygon, or Sonic; it does not appear in the [LayerZero OFT registry](https://metadata.layerzero-api.com/v1/metadata/experiment/ofts/list); [RWA.xyz](https://app.rwa.xyz/assets/mGLOBAL) lists only Ethereum; and no bridge adapter holds mGLOBAL mint or burn authority (see [Token Mint Authority](#token-mint-authority)).
 
 ### Shared Infrastructure (shared with all Midas products)
 
@@ -107,11 +114,21 @@ All contracts use OpenZeppelin's `TransparentUpgradeableProxy` pattern with a sh
 
 ## Historical Track Record
 
-- **Production History:** mGLOBAL token created on Ethereum [April 3, 2026](https://etherscan.io/tx/0xacc1f08c1f1ea036fa35444b67328ae3d3098d6cbbc520eacc81116156eb7772) (~10 weeks in production). Midas platform launched with mTBILL in mid-2024 (~22 months total)
-- **TVL Growth:** Midas grew from ~$4M (July 2024) to a peak of ~$927.8M (October 27, 2025), declining to ~$112.7M (June 23, 2026). See [DeFiLlama](https://defillama.com/protocol/midas-rwa)
-- **mGLOBAL Market Cap:** ~$52.63M (June 23, 2026), representing ~47% of Midas total TVL — up ~40% in a week despite InfiniFi's matured farm rolling over, driven by Aave Horizon adoption
-- **Price History:** mGLOBAL targets $1.00. Oracle price is $1.00000000 (round 2, 8 decimals, last updated May 15, 2026 per [onchain data](https://etherscan.io/address/0x66aa9fcd63df74e1f67a9452e6e59fbc67f75e38) — now **39 days stale**). The token has been in production for ~11.5 weeks; limited price history available. No yield has been reported onchain since mid-May.
-- **No known security incidents** for mGLOBAL or Midas platform
+- **Production History:** mGLOBAL token created on Ethereum [April 3, 2026](https://etherscan.io/tx/0xacc1f08c1f1ea036fa35444b67328ae3d3098d6cbbc520eacc81116156eb7772) (~4.7 months in production). Midas platform launched with mTBILL in mid-2024 (~2 years total)
+- **TVL Growth:** Midas grew from ~$4M (July 2024) to a peak of ~$927.8M (October 27, 2025), then fell to a 2026 trough around ~$89.8M (August 6, 2026) before recovering to ~$152.9M (August 24, 2026). See [DeFiLlama](https://defillama.com/protocol/midas-rwa)
+- **mGLOBAL Market Cap:** ~$69.23M (August 24, 2026), ~45% of Midas total TVL. Supply has grown steadily since launch: 74,344,745.20 mGLOBAL minted and 6,247,255.24 burned to date, for a net 68,097,489.96 outstanding
+- **Price History:** the oracle has published **five rounds** since deployment, all from the same updater EOA:
+
+  | Round | Date | Price | Setter |
+  |---|---|---|---|
+  | 1 | [April 5, 2026](https://etherscan.io/tx/0x45c0c4f317741d476578eba17e747df898834afb05a50e806b14bff75396eaca) | $1.00000000 | `setRoundData` |
+  | 2 | [May 15, 2026](https://etherscan.io/tx/0x08076ea85feaac9198f8462badd0946323ac33fa98a9cc4b6afc0e587f374d4d) | $1.00000000 | `setRoundDataSafe` |
+  | 3 | [June 29, 2026](https://etherscan.io/tx/0xb5a89445753a3b14be749ff7590b0a81e32c4166975a1e5327a57ec70cddcc81) | $1.00576480 | `setRoundDataSafe` |
+  | 4 | [July 23, 2026](https://etherscan.io/tx/0x029dcad255abca1cf02dccbacae8a29f37a31c959b129688690e029591169fb0) | $1.01128145 | `setRoundDataSafe` |
+  | 5 | [August 20, 2026](https://etherscan.io/tx/0x7600447f1393f66f7403c04c4b746e47efce5e7d2451596d04f74a07e6b5f6db) | $1.01664609 | `setRoundDataSafe` |
+
+  Yield accrual began with round 3. From May 15 to August 20 the price rose 1.6646%, an annualized ~6.3%; the three accruing intervals annualize to 4.68%, 8.32%, and 6.91% respectively. Update cadence is roughly monthly (24–45 day gaps), materially slower than mHYPER's twice-weekly cadence, so the published price can lag the true NAV by weeks
+- **No known security incidents** for mGLOBAL or the Midas platform
 
 **Fasanara Capital Track Record:**
 
@@ -123,7 +140,7 @@ All contracts use OpenZeppelin's `TransparentUpgradeableProxy` pattern with a sh
 - **Business:** Two main pillars — Fintech Lending (141 loan originators across 60+ countries, $115bn+ total volumes traded per [Fasanara lending](https://www.fasanara.com/lending)) and Digital Assets. EU SFDR Article 8 classified funds for certain Alternative Credit sub-funds
 - **Flagship strategy:** The [Global Diversified Alternative Debt Fund](https://www.fasanara.com/lending) (the multi-strategy receivables flagship that mGLOBAL's "Global Fund" mirrors) has ~10.5 years of history and $3B+ dedicated AUM. Fasanara reports ~$4.5–5.5B firm-wide AUM ([Alternatives Watch interview, 2024](https://www.alternativeswatch.com/2024/07/29/interview-alternative-credit-manager-fasanara-francesco-filia-fintech-lending/))
 - **Track record:** 15-year operating history. ESG initiatives (Sustainability Report 2025 published). No known regulatory actions or incidents found
-- **mGLOBAL strategy (documented, not onchain-verifiable):** Per [RWA.xyz](https://app.rwa.xyz/assets/mGLOBAL) and [Fasanara](https://www.fasanara.com/lending), mGLOBAL gives exposure to Fasanara's "Global Fund," which follows the same strategy as the Global Diversified Alternative Debt Fund: an asset-backed lending portfolio investing primarily in **short-dated trade receivables, digital invoices, and SME loans** bought from a network of ~141 fintech originators. The 88.61% "Unclassified" label reflects that these are offchain receivables (not onchain protocol positions), so the *strategy* is documented but the *specific allocation* (originators, geographies, sectors, delinquency/loss rates for this vehicle) is not disclosed or verifiable. See [Funds Management](#funds-management)
+- **mGLOBAL strategy (documented, not onchain-verifiable):** Per [RWA.xyz](https://app.rwa.xyz/assets/mGLOBAL) and [Fasanara](https://www.fasanara.com/lending), mGLOBAL gives exposure to Fasanara's "Global Fund," which follows the same strategy as the Global Diversified Alternative Debt Fund: an asset-backed lending portfolio investing primarily in **short-dated trade receivables, digital invoices, and SME loans** bought from a network of ~141 fintech originators. The 97.03% "Unclassified" label reflects that these are offchain receivables (not onchain protocol positions), so the *strategy* is documented but the *specific allocation* (originators, geographies, sectors, delinquency/loss rates for this vehicle) is not disclosed or verifiable. See [Funds Management](#funds-management)
 
 ## Funds Management
 
@@ -136,30 +153,31 @@ Where the funds end up, and what generates the yield (per [Fasanara lending](htt
 - **Capital flow:** USDC deposit → Midas DepositVault (mints mGLOBAL) → Fordefi tri-party MPC custody → Fasanara's "Global Fund" (mirrors the Global Diversified Alternative Debt Fund) → purchase of short-dated **trade receivables, digital invoices, and SME loans**.
 - **What earns the yield:** This is **asset-backed private credit / trade-finance income**, not DeFi yield or T-bills. Fasanara buys invoices/receivables at a discount; when the SME obligor repays at face value (typically within ~3 months), the spread is the return. Fasanara sits at the top of a **hub-and-spoke network of ~141 fintech originators across 60+ countries** ($115bn+ total volume) that source the underlying borrowers — Fasanara is the capital provider, not the originator.
 - **Risk profile of the assets:** ~3-month average duration, self-liquidating; **no leverage** on most vehicles; 10,000+ obligors per fund (claimed 20–30× more diversified than a CLO); proprietary credit scoring (Fasanara Credit Model / Debtor Rating); first-loss structuring and **credit insurance** (e.g. the Allianz Trade partnership). Fund-level target return is ~10–20% net p.a. depending on the sleeve.
-- **Why onchain APY shows 0%:** The last oracle update on May 15, 2026 set round 2 to $1.00000000 with `growthApr = 0`; no subsequent NAV/yield update has been published onchain. Public onchain data does not verify accrued profit or any yield-airdrop mechanism.
+- **How yield reaches holders:** each NAV publication raises the oracle price; there is no distribution or rebase. Every round to date has carried `growthApr = 0`, so the price is a step function that jumps on update and is flat in between — it does not accrue continuously. Onchain data confirms the *published* price but cannot verify the underlying profit that justifies it.
 - **Residual gap:** This describes *what kind* of credit risk backs mGLOBAL (defensive: short-dated, insured, unlevered, diversified SME trade finance), but **not whether this specific book is healthy** — no attested per-vehicle allocation, geography/sector mix, or delinquency/loss data is disclosed. Verifiability, not strategy legitimacy, remains the binding constraint.
 
 - **Fund Manager:** [Fasanara Capital Ltd](https://www.fasanara.com/) (London, founded 2011, AUM $4B+) — one of Europe's largest fintech-focused asset managers
-- **Strategy Allocations (per [SumCap](https://midas.sumcap.xyz/mglobal), June 24, 2026):**
-  - **Unclassified: $46.63M (88.61%)** — offchain/opaque positions not attributable to specific onchain protocols
-  - **Liquidity Buffer: $3.44M (6.54%)** — onchain wallet liquidity
-  - **Aave V3: $2.55M (4.85%)** — idle capital deployed on Aave (blue-chip DeFi)
-  - **Assets To be Deployed: $3.66 (0.00%)** — fully allocated
-  - **NAV:** ~$52.63M; **Price:** $1.0000; **APY:** 0.00% (static since May 15, 2026)
-  - **Change vs prior SumCap snapshot (June 16):** Unclassified fell from 92.09% → 88.61%, Liquidity Buffer rose from 1.13% → 6.54%, and Aave V3 fell from 6.78% → 4.85% as total NAV grew from $37.61M to ~$52.63M
+- **Strategy Allocations (per [SumCap / Delta Y](https://midas.sumcap.xyz/mglobal), August 23–24, 2026 window):**
+  - **Unclassified: $67,177,041.40 (97.03%)** — offchain/opaque positions not attributable to specific onchain protocols
+  - **USDC on Aave V3: $2,053,999.71 (2.97%)** — the only protocol-classified position
+  - **ETH: $5.80 (0.00%)** — dust
+  - **NAV:** $69,231,046.91; **Price:** $1.016646; **APY:** 7.13%
   - SumCap methodology: \"NAV is computed as the maximum between total onchain supply × most recent oracle price and NAV tracked by Delta Y across all vault allocator addresses\"
-  - ⚠ **88.61% of mGLOBAL NAV is unclassified** — the majority of the strategy portfolio cannot be verified onchain
+  - ⚠ **97.03% of mGLOBAL NAV is unclassified** — the classified share has shrunk as the vehicle has grown, and the offchain book is now almost the entire portfolio
+  - ⚠ **Reconciliation gap:** Delta Y attributes $2.05M to Aave V3, but the RedemptionVaultWithAave independently holds **$6,237,620 of aUSDC** onchain (verified via `balanceOf` on [aEthUSDC](https://etherscan.io/address/0x98C23E9d8f34FEFb1B7BD6a91B7FF122F4e16F5c)). The two figures measure different address sets and do not tie out; treat the Delta Y protocol split as indicative rather than a complete onchain census
 - **Custody:** Fordefi MPC custody with tri-party quorum per [Fordefi case study](https://web.fordefi.com/customer-stories/how-midas-brings-tokenized-investment-opportunities-on-chain-with-fordefis-defi-native-custody-2ti85) (Midas + Fasanara + independent signer)
-- **Aave Integration:** The DepositVault (MGlobalDepositVaultWithAave) and RedemptionVaultWithAave suggest idle USDC is deposited into Aave for yield — a positive structural feature. SumCap confirms $2.55M is on Aave V3
-- **Monitoring:** NAV updates provided by Fasanara, reviewed by Midas, then published onchain. Oracle last updated May 15, 2026 — **39 days stale as of June 23, 2026** (still round 2; staleness worsened since the prior assessment). The May 15 `AnswerUpdated` event kept the answer at $1.00000000 and set `growthApr = 0`, so no yield has been reported onchain since mid-May
+- **Aave Integration:** the RedemptionVaultWithAave holds **$6,237,620 aUSDC** — idle redemption capital verifiably deployed on blue-chip DeFi and, unlike the offchain book, independently auditable. This is ~9.0% of NAV. The DepositVault currently holds no USDC or aUSDC
+- **NAV process:** NAV is supplied by Fasanara, reviewed by Midas, then published onchain by the oracle updater EOA. The oracle is current — last updated **August 20, 2026, ~3.4 days before this snapshot** — on a roughly monthly cadence
 
 ### Accessibility
 
 - **KYC Required:** Yes — users must complete KYC/AML screening. Once approved, added to onchain greenlist via `GREENLISTED_ROLE` / `GREENLIST_OPERATOR_ROLE`
 - **Minting:** Deposit USDC, receive mGLOBAL tokens at oracle price ($1.00). Via `MGlobalDepositVaultWithAave`
-- **Redemption:** Two paths:
-  - **MGlobalRedemptionVaultWithAave:** Primary redemption vault with Aave integration for idle capital. Holds `M_GLOBAL_BURN_OPERATOR_ROLE`
-  - **MGlobalRedemptionVaultWithSwapper:** Secondary redemption vault with swapper functionality. Also holds `M_GLOBAL_BURN_OPERATOR_ROLE`
+- **Redemption:** two live paths, both holding `M_GLOBAL_BURN_OPERATOR_ROLE`, both unpaused, both accepting USDC only:
+  - **MGlobalRedemptionVaultWithAave** — primary vault; idle capital sits in Aave ($6,237,620 aUSDC). `instantDailyLimit` 2,000,000 mGLOBAL/day, `instantFee` 50 bps, `variationTolerance` 200 bps, greenlist enforced, Chainalysis-style `sanctionsList` set to [`0x40C5…c8fb`](https://etherscan.io/address/0x40C57923924B5c5c5455c48D93317139ADDaC8fb)
+  - **MGlobalRedemptionVaultWithSwapper** — secondary vault holding 2,000,001.74 mGLOBAL of swap inventory and $0.73 USDC. Same 2,000,000/day limit and 50 bps instant fee; routes through the mTBILL redemption vault [`0x569D…f0Ec`](https://etherscan.io/address/0x569D7dccBF6923350521ecBC28A555A500c4f0Ec) with liquidity provider [`0x0461…B846`](https://etherscan.io/address/0x0461bD693caE49bE9d030E5c212e080F9c78B846)
+  - A third vault ([`0xdbd621e6…8e76`](https://etherscan.io/address/0xdbd621e67d9cffffcdcd316a27285f657c178e76)) holds burn authority but is unfunded and unconfigured — see [Contract Addresses](#contract-addresses)
+  - Combined instant capacity is therefore bounded by the 2,000,000 mGLOBAL/day per-vault cap and, in practice, by the $6.24M of aUSDC actually held
 - **Fees (mGLOBAL-specific):**
   - **Management fee:** 0.40% annual on AUM
   - **Performance fee:** 0% on yield
@@ -177,21 +195,24 @@ Where the funds end up, and what generates the yield (per [Fasanara lending](htt
 
 **Backing check at mint time:** None — minter can issue unbacked tokens.
 
-**Per-address mint authority** (verified onchain June 17, 2026, from token contract [`0x7433806912Eae67919e66aea853d46Fa0aef98A8`](https://etherscan.io/address/0x7433806912Eae67919e66aea853d46Fa0aef98A8)):
+**Per-address mint authority** (enumerated from `RoleGranted`/`RoleRevoked` on [MidasAccessControl](https://etherscan.io/address/0x0312A9D1Ff2372DDEdCBB21e4B6389aFc919aC4B) and confirmed with `hasRole`, block 25,822,232):
 
 | Address | Can Mint | Can Burn | Role / Mechanism | Notes |
 |---------|:--------:|:--------:|------------------|-------|
-| [`0x76e350c5a674db787918e5f728466c7356d4d361`](https://etherscan.io/address/0x76e350c5a674db787918e5f728466c7356d4d361) | ✓ | ✓ | `M_GLOBAL_MINT_OPERATOR_ROLE` + `M_GLOBAL_BURN_OPERATOR_ROLE` + `M_GLOBAL_PAUSE_OPERATOR_ROLE` + `BLACKLIST_OPERATOR` + `GREENLIST_OPERATOR` | EOA, nonce 3. Per Midas pattern, claimed as Fordefi MPC (not verifiable onchain). Also holds generic BLACKLIST_OPERATOR and GREENLIST_OPERATOR roles |
+| [`0x76e350c5a674db787918e5f728466c7356d4d361`](https://etherscan.io/address/0x76e350c5a674db787918e5f728466c7356d4d361) | ✓ | ✓ | `M_GLOBAL_MINT_OPERATOR_ROLE` + `M_GLOBAL_BURN_OPERATOR_ROLE` + `M_GLOBAL_PAUSE_OPERATOR_ROLE` + `BLACKLIST_OPERATOR_ROLE` + `GREENLIST_OPERATOR_ROLE` | EOA, nonce 8. Per Midas pattern, claimed as Fordefi MPC (not verifiable onchain) |
 | [`0xce29c36c6d4556f2d01d79414c1354b968dddef1`](https://etherscan.io/address/0xce29c36c6d4556f2d01d79414c1354b968dddef1) | ✓ | — | `M_GLOBAL_MINT_OPERATOR_ROLE` | MGlobalDepositVaultWithAave (proxy). Mints when users deposit USDC |
 | [`0xa0fc8bdfb1e6a705c1375810989b1d70a982b01b`](https://etherscan.io/address/0xa0fc8bdfb1e6a705c1375810989b1d70a982b01b) | — | ✓ | `M_GLOBAL_BURN_OPERATOR_ROLE` | MGlobalRedemptionVaultWithAave (proxy) |
 | [`0x1e0fd66753198c7b8ba64edee8d41d8628bf20d7`](https://etherscan.io/address/0x1e0fd66753198c7b8ba64edee8d41d8628bf20d7) | — | ✓ | `M_GLOBAL_BURN_OPERATOR_ROLE` | MGlobalRedemptionVaultWithSwapper (proxy) |
+| [`0xdbd621e67d9cffffcdcd316a27285f657c178e76`](https://etherscan.io/address/0xdbd621e67d9cffffcdcd316a27285f657c178e76) | — | ✓ | `M_GLOBAL_BURN_OPERATOR_ROLE` | Second swapper vault, [granted August 12, 2026](https://etherscan.io/tx/0x8cff72082df0ec3a239cde44bc40efd1fe608945bae172e347f62bd0f3a91524). Unfunded and unconfigured (sentinel `0xFFfF…FFfF` addresses, 0 fee, uncapped daily limit) |
+
+No bridge adapter, OFT adapter, or CCIP token pool holds mint or burn authority — mGLOBAL is not a cross-chain token.
 
 **Mint-role grants bypass the 48-hour timelock entirely.** Either of the two `DEFAULT_ADMIN_ROLE` holders can grant themselves `M_GLOBAL_MINT_OPERATOR_ROLE` and mint unbacked tokens in two transactions with zero delay.
 
 ### Collateralization
 
 - **Backing Model:** Offchain / hybrid — mGLOBAL is a **subordinated debt instrument** of Midas Software GmbH, not a direct claim on underlying assets
-- **Collateral Quality:** Per [SumCap](https://midas.sumcap.xyz/mglobal) (June 24, 2026): 88.61% Unclassified (offchain/opaque), 6.54% Liquidity Buffer (USDC), 4.85% Aave V3 aUSDC (blue-chip DeFi). The 88.61% unclassified portion cannot be assessed for quality — this is the primary collateralization concern
+- **Collateral Quality:** per [SumCap / Delta Y](https://midas.sumcap.xyz/mglobal) (August 24, 2026): **97.03% Unclassified** (offchain/opaque) and 2.97% USDC on Aave V3. The unclassified portion cannot be assessed for quality and is now almost the entire portfolio — this is the primary collateralization concern. Independently verifiable onchain backing is limited to the $6,237,620 of aUSDC in the RedemptionVaultWithAave (~9.0% of NAV)
 - **Verifiability:** Hybrid. The Aave integration in vaults provides partial onchain visibility of idle capital. Full strategy portfolio composition requires offchain reporting
 - **Risk Curation:** Fasanara has discretion over allocation within the strategy framework. Midas enforces policy limits via Fordefi policy engine
 - **Tri-Party Governance (via Fordefi):** Per Fordefi case study: Midas Treasury + Fasanara (Asset Manager) + Independent Oversight Signer. Operations within predefined rules clear automatically; anything outside routes to tri-party quorum
@@ -200,34 +221,35 @@ Where the funds end up, and what generates the yield (per [Fasanara lending](htt
 ### Provability
 
 - **Reserve Transparency:** Hybrid. The shared Midas [Attestation Engine](https://docs.midas.app/transparency/the-midas-attestation-engine) (SAVE, introduced March 2026) adds a multi-party verification layer via three contracts: [KeystoneForwarder](https://etherscan.io/address/0x0b93082D9b3C7C97fAcd250082899BAcf3af3885), [SaveCreReceiverProxy](https://etherscan.io/address/0xC50102b6598924Aa8deB201c757bFb9a3dBdB9b6), and [MidasSaveRegistryWithClaim](https://etherscan.io/address/0x2D6e9F608807436DE5D9603B00Abe3FEd1Bc809d). The registry stores hashes only — not actual reserve data or NAV
-- **NAV/Price Updates:** Token price updated via privileged role on the `MGlobalCustomAggregatorFeedGrowth` oracle ([`0x66aa9fcd63df74e1f67a9452e6e59fbc67f75e38`](https://etherscan.io/address/0x66aa9fcd63df74e1f67a9452e6e59fbc67f75e38)). Current price: $1.00000000 (round 2). **Update history (verified onchain):** The oracle has been updated only **2 times since deployment**: [April 5, 2026](https://etherscan.io/tx/0x45c0c4f317741da7b1e210e7228c5fbc190cb44d07fcef68bd5c0e2f56ddcd39) (initial price set) and [May 15, 2026](https://etherscan.io/tx/0x08076ea85feaac9198f8462badd0946323ac33fa98a9cc4b6afc0e587f374d4d) (`AnswerUpdated`: answer $1.00000000, round 2, `growthApr = 0`). **The oracle is now 39 days stale** (last update May 15, 2026; snapshot June 23, 2026 — still round 2). This is atypical — mHYPER's oracle is updated twice per week. For a stablecoin product, the price has been static at $1.00, but the lack of regular updates is notable
-- **Oracle Bounds:** `maxAnswerDeviation` = 100000000 ($1.00, effectively 100% deviation per update — very loose), `minAnswer` = $0.10, `maxAnswer` = $1,000. These are much looser than mHYPER's 0.35% deviation cap
+- **NAV/Price Updates:** the token price is set via a privileged role on the `MGlobalCustomAggregatorFeedGrowth` oracle ([`0x66aa9fcd63df74e1f67a9452e6e59fbc67f75e38`](https://etherscan.io/address/0x66aa9fcd63df74e1f67a9452e6e59fbc67f75e38)). Current price $1.01664609 at round 5, published August 20, 2026 — **3.4 days before this snapshot**. Full round history is tabulated in [Historical Track Record](#historical-track-record). Cadence is roughly monthly against mHYPER's twice-weekly, so the onchain price can trail true NAV by weeks
+- **Oracle Bounds:** `maxAnswerDeviation` = 100000000 ($1.00 — a 100% move permitted per update), `minAnswer` = $0.10, `maxAnswer` = $1,000. `minGrowthApr` = `maxGrowthApr` = 0, so no interpolated growth is permitted; the price is a step function that only changes when a round is published. `onlyUp` is **true**
+- ⚠ **The deviation cap and the `onlyUp` guard are not enforced on the admin path.** The oracle exposes two setters. `setRoundDataSafe(int256,uint256,int80)` checks the deviation against `maxAnswerDeviation`, enforces `onlyUp`, and requires at least an hour since the last update — but it then calls `setRoundData(int256,uint256,int80)`, which is itself `public onlyAggregatorAdmin` and validates **only** that the answer is within `[minAnswer, maxAnswer]`, that `growthApr` is within `[minGrowthApr, maxGrowthApr]`, and that the data timestamp is in the past. The oracle admin can therefore call `setRoundData` directly and set any price between **$0.10 and $1,000 in a single transaction**, in either direction, with no deviation limit and no hourly spacing. Round 1 was in fact written through the raw `setRoundData` path ([selector `0x2b6e02c7`](https://etherscan.io/tx/0x45c0c4f317741d476578eba17e747df898834afb05a50e806b14bff75396eaca)); rounds 2–5 used `setRoundDataSafe` (selector `0x92260352`). The safe path is an operational convention, not an invariant
+- ⚠ **`onlyUp` blocks markdowns on the safe path.** Because `onlyUp` is true, `setRoundDataSafe` rejects any downward revision, so a credit impairment in Fasanara's receivables book cannot be reflected through the routine update path. NAV can only ratchet upward unless the admin switches to the raw setter. A stale-high price lets early redeemers exit at more than the assets are worth, concentrating the loss on whoever remains — the classic first-mover run dynamic for an unlisted, redemption-only instrument
 - **Oracle Model:** Uses MGlobalCustomAggregatorFeedGrowth with separate PriceRaised ([`0x494f142c35167cfbdd3887e8d7897822e63c9618`](https://etherscan.io/address/0x494f142c35167cfbdd3887e8d7897822e63c9618)) and PriceLowered ([`0x4c825154d02eafab7f3c779d96c279bcdb9fcf6f`](https://etherscan.io/address/0x4c825154d02eafab7f3c779d96c279bcdb9fcf6f)) bound feeds. These appear to define upper/lower acceptable price bounds, but currently have **no role holders assigned** — suggesting this safety feature is not yet active
 - **Attestation Engine Data:** The registry stores proof IDs, attestation hashes, claim hashes, verifier hashes, timestamps, and attestor/verifier addresses. It does **not** expose actual reserve data or an onchain URI/CID
 - **Third-Party Verification:** Per Midas docs, the Attestation Engine uses LlamaRisk and Canary Protocol as independent verifiers
 
 ## Liquidity Risk
 
-- **DEX Liquidity:** **Zero** — No Uniswap V3 pools found for mGLOBAL/USDC at any fee tier (500/3000/10000 bps) via [Uniswap V3 Factory](https://etherscan.io/address/0x1F98431c8aD98523631AE4a59f267346ea31F984). Zero DEX pairs on DexScreener. The token has no secondary market — exit is entirely dependent on Midas redemption infrastructure
-- **Aave Horizon collateral listing (June 2026):** mGLOBAL is now an **active collateral reserve** on the permissioned [Aave Horizon RWA market](https://app.aave.com/reserve-overview/?underlyingAsset=0x7433806912eae67919e66aea853d46fa0aef98a8&marketName=proto_horizon_v3) (Pool [`0xAe05…32C8`](https://etherscan.io/address/0xAe05Cd22df81871bc7cC2a04BeCfb516bFe332C8)). Verified onchain: `usageAsCollateral = true`, **but LTV = 0.05% and liquidation threshold = 0.10%** (no eMode), so the credit currently extendable against mGLOBAL is effectively **zero** — this is a conservative "onboarded-but-throttled" listing, not a meaningful borrowing market. Supply cap 50M; **$19.85M already supplied** (aMGLOBAL [`0x49d3…B985`](https://etherscan.io/address/0x49d3cdE03813eE32DFD47F6aA3957d5F9CbAB985)); borrowing of mGLOBAL itself disabled; liquidation bonus 6%. It does **not** add a redemption exit for holders (Horizon suppliers must withdraw, then redeem via Midas), but it is a genuine third-party institutional onboarding signal (Horizon is permissioned and curator-vetted) and a source of independent demand
-- **Primary Exit:** Via Midas redemption vaults (MGlobalRedemptionVaultWithAave + MGlobalRedemptionVaultWithSwapper)
-- **Redemption Mechanism:**
-  - **MGlobalRedemptionVaultWithAave** — primary redemption with Aave integration. Likely supports instant redemptions when liquidity available
-  - **MGlobalRedemptionVaultWithSwapper** — secondary redemption with swapper functionality
-- **Large Holder Impact (HIGH, eased from EXTREME):** The top holder is now [InfiniFi's renewed MidasFarm](https://etherscan.io/address/0xf4ea3ec87b1c254f17a2fb68164db0caf6c4cecf) at **57.94%** (~$30.49M), down from 81%. InfiniFi's original farm matured June 15, 2026 and **renewed rather than redeemed** — rolling its position into a new MidasFarm with `maturity()` of **July 21, 2026**. This removed the *immediate* exit trigger (a sophisticated counterparty chose to re-lock) but a fresh maturity re-arms in ~1 month. Aave Horizon (37.71%) and the Safe (4.35%) now hold the balance, so a single exit is less catastrophic than at 81% — but a ~58% holder unwinding into ~$0 vault liquidity remains a risk.
-- **Vault USDC Balances (onchain, June 23, 2026):**
-  - [DepositVault](https://etherscan.io/address/0xce29c36c6d4556f2d01d79414c1354b968dddef1): **$0 USDC**
-  - [RedemptionVaultWithAave](https://etherscan.io/address/0xa0fc8bdfb1e6a705c1375810989b1d70a982b01b): **$0 USDC**
-  - [RedemptionVaultWithSwapper](https://etherscan.io/address/0x1e0fd66753198c7b8ba64edee8d41d8628bf20d7): **~$0.73 USDC**
-  - The vaults hold negligible idle USDC — funds are either deployed to Aave (aUSDC) or moved offchain to Fasanara custody. This means instant redemption capacity is currently **near zero** at the vault level (unchanged from prior assessment)
+- **DEX Liquidity:** **Zero.** No Uniswap V3 pool exists for mGLOBAL/USDC at the 100, 500, 3000, or 10000 bps tiers via the [Uniswap V3 Factory](https://etherscan.io/address/0x1F98431c8aD98523631AE4a59f267346ea31F984), and no Uniswap V2 pair exists via the [V2 Factory](https://etherscan.io/address/0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f). There is no secondary market; exit is entirely dependent on Midas redemption infrastructure
+- **Aave Horizon collateral reserve — now at its cap:** mGLOBAL is an active collateral reserve on the permissioned [Aave Horizon RWA market](https://app.aave.com/reserve-overview/?underlyingAsset=0x7433806912eae67919e66aea853d46fa0aef98a8&marketName=proto_horizon_v3) (Pool [`0xAe05…32C8`](https://etherscan.io/address/0xAe05Cd22df81871bc7cC2a04BeCfb516bFe332C8), aMGLOBAL [`0x49d3…B985`](https://etherscan.io/address/0x49d3cdE03813eE32DFD47F6aA3957d5F9CbAB985)). Current reserve configuration, decoded from `getConfiguration`: `usageAsCollateral` true, **LTV 0.05%**, **liquidation threshold 0.10%**, liquidation bonus 6%, reserve factor 0%, borrowing of mGLOBAL disabled, not frozen and not paused. The credit extendable against mGLOBAL is therefore still effectively **zero**.
+  - The **supply cap was reduced from 50,000,000 to 30,000,000 on [July 2, 2026](https://etherscan.io/tx/0x8f4a77b86f71129e8acc7452494a732150c963fbbef50d670d958ee3ea668acf)** (it had been [raised from 0 to 50M on June 23, 2026](https://etherscan.io/tx/0xc03ba2579c8217ddf090fdc3aa3e322c86b3a116f97fc2ed00f40e1f2ed526eb)), and the reserve now sits at **29,999,999 of 30,000,000** — fully saturated. The curator tightened the limit rather than extending credit, and no further mGLOBAL can be supplied. This closes what had been the main source of incremental demand
+  - Horizon is **not an exit venue**: suppliers must withdraw and then redeem through Midas
+  - Horizon prices mGLOBAL through a Chainlink OCR2 feed, "mGlobal NAV - Aave Llamaguard" ([aggregator `0x61b3…1460`](https://etherscan.io/address/0x61b35E8fD649992e184FC3e619E6899c0e851460) behind proxy [`0xe034…E939`](https://etherscan.io/address/0xe034De753a3d855B6daD1A4984de75a5c443E939)), with **16 transmitters** and updates every few hours (round 73, last written 8.6 hours before this snapshot) against the Midas oracle's monthly cadence. The DON improves availability and adds an attestation layer, but it *tracks* the Midas NAV — it does not value the book independently, so a bad Midas print still propagates into Aave. The feed itself carries no meaningful bounds (`minAnswer` 0, `maxAnswer` effectively unbounded)
+- **Primary Exit:** the two live Midas redemption vaults. Instant redemption is capped at **2,000,000 mGLOBAL per vault per day** with a **50 bps** fee; larger exits go through the request/approval flow processed offchain by Midas
+- **Onchain redemption liquidity:** the RedemptionVaultWithAave holds **$6,237,620 of aUSDC** — real, verifiable instant-redemption backing worth ~9.0% of NAV, and a structural improvement over an empty vault. The RedemptionVaultWithSwapper holds $0.73 USDC plus 2,000,001.74 mGLOBAL of swap inventory; the DepositVault and the staged third vault hold nothing. Anything beyond ~$6.2M still depends on Fasanara unwinding offchain receivables
+- **Holder Concentration (MODERATE):** the largest beneficial holder is **InfiniFi at 30.29%** (20,627,291.44 mGLOBAL, ~$21M), followed by [`0x882C…EDb7`](https://etherscan.io/address/0x882C825405fBBE45DCc1ad52b639aFbC4592EDb7) at 26.11% and [`0x0dfa…8319`](https://etherscan.io/address/0x0dfa220249fccc15fd19e7c7fa3198f4742b8319) at 14.48%. Only 16 addresses hold a non-zero balance, so the holder base is small even where it is no longer dominated by one name. A single 30% holder exiting would require roughly $21M against ~$6.2M of instant capacity — still a forced offchain unwind, but no longer an all-or-nothing dependency on one counterparty
+- **InfiniFi exposure has changed shape, not size:** InfiniFi did not redeem. On [August 17, 2026](https://etherscan.io/tx/0xb4d8d9c153c8242adc6701c987709f9a372e29ea538f4990902d95ebad32abde) its `MidasFarm` moved the entire position into an InfiniFi [`RWAEscrowRouter`](https://etherscan.io/address/0x7912Eaff92B2f5Bc64Cdd21C76d79FFC12eA855E), which values the holding offchain via the `RWAEscrowRateManager` keeper and reports `liquidity()` = 0. From mGLOBAL's side the exposure is unchanged in size; from InfiniFi's side it is now booked as an offchain-attested escrow rather than a tokenized farm, which reduces transparency on both ends and removes the fixed maturity date that previously gave advance warning of an exit
+- **Stress Performance:** no forced-redemption stress event has occurred. The June 2026 InfiniFi farm maturity passed without a redemption, and the August transfer into the escrow router likewise moved the position without touching Midas redemption capacity — so the exit path has still never been tested at size
 
 ## Centralization & Control Risks
 
 ### Governance
 
 - **Contract Upgradeability:** Yes — all contracts use `TransparentUpgradeableProxy` with shared `ProxyAdmin` at [`0xbf25b58cB8DfaD688F7BcB2b87D71C23A6600AaC`](https://etherscan.io/address/0xbf25b58cB8DfaD688F7BcB2b87D71C23A6600AaC)
-- **ProxyAdmin Owner:** [`MidasTimelockController`](https://etherscan.io/address/0xE3EEe3e0D2398799C884a47FC40C029C8e241852) — a verified OpenZeppelin `TimelockController` with a **48-hour minimum delay**. Contract upgrades must be proposed, wait 48 hours, then executed
-- **Timelock Proposer/Executor:** Gnosis Safe [`0xB60842E9DaBCd1C52e354ac30E82a97661cB7E89`](https://etherscan.io/address/0xB60842E9DaBCd1C52e354ac30E82a97661cB7E89) — **1/3 onchain threshold** (any single Safe owner can propose/execute). Safe owners:
+- **ProxyAdmin Owner:** [`MidasTimelockController`](https://etherscan.io/address/0xE3EEe3e0D2398799C884a47FC40C029C8e241852) — a verified OpenZeppelin `TimelockController` with a **48-hour minimum delay**. Contract upgrades must be proposed, wait 48 hours, then executed. Every mGLOBAL proxy implementation matches the addresses in [Contract Addresses](#contract-addresses); none has been upgraded since deployment
+- **Shared timelock queue:** the timelock serves all Midas products and has processed 87 scheduled operations (82 executed, 3 cancelled). Two operations scheduled August 18, 2026 are **pending and past their 48-hour ETA** — both are `upgrade(proxy,impl)` calls targeting the mTBILL and mBASIS data feeds, not mGLOBAL contracts. Because the `ProxyAdmin` is shared, queue activity should be monitored even when the target is another product
+- **Timelock Proposer/Executor/Canceller:** Gnosis Safe [`0xB60842E9DaBCd1C52e354ac30E82a97661cB7E89`](https://etherscan.io/address/0xB60842E9DaBCd1C52e354ac30E82a97661cB7E89) holds all three roles — **1/3 onchain threshold**, so any single Safe owner can propose, execute, or cancel. `TIMELOCK_ADMIN_ROLE` is held only by the timelock itself. `getMinDelay()` returns 172,800 seconds (48 hours). Safe owners:
   - [`0x8003544D32eE074aA8A1fb72129Fa8Ef7fe02E5f`](https://etherscan.io/address/0x8003544D32eE074aA8A1fb72129Fa8Ef7fe02E5f) — EOA. Per Midas, Fordefi MPC (3/n) — not verifiable onchain
   - [`0x82B30194bEae06D991Bc71850F949ec8cB7E0CB7`](https://etherscan.io/address/0x82B30194bEae06D991Bc71850F949ec8cB7E0CB7) — Nested Gnosis Safe (3/7)
   - [`0xC50BD8430545C80a681C7cb33E6560fB0Bd86880`](https://etherscan.io/address/0xC50BD8430545C80a681C7cb33E6560fB0Bd86880) — EOA. Per Midas, Fireblocks MPC (3/n) — not verifiable onchain
@@ -235,33 +257,34 @@ Where the funds end up, and what generates the yield (per [Fasanara lending](htt
 - **Access Control:** Role-based via `MidasAccessControl` ([`0x0312A9D1Ff2372DDEdCBB21e4B6389aFc919aC4B`](https://etherscan.io/address/0x0312A9D1Ff2372DDEdCBB21e4B6389aFc919aC4B))
 - **DEFAULT_ADMIN_ROLE holders (2):** Two addresses hold `DEFAULT_ADMIN_ROLE` on MidasAccessControl — **role changes (mint/burn/pause/blacklist grants) bypass the timelock** and can be executed immediately:
   - The 1/3 Gnosis Safe ([`0xB60842E9DaBCd1C52e354ac30E82a97661cB7E89`](https://etherscan.io/address/0xB60842E9DaBCd1C52e354ac30E82a97661cB7E89))
-  - [`0xd4195cf4df289a4748c1a7b6ddbe770e27ba1227`](https://etherscan.io/address/0xd4195cf4df289a4748c1a7b6ddbe770e27ba1227) — EOA. [Per Midas](https://docs.midas.app/security/smart-contract-security#midas-controller), Fordefi MPC (3/n) — not verifiable onchain
+  - [`0xd4195cf4df289a4748c1a7b6ddbe770e27ba1227`](https://etherscan.io/address/0xd4195cf4df289a4748c1a7b6ddbe770e27ba1227) — EOA, nonce 375. [Per Midas](https://docs.midas.app/security/smart-contract-security#midas-controller), Fordefi MPC (3/n) — not verifiable onchain
   - **Either of the two remaining admins can grant/revoke any role with no timelock.** Midas states they are working on gating specific functions behind a timelock
 - **Governance Model:** No onchain governance. Midas controls all admin functions
 - **Privileged Roles:**
   1. **`M_GLOBAL_MINT_OPERATOR_ROLE`** (`0x86c2e8326862f916bf4ee800260d2306dc3c829808f94feb79f6d3a20aaf9bc2`) — Can mint unlimited mGLOBAL tokens. **The `mint()` function has no onchain collateral check** — it only verifies the caller has the mint role. Currently held by:
     - [`0x76e350c5a674db787918e5f728466c7356d4d361`](https://etherscan.io/address/0x76e350c5a674db787918e5f728466c7356d4d361) — EOA, nonce 3. Per Midas pattern, Fordefi MPC (not verifiable). Also holds BURN, PAUSE, BLACKLIST_OP, GREENLIST_OP roles
     - [`0xce29c36c6d4556f2d01d79414c1354b968dddef1`](https://etherscan.io/address/0xce29c36c6d4556f2d01d79414c1354b968dddef1) — MGlobalDepositVaultWithAave (mints when users deposit USDC)
-  2. **`M_GLOBAL_BURN_OPERATOR_ROLE`** — Can burn mGLOBAL tokens from any address. Currently held by:
+  2. **`M_GLOBAL_BURN_OPERATOR_ROLE`** — Can burn mGLOBAL tokens from any address. Held by four addresses:
     - [`0x76e350c5a674db787918e5f728466c7356d4d361`](https://etherscan.io/address/0x76e350c5a674db787918e5f728466c7356d4d361) — same EOA as above (Fordefi MPC)
     - [`0xa0fc8bdfb1e6a705c1375810989b1d70a982b01b`](https://etherscan.io/address/0xa0fc8bdfb1e6a705c1375810989b1d70a982b01b) — MGlobalRedemptionVaultWithAave (proxy)
     - [`0x1e0fd66753198c7b8ba64edee8d41d8628bf20d7`](https://etherscan.io/address/0x1e0fd66753198c7b8ba64edee8d41d8628bf20d7) — MGlobalRedemptionVaultWithSwapper (proxy)
+    - [`0xdbd621e67d9cffffcdcd316a27285f657c178e76`](https://etherscan.io/address/0xdbd621e67d9cffffcdcd316a27285f657c178e76) — second swapper vault, unfunded and unconfigured (sentinel addresses, zero fee, uncapped daily limit)
   3. **`M_GLOBAL_PAUSE_OPERATOR_ROLE`** — Can pause/unpause the contract (freezing all transfers). Held by [`0x76e350c5a674db787918e5f728466c7356d4d361`](https://etherscan.io/address/0x76e350c5a674db787918e5f728466c7356d4d361)
   4. **`DEFAULT_ADMIN_ROLE`** — Can grant/revoke all other roles (held by 1/3 Safe + one EOA, no timelock). A compromised admin can grant itself the MINT role and mint unbacked tokens in two transactions
   5. **ProxyAdmin owner** — Can upgrade all contract implementations (via 48hr timelock)
-  6. **Oracle updater** — Can set the NAV price via `M_GLOBAL_CUSTOM_AGGREGATOR_FEED_ADMIN_ROLE` (`0x9e02beae92a72aee37131404ba654d9d66746f20885ff63bd08d7b4b8864a54e`). Currently held by a single EOA: [`0x088a74de7df74e6a6eb832d28878a9f134ee4f05`](https://etherscan.io/address/0x088a74de7df74e6a6eb832d28878a9f134ee4f05) — nonce 4, no timelock on price updates. Oracle bounds: maxAnswerDeviation = 100% ($1.00), minAnswer = $0.10, maxAnswer = $1,000
-  7. **Greenlist/Blacklist operators:**
-     - Generic `GREENLIST_OPERATOR`: [`0x76e350c5a674db787918e5f728466c7356d4d361`](https://etherscan.io/address/0x76e350c5a674db787918e5f728466c7356d4d361) and [`0x9ba8c38ae60e6e6311d53f8a85e5cf4004d3c987`](https://etherscan.io/address/0x9ba8c38ae60e6e6311d53f8a85e5cf4004d3c987) (nonce 0 — never transacted)
-     - Generic `BLACKLIST_OPERATOR`: [`0x76e350c5a674db787918e5f728466c7356d4d361`](https://etherscan.io/address/0x76e350c5a674db787918e5f728466c7356d4d361) and [`0x9ba8c38ae60e6e6311d53f8a85e5cf4004d3c987`](https://etherscan.io/address/0x9ba8c38ae60e6e6311d53f8a85e5cf4004d3c987)
-     - Token-specific `M_GLOBAL_BLACKLIST_OPERATOR_ROLE` and `M_GLOBAL_GREENLIST_OPERATOR_ROLE`: **NOT currently granted to anyone**
+  6. **Oracle updater** — Can set the NAV price via `M_GLOBAL_CUSTOM_AGGREGATOR_FEED_ADMIN_ROLE` (`0x9e02beae92a72aee37131404ba654d9d66746f20885ff63bd08d7b4b8864a54e`). Held by a single EOA: [`0x088a74de7df74e6a6eb832d28878a9f134ee4f05`](https://etherscan.io/address/0x088a74de7df74e6a6eb832d28878a9f134ee4f05) — nonce 12, no timelock on price updates. Because `setRoundData` is directly callable by this role and skips the deviation and `onlyUp` checks (see [Provability](#provability)), this single key can reprice mGLOBAL anywhere in $0.10–$1,000 in one transaction
+  7. **`M_GLOBAL_DEPOSIT_VAULT_ADMIN_ROLE`** — Held by one EOA, [`0x2acb4bdcbef02f81bf713b696ac26390d7f79a12`](https://etherscan.io/address/0x2acb4bdcbef02f81bf713b696ac26390d7f79a12) (nonce 7,786 — an active operational key). Controls deposit-vault parameters
+  8. **Greenlist/Blacklist operators — 53 EOAs each.** `GREENLIST_OPERATOR_ROLE` (`0x77c5b782…1999d`) and `BLACKLIST_OPERATOR_ROLE` (`0x2fdc6683…889ff`) are each held by the **same 53 externally owned accounts**, accumulated one at a time since December 2023 and still being added (most recently August 20, 2026). These are platform-wide Midas roles, not mGLOBAL-specific, and the token-specific `M_GLOBAL_GREENLIST_OPERATOR_ROLE` / `M_GLOBAL_BLACKLIST_OPERATOR_ROLE` variants are granted to nobody — so all greenlist and blacklist authority over mGLOBAL runs through this 53-key set. **Any one of the 53 can blacklist an arbitrary holder**, which under the token's transfer checks freezes that holder's balance and blocks redemption. For a KYC-gated instrument some operator breadth is expected, but 53 independent EOAs with unilateral freeze authority is a wide and poorly-bounded surface, and none of it is timelocked
+     - `BLACKLISTED_ROLE` is currently held by exactly one address, [`0x3e2e66af…4436`](https://etherscan.io/address/0x3e2e66af967075120fa8be27c659d0803dff4436), blacklisted on October 15, 2025 — platform-wide and predating mGLOBAL
+     - `M_GLOBAL_GREENLISTED_ROLE` (the mGLOBAL KYC allowlist) is held by 98 addresses
 - **Fund Seizure / Unbacked Minting:** The mint operator can create tokens without depositing collateral (no onchain backing check). The burn operator can burn from any address. The blacklist/pause operators can freeze activity. Role grants bypass the timelock — either of the two `DEFAULT_ADMIN_ROLE` holders can grant themselves these roles immediately and unilaterally. `renounceRole` is disabled (always reverts) per shared MidasAccessControl code
 - **Audit Assessment:** Hacken auditors explicitly flagged the protocol as **"highly centralized"** with system admins controlling all critical roles
 
 ### Programmability
 
 - **System Operations:** Primarily offchain. Strategy execution, NAV calculation, and redemption processing are handled by Midas/Fasanara offchain
-- **Oracle/NAV Updates:** The `MGlobalCustomAggregatorFeedGrowth` is updated by a privileged role with significantly looser bounds than mHYPER (100% deviation vs 0.35%). The PriceRaised/PriceLowered bound feeds exist onchain but have no role holders — this safety feature appears inactive
-- **PPS Definition:** The oracle price IS the PPS. It is updated by an admin role, not computed onchain from reserves
+- **Oracle/NAV Updates:** the `MGlobalCustomAggregatorFeedGrowth` is written by a privileged role with far looser bounds than mHYPER (100% permitted deviation vs 0.35%), and the deviation bound is skippable entirely via the raw `setRoundData` path. The PriceRaised/PriceLowered bound feeds exist onchain but have no role holders — this safety feature remains inactive
+- **PPS Definition:** The oracle price IS the PPS. It is updated by an admin role, not computed onchain from reserves. `onlyUp` prevents downward revisions on the guarded path, so the published PPS cannot reflect a loss without an explicit switch to the unguarded setter
 - **Off-Chain Dependencies:** Critical
   - Fasanara's strategy execution and NAV reporting
   - Midas's redemption processing
@@ -271,10 +294,11 @@ Where the funds end up, and what generates the yield (per [Fasanara lending](htt
 
 ### External Dependencies
 
-- **Fasanara Capital (Critical):** Strategy management, NAV calculation, risk monitoring. **Due diligence on Fasanara is partially complete** — confirmed $4B+ AUM, 15-year history, London-based institutional manager with MIFIDPRU disclosure. However, crypto-native track record and mGLOBAL-specific mandate remain unverified. 88.61% NAV opacity is a key concern. Fasanara is larger ($4B vs $300M AUM) and more established (15yr vs 7yr), but its digital asset strategy transparency is lower
+- **Fasanara Capital (Critical):** strategy management, NAV calculation, risk monitoring. Firm-level diligence is complete — FCA-authorised, $4B+ AUM, 15-year history, London-based, MIFIDPRU disclosure. What remains unverified is the mGLOBAL-specific mandate: **97.03% of NAV is unclassified**, so neither the position-level book nor its credit health can be checked. Fasanara is larger and more established than mHYPER's Hyperithm, but its transparency on this vehicle is materially lower
 - **Fordefi (Critical):** MPC custody of underlying assets with tri-party MPC governance
-- **Aave (Important):** Two distinct relationships. (1) The DepositVault and RedemptionVault integrate directly with Aave V3 for idle capital management — a positive dependency vs mHYPER's fully offchain handling. (2) As of June 2026, mGLOBAL is also a **collateral reserve on Aave Horizon** ($19.85M supplied, but LTV 0.05% → near-zero credit). This makes Aave's mGLOBAL price oracle ([`0xB92A…8193`](https://etherscan.io/address/0xB92A68763b2F83e094595c7B41a7FB9D0f8Da193), currently $1.00) a downstream consumer of mGLOBAL's price — relevant given mGLOBAL's own oracle is loose (100% deviation) and 39 days stale. The conservative 0.05% LTV likely reflects Aave/curator caution about exactly that
-- **Strategy Counterparties:** cannot verify specific strategy counterparties, 88.61% of NAV is unclassified
+- **Aave (Important):** two distinct relationships. (1) The RedemptionVaultWithAave holds $6,237,620 of aUSDC, so redemption float is verifiably on blue-chip DeFi rather than fully offchain — a structural advantage over mHYPER. (2) mGLOBAL is a **collateral reserve on Aave Horizon**, saturated at its 30M supply cap with LTV 0.05%, so Aave extends near-zero credit against it. Horizon consumes mGLOBAL's price through the Chainlink OCR2 "mGlobal NAV - Aave Llamaguard" feed ([`0xe034…E939`](https://etherscan.io/address/0xe034De753a3d855B6daD1A4984de75a5c443E939), $1.01664609), which mirrors the Midas NAV rather than valuing the book independently. The conservative LTV and the cap reduction both read as curator caution about exactly that dependency
+- **InfiniFi (Important):** the single largest holder at 30.29%, now held through an [`RWAEscrowRouter`](https://etherscan.io/address/0x7912Eaff92B2f5Bc64Cdd21C76d79FFC12eA855E) that marks the position offchain via a keeper rather than through the mGLOBAL oracle. Concentration risk runs in both directions: mGLOBAL depends on InfiniFi not exiting, and per the [InfiniFi report](https://github.com/yearn/risk-score/blob/master/reports/report/infinifi.md) InfiniFi's own backing is heavily dependent on this position
+- **Strategy Counterparties:** specific counterparties cannot be verified; 97.03% of NAV is unclassified
 - **Oracle:** NAV reported via custom contract (MGlobalCustomAggregatorFeedGrowth). **Not** a Chainlink data feed. Bound feeds (PriceRaised/PriceLowered) exist but have no active role holders
 - **MidasAccessControl (Critical):** Shared across all Midas products. A failure or compromise of this contract would affect mGLOBAL alongside mHYPER, mTBILL, and other Midas tokens
 
@@ -283,16 +307,17 @@ Where the funds end up, and what generates the yield (per [Fasanara lending](htt
 - **Team:** **Shared with all Midas products.** Dennis Dinkelmeyer (CEO, ex-Goldman Sachs), Fabrice Grinda (Executive Chairman, co-founded OLX, FJ Labs), Romain Bourgois (CPO, ex-Ondo Finance). Team includes alumni from Goldman Sachs, Anchorage Digital, Capital Group
 - **Investors:** Framework Ventures (lead), BlockTower, HV Capital, Coinbase Ventures, GSR, Hack VC, Cathay Ledger, 6th Man Ventures, FJ Labs, Lattice Capital. $8.75M seed (March 2024)
 - **Documentation Quality:** Midas has comprehensive docs at docs.midas.app covering token mechanics, fees, risk management, smart contracts. **However, mGLOBAL-specific documentation is limited**
-- **Legal Structure:** Midas Software GmbH, Pappelallee 78/79, 10437 Berlin, Germany (HRB 254645, LEI 984500BB00BN6D2B7C48). Incorporated June 2023. The issuer is **neither licensed nor registered** with the Liechtenstein FMA or any other supervisory authority. Base Prospectus approved by FMA Liechtenstein (July 17, 2025, valid until July 17, 2026)
-- **Fasanara Due Diligence:** Fasanara's team, regulatory status, AUM, and incident history need to be researched
+- **Legal Structure:** Midas Software GmbH, Pappelallee 78/79, 10437 Berlin, Germany (HRB 254645, LEI 984500BB00BN6D2B7C48). Incorporated June 2023. The issuer is **neither licensed nor registered** with the Liechtenstein FMA or any other supervisory authority
+- **Base Prospectus — validity lapsed, renewal `TODO`:** the prospectus approved by FMA Liechtenstein on July 17, 2025 was valid **until July 17, 2026**, which has now passed. Whether a successor prospectus has been approved could not be confirmed: [docs.midas.app](https://docs.midas.app/legal/legal-structure) is behind a Cloudflare bot challenge and returns no content to automated retrieval, and the FMA prospectus register was not reachable from this environment. A lapsed base prospectus would constrain new public offers of the instrument in the EEA without affecting existing tokens onchain. **Confirm renewal directly with Midas before allocating**
+- **Fasanara Due Diligence:** complete at the firm level (see Historical Track Record); open only on the mGLOBAL-specific mandate
 - **Incident Response:** Midas demonstrated operational capability during the Stream Finance incident (processed $150M+ in redemptions within 48 hours)
 
 ## Monitoring
 
 1. **Oracle/NAV Updates (CRITICAL)**
   - **Contract:** [`0x66aa9fcd63df74e1f67a9452e6e59fbc67f75e38`](https://etherscan.io/address/0x66aa9fcd63df74e1f67a9452e6e59fbc67f75e38) (MGlobalCustomAggregatorFeedGrowth)
-  - **Monitor:** `AnswerUpdated` events, `latestRoundData()` values, `setRoundData` calls
-  - **Alert:** Any price deviation from $1.00 (the stable peg), stale price (>7 days without update), unexpected price jumps
+  - **Monitor:** `AnswerUpdated` events, `latestRoundData()` / `latestRoundDataRaw()`, and — critically — **which setter was used**: calldata selector `0x2b6e02c7` (`setRoundData`, unguarded) versus `0x92260352` (`setRoundDataSafe`, guarded). Also watch `setOnlyUp`, `setMinGrowthApr`, `setMaxGrowthApr`
+  - **Alert:** any use of the raw `setRoundData` selector; any downward price revision; any single-round move beyond ~1.5% (roughly two months of expected accrual); no update for >45 days (cadence has been 24–45 days); `onlyUp` being set to false
   - **Frequency:** Hourly
 
 2. **Oracle Bound Feeds (RECOMMENDED)**
@@ -354,17 +379,35 @@ Where the funds end up, and what generates the yield (per [Fasanara lending](htt
   - **Alert:** Significant aUSDC balance decrease (indicating withdrawal from Aave)
   - **Frequency:** Daily
 
-9. **Aave Horizon Reserve (RECOMMENDED)**
-  - **Contracts:** Horizon Pool [`0xAe05Cd22df81871bc7cC2a04BeCfb516bFe332C8`](https://etherscan.io/address/0xAe05Cd22df81871bc7cC2a04BeCfb516bFe332C8), aMGLOBAL [`0x49d3cdE03813eE32DFD47F6aA3957d5F9CbAB985`](https://etherscan.io/address/0x49d3cdE03813eE32DFD47F6aA3957d5F9CbAB985)
-  - **Monitor:** mGLOBAL reserve config (LTV, liquidation threshold, supply cap, frozen flag) via `getReserveConfigurationData`, aMGLOBAL total supply
-  - **Alert:** LTV/liquidation threshold raised above ~0.10% (Aave extending real credit — stronger endorsement but larger liquidation dependency on mGLOBAL's loose/stale oracle), supply approaching the 50M cap, reserve frozen/paused
+9. **Aave Horizon Reserve (CRITICAL)**
+  - **Contracts:** Horizon Pool [`0xAe05Cd22df81871bc7cC2a04BeCfb516bFe332C8`](https://etherscan.io/address/0xAe05Cd22df81871bc7cC2a04BeCfb516bFe332C8), aMGLOBAL [`0x49d3cdE03813eE32DFD47F6aA3957d5F9CbAB985`](https://etherscan.io/address/0x49d3cdE03813eE32DFD47F6aA3957d5F9CbAB985), price feed [`0xe034De753a3d855B6daD1A4984de75a5c443E939`](https://etherscan.io/address/0xe034De753a3d855B6daD1A4984de75a5c443E939)
+  - **Monitor:** reserve config via `getConfiguration` (LTV, liquidation threshold, supply cap, frozen/paused flags), aMGLOBAL total supply against the cap, and the Llamaguard feed's `latestTimestamp`
+  - **Alert:** any further supply-cap reduction (the curator already cut 50M → 30M and the reserve is at the cap, so a cut would force withdrawals); LTV or liquidation threshold raised above ~0.10%; reserve frozen, paused, or delisted; Llamaguard feed stale beyond ~24 hours or diverging from the Midas oracle price
   - **Frequency:** Daily / on event
 
-10. **InfiniFi Farm Maturity (CRITICAL)**
-  - **Contract:** new MidasFarm [`0xf4ea3ec87b1c254f17a2fb68164db0caf6c4cecf`](https://etherscan.io/address/0xf4ea3ec87b1c254f17a2fb68164db0caf6c4cecf)
-  - **Monitor:** mGLOBAL `balanceOf`, farm `maturity()` (currently July 21, 2026)
-  - **Alert:** Balance drop (redemption rather than renewal), approach of maturity date
+10. **InfiniFi Concentration (CRITICAL)**
+  - **Contract:** InfiniFi `RWAEscrowRouter` [`0x7912Eaff92B2f5Bc64Cdd21C76d79FFC12eA855E`](https://etherscan.io/address/0x7912Eaff92B2f5Bc64Cdd21C76d79FFC12eA855E)
+  - **Monitor:** mGLOBAL `balanceOf` on the router, plus the router's `totalAssets()`, `liquidity()`, `paused()`, and `lastUpdatedAt()` (keeper freshness)
+  - **Alert:** any balance decrease (redemption or transfer out), the router being paused, or the keeper attestation going stale. Unlike the previous `MidasFarm` structure this wrapper exposes **no maturity date**, so a drawdown gives no advance notice — monitor the balance itself
   - **Frequency:** Daily
+
+11. **Redemption Capacity (CRITICAL)**
+  - **Contracts:** RedemptionVaultWithAave [`0xa0fc8bdfb1e6a705c1375810989b1d70a982b01b`](https://etherscan.io/address/0xa0fc8bdfb1e6a705c1375810989b1d70a982b01b), aEthUSDC [`0x98C23E9d8f34FEFb1B7BD6a91B7FF122F4e16F5c`](https://etherscan.io/address/0x98C23E9d8f34FEFb1B7BD6a91B7FF122F4e16F5c)
+  - **Monitor:** aUSDC `balanceOf` the redemption vault (currently $6,237,620), `instantDailyLimit()`, `instantFee()`, and `paused()` on both live vaults
+  - **Alert:** aUSDC balance falling below ~$2M or below 3% of NAV; `instantDailyLimit` reduced; `instantFee` raised materially above 50 bps; either vault paused
+  - **Frequency:** Hourly
+
+12. **Staged Third Redemption Vault (RECOMMENDED)**
+  - **Contract:** [`0xdbd621e67d9cffffcdcd316a27285f657c178e76`](https://etherscan.io/address/0xdbd621e67d9cffffcdcd316a27285f657c178e76)
+  - **Monitor:** `mTbillRedemptionVault()`, `liquidityProvider()`, `instantFee()`, `instantDailyLimit()`, token balances, and whether `M_GLOBAL_BURN_OPERATOR_ROLE` is retained
+  - **Alert:** the sentinel `0xFFfF…FFfF` addresses being replaced (activation), any funding of the vault, or any burn executed through it while it remains uncapped and zero-fee
+  - **Frequency:** On event
+
+13. **Greenlist / Blacklist Operator Set (RECOMMENDED)**
+  - **Contract:** [`0x0312A9D1Ff2372DDEdCBB21e4B6389aFc919aC4B`](https://etherscan.io/address/0x0312A9D1Ff2372DDEdCBB21e4B6389aFc919aC4B) (MidasAccessControl)
+  - **Monitor:** `RoleGranted` / `RoleRevoked` for `GREENLIST_OPERATOR_ROLE` (`0x77c5b782…1999d`), `BLACKLIST_OPERATOR_ROLE` (`0x2fdc6683…889ff`), and `BLACKLISTED_ROLE` (`0x548c7f03…a8ed`)
+  - **Alert:** the operator set growing beyond its current 53 members, or any address being added to `BLACKLISTED_ROLE` — a blacklist freezes the holder's balance and blocks redemption
+  - **Frequency:** On event
 
 ## Appendix: Contract Architecture
 
@@ -394,13 +437,15 @@ Where the funds end up, and what generates the yield (per [Fasanara lending](htt
 │  │  metadata(key) / setMetadata(key, data)                              │    │
 │  └──────────────────────────────────────────────────────────────────────┘    │
 │                                                                              │
-│  ┌──────────────────────────────────┐                                      │
-│  │  MGlobalRedemptionVaultWithSwapper│                                      │
-│  │  (TransparentProxy)              │                                      │
-│  │  0x1e0fd667..20d7                │                                      │
-│  │                                  │                                      │
-│  │  Has: BURN_OPERATOR_ROLE         │                                      │
-│  └──────────────────────────────────┘                                      │
+│  ┌──────────────────────────────────┐  ┌──────────────────────────────────┐  │
+│  │  MGlobalRedemptionVaultWithSwapper│  │  2nd SwapperVault (STAGED)       │  │
+│  │  (TransparentProxy)              │  │  0xdbd621e6..8e76                │  │
+│  │  0x1e0fd667..20d7                │  │                                  │  │
+│  │  Holds 2,000,001.74 mGLOBAL      │  │  Has: BURN_OPERATOR_ROLE         │  │
+│  │  Has: BURN_OPERATOR_ROLE         │  │  UNFUNDED / UNCONFIGURED         │  │
+│  │  2M/day cap, 50 bps fee          │  │  sentinel 0xFFfF..FFfF, 0 fee,   │  │
+│  │                                  │  │  uncapped daily limit            │  │
+│  └──────────────────────────────────┘  └──────────────────────────────────┘  │
 │                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
 
@@ -412,9 +457,11 @@ Where the funds end up, and what generates the yield (per [Fasanara lending](htt
 │  │  Proxy: 0x66aa9fcd63df74e1f67a9452e6e59fbc67f75e38                   │    │
 │  │  Impl:  0x96ac55e782b9ee3f1dd72b3ba033352b5af95e49                   │    │
 │  │                                                                      │    │
-│  │  Price: $1.00000000 (r2, updated May 15 2026 — 39d stale)            │    │
-│  │  maxAnswerDeviation: 100% ($1.00) — VERY LOOSE                       │    │
-│  │  minAnswer: $0.10, maxAnswer: $1,000                                 │    │
+│  │  Price: $1.01664609 (r5, updated Aug 20 2026 — 3.4d)                 │    │
+│  │  maxAnswerDeviation: 100% — and NOT enforced on setRoundData         │    │
+│  │  minAnswer: $0.10, maxAnswer: $1,000  (the only hard bounds)         │    │
+│  │  onlyUp: true — guarded path cannot mark NAV down                    │    │
+│  │  minGrowthApr = maxGrowthApr = 0 (step function, no interpolation)   │    │
 │  │  Updater: EOA 0x088a74de..f05 (no timelock)                          │    │
 │  └──────────────────────────────────────────────────────────────────────┘    │
 │                                                                              │
@@ -487,8 +534,11 @@ Where the funds end up, and what generates the yield (per [Fasanara lending](htt
 │                                                                              │
 │  ┌──────────────────────────────────────────────────────────────────────┐    │
 │  │  Aave (Onchain Protocol Dependency)                                  │    │
-│  │  DepositVault and RedemptionVault deposit idle USDC → aUSDC         │    │
-│  │  Blue-chip DeFi protocol; positive structural feature               │    │
+│  │  RedemptionVaultWithAave holds $6,237,620 aUSDC (~9.0% of NAV)      │    │
+│  │  Aave Horizon: collateral reserve, SATURATED at 30M cap             │    │
+│  │    LTV 0.05% / LT 0.10% — near-zero credit extended                 │    │
+│  │    Price via Chainlink OCR2 "mGlobal NAV - Aave Llamaguard"         │    │
+│  │    0xe034De75..E939 (16 transmitters) — mirrors Midas NAV           │    │
 │  └──────────────────────────────────────────────────────────────────────┘    │
 │                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
@@ -508,25 +558,32 @@ Where the funds end up, and what generates the yield (per [Fasanara lending](htt
 │  Additional MINT holders via M_GLOBAL_MINT_OPERATOR_ROLE:                    │
 │  └─ DepositVault 0xce29c36c6d4556f2d01d79414c1354b968dddef1                 │
 │                                                                              │
-│  Additional BURN holders via M_GLOBAL_BURN_OPERATOR_ROLE:                    │
+│  Additional BURN holders via M_GLOBAL_BURN_OPERATOR_ROLE (4 total):          │
 │  ├─ RedemptionVaultWithAave 0xa0fc8bdfb1e6a705c1375810989b1d70a982b01b     │
-│  └─ RedemptionVaultWithSwapper 0x1e0fd66753198c7b8ba64edee8d41d8628bf20d7  │
+│  ├─ RedemptionVaultWithSwapper 0x1e0fd66753198c7b8ba64edee8d41d8628bf20d7  │
+│  └─ 2nd SwapperVault 0xdbd621e67d9cffffcdcd316a27285f657c178e76 (staged)   │
 │                                                                              │
 │  Oracle Updater EOA (sets NAV price, no timelock):                           │
-│  └─ 0x088a74de7df74e6a6eb832d28878a9f134ee4f05 (nonce 4)                    │
+│  └─ 0x088a74de7df74e6a6eb832d28878a9f134ee4f05 (nonce 12)                   │
+│                                                                              │
+│  Greenlist + Blacklist operators: 53 EOAs (each holds BOTH roles)            │
+│  └─ platform-wide; token-specific M_GLOBAL_* variants granted to nobody     │
 │                                                                              │
 │  ⚠ Role changes bypass timelock (only upgrades go through 48h)              │
 │  ⚠ mint() has no onchain collateral check                                   │
-│  ⚠ Oracle maxAnswerDeviation = 100% ($1.00) — very loose                    │
+│  ⚠ setRoundData() skips maxAnswerDeviation AND onlyUp → $0.10–$1,000       │
+│  ⚠ onlyUp=true → guarded path can never report a NAV loss                   │
+│  ⚠ Any 1 of 53 blacklist operators can freeze a holder, no timelock         │
 │  ⚠ PriceRaised/PriceLowered bound feeds have NO role holders (inactive)     │
 │  ⚠ Either of 2 DEFAULT_ADMIN can grant MINT → unbacked tokens              │
 │                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
 
-Data flow: User deposits USDC → DepositVault mints mGLOBAL at oracle price (~$1.00).
-Idle USDC in vaults is deposited to Aave for yield. Active strategy funds go to
-Fasanara via Fordefi custody for offchain execution. NAV/price updated by oracle
-updater EOA. User redeems via RedemptionVaultWithAave or RedemptionVaultWithSwapper.
+Data flow: User deposits USDC → DepositVault mints mGLOBAL at the oracle price
+($1.01664609). Redemption float sits in Aave as aUSDC. Active strategy funds go to
+Fasanara via Fordefi custody for offchain execution; 97.03% of NAV is unclassified.
+NAV/price is published by the oracle updater EOA roughly monthly. Users redeem via
+RedemptionVaultWithAave or RedemptionVaultWithSwapper (2,000,000/day each, 50 bps).
 ```
 
 ---
@@ -536,29 +593,31 @@ updater EOA. User redeems via RedemptionVaultWithAave or RedemptionVaultWithSwap
 ### Key Strengths
 
 - **Doxxed Midas team with institutional backing** — Goldman Sachs / Morgan Stanley alumni, backed by Coinbase Ventures, Framework Ventures, BlockTower
-- **Established strategy manager** — Fasanara Capital Ltd (London, founded 2011, $4B+ AUM, 15-year track record) is a major European institutional asset manager with MIFIDPRU disclosure and SFDR Article 8 classified funds. While less crypto-native than Hyperithm, its size, history, and regulatory infrastructure are meaningful
-- **Institutional-grade custody** — Fordefi MPC with tri-party MPC governance prevents unilateral fund access
-- **Shared, extensively audited infrastructure** — 10 audits (2023–2025) on Midas core contracts
-- **Aave integration at vault level** — idle capital is verifiably deposited on Aave (blue-chip DeFi), providing partial onchain transparency not present in mHYPER
-- **Strong $1M bug bounty** across Sherlock + Cantina platforms
-- **Stable peg product** — $1.00 target is simpler to verify than floating NAV tokens
-- **Third-party institutional onboarding** — mGLOBAL is now a collateral reserve on the permissioned, curator-vetted [Aave Horizon RWA market](https://app.aave.com/reserve-overview/?underlyingAsset=0x7433806912eae67919e66aea853d46fa0aef98a8&marketName=proto_horizon_v3) ($19.85M supplied). A genuine due-diligence signal — though the 0.05% LTV means Aave extends near-zero credit against it
-- **Counterparty re-commitment** — InfiniFi renewed its ~$30M position after the June 15 maturity rather than exiting, and total supply grew ~40% in a week, indicating continued institutional demand
+- **Established strategy manager** — Fasanara Capital Ltd (London, founded 2011, $4B+ AUM, 15-year track record) is a major European institutional asset manager, FCA-authorised, with MIFIDPRU disclosure and SFDR Article 8 classified funds
+- **Institutional-grade custody** — Fordefi MPC with tri-party governance prevents unilateral fund access
+- **Shared, extensively audited infrastructure** — 10 audits (2023–2025) on Midas core contracts, plus a $1M bug bounty across Sherlock and Cantina
+- **NAV publication and yield accrual are working** — the oracle has produced five rounds, is current to within 3.4 days, and has delivered a realized ~6.3% annualized return since accrual began
+- **Real, verifiable redemption liquidity** — the RedemptionVaultWithAave holds $6,237,620 of aUSDC (~9.0% of NAV), independently auditable onchain
+- **Holder concentration is moderate** — no single beneficial holder exceeds ~30%
+- **Timelock discipline holds** — 48-hour delay on upgrades, ProxyAdmin owned by the timelock, and no mGLOBAL proxy has ever been upgraded
 
 ### Key Risks
 
-- **Incomplete strategy manager due diligence** — Fasanara Capital Ltd is now partially researched (founded 2011, $4B+ AUM, London-based, large team, MIFIDPRU disclosure). However, its specific digital asset strategy mandate for mGLOBAL, crypto-native track record, and FCA registration details remain unverified. 88.61% of mGLOBAL NAV is classified as \"Unclassified\" — significantly more opaque than even mHYPER's 76.8%
-- **Very loose oracle bounds** — maxAnswerDeviation of 100% ($1.00) means the oracle price can move from $1.00 to $0.10 or $1,000 in a single update. The PriceRaised/PriceLowered bound feeds are deployed but inactive. **Oracle is 39 days stale** (last update May 15, 2026; worse than the prior assessment) with APY stuck at 0.00%
-- **Short production history** — ~10 weeks vs mHYPER's ~9+ months. No stress-test events. APY has been 0% since inception (no yield reported onchain)
-- **Unbacked minting possible** — tokens can be minted without collateral by any address holding `M_GLOBAL_MINT_OPERATOR_ROLE`. Role grants bypass the 48-hour timelock entirely
-- **Weak access control** — `DEFAULT_ADMIN_ROLE` held by two addresses (1/3 Safe + one EOA). Either can grant/revoke any role immediately
-- **Zero secondary market** — No Uniswap V3 pools, no DexScreener pairs. Exit entirely dependent on Midas redemption infrastructure. Vaults hold near-zero USDC for instant redemptions
+- **Near-total strategy opacity** — 97.03% of NAV is "Unclassified" per [SumCap / Delta Y](https://midas.sumcap.xyz/mglobal), the highest share since launch and far more opaque than mHYPER. The position-level book, its geography/sector mix, and its delinquency and loss rates are undisclosed and not verifiable onchain
+- **The oracle's safety bounds are bypassable** — `setRoundData` is directly callable by the oracle admin role and enforces neither `maxAnswerDeviation` nor `onlyUp`. A single EOA can set any price between $0.10 and $1,000 in one transaction. The deviation cap is an operational convention, not an invariant
+- **NAV cannot be marked down through the routine path** — with `onlyUp` true, `setRoundDataSafe` rejects downward revisions, so a credit impairment cannot be reflected without switching setters. A stale-high price rewards early redeemers at the expense of those who remain
+- **53 EOAs hold blacklist authority** — any one of them can freeze an arbitrary holder's balance and block their redemption, with no timelock and no multisig
+- **Unbacked minting possible** — `mint()` has no onchain collateral check, and role grants bypass the 48-hour timelock entirely, so either `DEFAULT_ADMIN_ROLE` holder can self-grant the mint role and issue unbacked tokens in two transactions
+- **Zero secondary market** — no Uniswap V2 or V3 liquidity at any tier. Exit depends entirely on Midas redemption, capped at 2,000,000 mGLOBAL/day per vault, with only ~$6.2M of instant capacity behind it
+- **The Horizon demand sink is closed** — the supply cap was cut from 50M to 30M and the reserve is saturated, so the venue that absorbed most of the recent growth can absorb no more
+- **A burn-authorized contract sits unconfigured** — the staged third vault holds `M_GLOBAL_BURN_OPERATOR_ROLE` with sentinel addresses, zero fee, and an uncapped daily limit
+- **Base Prospectus validity has lapsed** and renewal is unconfirmed (`TODO`)
 
 ### Critical Risks
 
-- **Fasanara due diligence gap (partially resolved):** Fasanara Capital Ltd is now confirmed as a London-based, $4B+ AUM institutional manager with 15-year history, MIFIDPRU disclosure, and a large professional team. This is significantly stronger than the initial "unverified" assessment. However, its specific digital asset strategy for mGLOBAL remains opaque — 92% of NAV is "Unclassified."
-- **Oracle can report any price:** With 100% maxAnswerDeviation and no active bound feeds, a compromised oracle updater can set the price anywhere between $0.10 and $1,000 in a single transaction. Combined with no-timelock role grants and unbacked minting, this creates a path to significant token holder loss
-- **InfiniFi concentration — eased but not gone:** Originally 81% of mGLOBAL ($30.6M) sat in [InfiniFi's MidasFarm](https://etherscan.io/address/0x7373A7ce3C023C56Cb66747AFbdF827627D31679). That farm matured June 15, 2026 and InfiniFi **renewed** rather than redeemed — rolling the full $30.49M into a [new MidasFarm](https://etherscan.io/address/0xf4ea3ec87b1c254f17a2fb68164db0caf6c4cecf) with maturity July 21, 2026. Combined with $19.85M of new Aave Horizon demand, top-holder concentration fell to **57.94%**. The renewal is a positive signal (a sophisticated counterparty re-locked), but a ~58% holder remains and the maturity/exit trigger simply re-arms in ~1 month against ~$0 vault liquidity
+- **Oracle can report almost any price, and only upward through the safe path.** Combining the unguarded `setRoundData` route ($0.10–$1,000 in one transaction), a single non-timelocked EOA holding the feed admin role, inactive PriceRaised/PriceLowered bound feeds, and no-timelock role grants produces a direct path to mispricing every mint and redemption. The `onlyUp` flag narrows the *routine* failure mode to over-valuation rather than a crash, which is the more insidious direction for a redemption-only instrument: it converts an unreported credit loss into a first-mover run
+- **97% of the book is unverifiable.** The strategy type is documented and defensible — short-dated, insured, unlevered SME trade receivables — but nothing about *this* vehicle's holdings can be checked. Verifiability, not strategy legitimacy, is the binding constraint on the score
+- **Concentration and illiquidity still compound.** InfiniFi's 30.29% now sits in an escrow wrapper with no maturity date, so a withdrawal arrives without warning. ~$21M of exposure against ~$6.2M of instant capacity and zero DEX depth means any large exit becomes an offchain unwind of receivables on Fasanara's timetable, not the holder's
 
 ---
 
@@ -581,115 +640,114 @@ updater EOA. User redeems via RedemptionVaultWithAave or RedemptionVaultWithSwap
 **Audits:**
 
 - 10 audits across 3 years (2023–2025): 2 Hacken + 2 Côme + 6 Sherlock contests on shared Midas infrastructure
-- Broad coverage: core contracts, vaults, bridges (LayerZero/Axelar), oracle system, legacy components
-- **mGLOBAL-specific contracts (Aave vaults, growth oracle) are NEW and may not have been covered by prior audits.** The core token logic and access control are audited, but the Aave integration and oracle model are extensions beyond original audit scopes
+- Broad coverage: core contracts, vaults, bridges, oracle system, legacy components
+- **mGLOBAL-specific contracts (Aave-integrated vaults, growth oracle) remain extensions beyond the original audit scopes** and have not been separately audited. The `setRoundData` / `setRoundDataSafe` split documented in [Provability](#provability) is exactly the kind of issue a scoped audit of the growth oracle would be expected to address
 - Several findings accepted rather than fixed in earlier audits
 - Hacken explicitly flagged the protocol as "highly centralized"
 
-**Bug Bounty:** $1M total allocated across [Sherlock](https://audits.sherlock.xyz/bug-bounties/122) ($500K max) and [Cantina](https://cantina.xyz/bounties/d77405e5-99ce-4ba5-846c-885820b030e1) ($500K max). Active since March 2026.
+**Bug Bounty:** $1M total across [Sherlock](https://audits.sherlock.xyz/bug-bounties/122) ($500K max) and [Cantina](https://cantina.xyz/bounties/d77405e5-99ce-4ba5-846c-885820b030e1) ($500K max). Active since March 2026.
 
 **Time in Production:**
 
-- mGLOBAL: ~10 weeks (April 2026)
-- Midas platform: ~22 months (mTBILL since mid-2024)
-- Market cap: ~$52.63M, platform TVL: ~$112.7M (down from ~$927.8M peak)
-- No security incidents for mGLOBAL
-- No stress-test events (mHYPER processed $150M+ during Stream Finance, but mGLOBAL has no comparable test)
+- mGLOBAL: ~4.7 months (since April 3, 2026)
+- Midas platform: ~2 years (mTBILL since mid-2024)
+- Market cap ~$69.23M; platform TVL ~$152.9M
+- No security incidents for mGLOBAL; no forced-redemption stress event
 
-**Score: 2.5/5** — 10 audits on shared infrastructure provides strong foundation, but mGLOBAL-specific contract patterns (Aave vaults, growth oracle) are extensions not separately audited. Short 10-week production history with no stress testing. Strong $1M bug bounty. Platform-level track record (~22 months) is positive but the specific product is very new.
+**Score: 2.5/5** — the audit position is unchanged: a strong shared-infrastructure foundation, but the mGLOBAL-specific patterns are still unaudited, and a live example of an unguarded oracle path argues against crediting the extension as covered. Time in production has roughly doubled and NAV operations now have a real track record, which offsets rather than improves on the audit gap.
 
 #### 2. Centralization & Control Risks (Weight: 30%)
 
-**Subcategory A: Governance — 3.0**
+**Subcategory A: Governance — 3.5**
 
-- Upgradeable proxy contracts with **48-hour timelock** on upgrades via `MidasTimelockController` — users have time to react to proposed upgrades
-- However, role changes (mint/burn/pause/blacklist grants) bypass the timelock entirely
-- `DEFAULT_ADMIN_ROLE` held by **two addresses**: the 1/3 Gnosis Safe plus one EOA (claimed Fordefi MPC). Either can grant/revoke any role with no timelock
-- Oracle price updated by a single EOA with no timelock
-- Admin controls all critical roles (flagged by auditors as "highly centralized")
-- Oracle bound feeds (PriceRaised/PriceLowered) exist but have **no role holders** — inactive safety mechanism
-- 1/3 Safe threshold means single Safe owner can propose/execute. Offchain MPC mitigations (Fordefi/Fireblocks) cannot be verified onchain
-- Tri-party MPC custody (Fordefi) is a positive but applies only to fund movements, not contract administration
+- 48-hour timelock on upgrades via `MidasTimelockController`, ProxyAdmin owned by the timelock, and no mGLOBAL proxy has ever been upgraded — the mechanism is real and has been exercised
+- Role changes still bypass the timelock entirely
+- `DEFAULT_ADMIN_ROLE` held by two addresses (a 1/3 Safe plus one EOA); either can grant or revoke any role instantly
+- The 1/3 Safe holds `PROPOSER`, `EXECUTOR`, **and** `CANCELLER` on the timelock, so a single Safe owner controls the entire upgrade lifecycle including cancellation
+- **53 EOAs hold `GREENLIST_OPERATOR_ROLE` and `BLACKLIST_OPERATOR_ROLE`.** Any one can freeze an arbitrary holder's balance and block redemption, untimelocked. This is a far wider unilateral-freeze surface than the two-operator arrangement the design implies, and it is the main reason this subscore moves against the protocol
+- Oracle price written by a single EOA with no timelock, on a path that skips its own deviation and direction guards
+- Bound feeds (PriceRaised/PriceLowered) still have no role holders — inactive
+- Tri-party MPC custody (Fordefi) is a genuine positive but governs fund movements, not contract administration
 
 **Subcategory B: Programmability — 4.0**
 
 - Strategy execution fully offchain (Fasanara)
-- NAV/oracle admin-updated at unknown frequency. The Attestation Engine adds programmatic verification and onchain hash publication, but the onchain price update is still admin-triggered and not contractually gated by attestation
-- PPS is admin-reported, not computed onchain from reserves
-- Redemption partially offchain (standard redemptions processed by Midas team)
+- NAV is admin-published on a roughly monthly cadence; the Attestation Engine publishes hashes but does not gate the price update
+- PPS is admin-reported, not computed onchain from reserves, and `onlyUp` prevents the routine path from ever reporting a loss
 - Users cannot independently compute the exchange rate onchain
-- **Aave integration is a positive** — idle capital in vaults is verifiable on Aave (blue-chip). This gives partial onchain programmability not present in mHYPER
-- Very loose oracle bounds (100% deviation) — admin has effectively unrestricted pricing authority per update
-- Bound feeds deployed but inactive — safety net not operational
-- No smart contract restrictions on how the funds are managed. Tokens can be minted without backing
+- Oracle bounds are loose in principle (100% deviation) and unenforced in practice on the admin path
+- Offsetting: the Aave position is now materially funded ($6.24M aUSDC) and independently verifiable, and instant redemption is governed by explicit onchain parameters (2,000,000/day cap, 50 bps fee) rather than pure discretion
+- No smart-contract restriction on how funds are managed; tokens can be minted without backing
 
-**Subcategory C: External Dependencies — 4.0**
+**Subcategory C: External Dependencies — 4.2**
 
-- Fasanara Capital: single critical dependency for strategy management and NAV calculation. The strategy *type* is documented (short-dated SME trade receivables / invoices via ~141 fintech originators), but **the position-level allocation for the mGLOBAL pool is undisclosed and not onchain-verifiable** (88.61% unclassified). This is a single point of failure for core value creation, with no transparency on the specific book's composition or credit health
-- Aave: idle capital integration (blue-chip, positive). Aave failure would impact vault idle capital but not core strategy
+- Fasanara Capital: single critical dependency for strategy and NAV. The strategy *type* is documented, but **97.03% of NAV is unclassified** — nearly the whole book
+- InfiniFi: 30.29% holder whose position moved into an offchain-attested escrow wrapper with no maturity date, reducing visibility on the largest single exit risk
+- Aave: redemption float on Aave V3 is a positive; the Horizon reserve is saturated at a reduced 30M cap, and its Llamaguard feed mirrors rather than independently validates the Midas NAV
 - Fordefi: MPC custody with tri-party governance (established, tested)
-- MidasAccessControl: shared across all Midas products — single compromise affects entire platform
-- Strategy counterparties: unverifiable without access to Midas transparency data
-- Distributed backup shares for the Fordefi workspace, allowing Midas to recover and secure key material in case of counterparty failure
+- MidasAccessControl and the shared ProxyAdmin: a compromise affects every Midas product simultaneously
+- Strategy counterparties remain unverifiable
 
-**Centralization Score = (3.0 + 4.0 + 4.0) / 3 ≈ 3.7**
+**Centralization Score = (3.5 + 4.0 + 4.2) / 3 ≈ 3.9**
 
-**Score: 3.7/5** — Same structural centralization risks as mHYPER, with additional concerns: (a) oracle bounds are 285x looser (100% vs 0.35%), (b) bound feeds are deployed but inactive, (c) Fasanara is a single point of failure whose documented strategy (SME trade receivables) is established but whose per-vehicle allocation and credit metrics are undisclosed and unverifiable onchain. The Aave integration partially offsets programmability concerns. The 48-hour timelock on upgrades is meaningful; role changes bypassing it entirely is not.
+**Score: 3.9/5** — the structural picture is unchanged but two specifics have hardened against the protocol: a 53-key unilateral freeze surface, and an oracle whose stated bounds are not enforced on the path the admin can actually take. Dependency opacity also increased. The functioning timelock and the funded, verifiable Aave position keep this from moving further.
 
 #### 3. Funds Management (Weight: 30%)
 
 **Subcategory A: Collateralization — 4.5**
 
-- Tokens are subordinated debt instruments — not direct claims on collateral
-- Strategy *type* is documented (short-dated SME trade receivables / digital invoices, ~3-month duration, unlevered, credit-insured), but the **position-level composition, collateral quality, and current loss/delinquency metrics are 88.61% unclassified and undisclosed for this vehicle**. Unlike mHYPER's Hyperithm which had identifiable onchain counterparties, mGLOBAL's assets sit offchain and cannot be independently verified
-- Aave integration means idle USDC → aUSDC is onchain and verifiable ($2.55M / 4.85%), but this only covers idle capital, not the active strategy
-- No onchain collateral verification in smart contracts; admin can mint tokens without backing
+- Tokens are subordinated debt instruments, not direct claims on collateral
+- The strategy *type* is documented (short-dated SME trade receivables, ~3-month duration, unlevered, credit-insured), but **97.03% of NAV is unclassified** and the position-level composition, collateral quality, and loss/delinquency metrics for this vehicle are undisclosed
+- Verifiable onchain backing is limited to $6,237,620 of aUSDC (~9.0% of NAV) — real and auditable, but redemption float rather than strategy collateral
+- No onchain collateral verification; `mint()` has no backing check
 - Tri-party MPC custody via Fordefi should prevent unilateral fund access
-- **Score is HIGHER (riskier) than mHYPER's 3.5** due to high strategy opacity and unverifiable asset quality
+- Held at 4.5: the increase in opacity and the improvement in verifiable float offset each other, and the dominant fact — an unauditable book — is unchanged
 
 **Subcategory B: Provability — 3.5**
 
-- NAV reported by Fasanara, with shared Midas Attestation Engine providing multi-party verification (LlamaRisk, Canary, vlayer, Chainlink CRE)
-- Aave integration provides onchain visibility of idle vault capital — a structural improvement over mHYPER
-- Full portfolio composition and strategy-level positions are not verifiable onchain; the registry stores only hashes
-- Oracle updates are admin-triggered with no onchain gating from the Attestation Engine
+- NAV reported by Fasanara with the shared Attestation Engine providing multi-party verification (LlamaRisk, Canary, vlayer, Chainlink CRE)
+- Improved: the oracle now publishes a real, verifiable growth series across five rounds, and Aave's independent Chainlink OCR2 feed republishes the NAV with 16 transmitters — more eyes on the number than at the prior assessment
+- Worsened: the guarded setter is bypassable, `onlyUp` prevents markdowns on the routine path, and the classified share of NAV fell to 2.97%
+- Full portfolio composition is not verifiable onchain; the registry stores only hashes
+- Oracle updates remain admin-triggered with no onchain gating from the Attestation Engine
 - mGLOBAL-specific proof IDs in the registry have not been identified
-- **Score is HIGHER than mHYPER's 3.0** because: (a) Fasanara's reporting practices are unverified, (b) strategy allocation is completely opaque, (c) shorter history means fewer attestation cycles to build trust
+- Held at 3.5: a live, auditable price series and independent republication are genuine gains, cancelled out by the enforcement gap and the shrinking classified share
 
 **Funds Management Score = (4.5 + 3.5) / 2 = 4.0**
 
-**Score: 4.0/5** — Offchain funds management with subordinated debt structure. The Aave integration provides a positive onchain anchor, but it only covers idle capital, not active strategies. The underlying strategy is now documented (Fasanara SME trade-receivable private credit — a defensive, established profile), but **88.61% of NAV is unclassified and the per-vehicle allocation is undisclosed/unverifiable onchain**. The Attestation Engine provides a verification pipeline, but it cannot compensate for the missing position-level transparency. Score unchanged: verifiability, not strategy legitimacy, is the binding constraint.
+**Score: 4.0/5** — offchain funds management under a subordinated-debt structure. The Aave position is now a meaningful onchain anchor and NAV publication works, but 97.03% of the book is unclassified and the price that governs every mint and redemption can be set outside its stated bounds by one key. Verifiability, not strategy legitimacy, remains the binding constraint.
 
 #### 4. Liquidity Risk (Weight: 15%)
 
-- **Exit Mechanism:** Two redemption vaults (WithAave + WithSwapper). 0.5% fee on instant redemption
-- **DEX Liquidity:** none, principal can be redeemed with a fee or full after cycle. Note: the Aave Horizon listing is **not** an exit venue — it lets qualified users borrow stablecoins against mGLOBAL (currently throttled to ~0 via 0.05% LTV); Horizon suppliers still exit by withdrawing and redeeming through Midas
-- **Redemption Vault Duality:** Two vaults provide redundancy — if one faces issues, the other may still process redemptions.
-- **Holder Concentration (HIGH, eased from EXTREME):** Top holder fell from 81% to **57.94%** ([InfiniFi's renewed MidasFarm](https://etherscan.io/address/0xf4ea3ec87b1c254f17a2fb68164db0caf6c4cecf), ~$30.49M). InfiniFi's matured farm **renewed rather than redeemed** (new maturity July 21, 2026), removing the immediate exit trigger; $19.85M of independent Aave Horizon demand and a growing supply diluted the concentration. A ~58% holder unwinding at the next maturity into ~$0 vault liquidity remains a serious risk
-- **Vault Liquidity (onchain, June 23, 2026):** DepositVault $0, RedemptionVaultWithAave $0, RedemptionVaultWithSwapper ~$0.73 USDC. Instant-redemption capacity at the vault level is effectively **near zero** — a large redemption depends on Fasanara unwinding offchain positions
-- **Stress Performance:** No forced-redemption stress event, but the June 15 InfiniFi maturity — the report's prior worst-case trigger — passed without incident (the counterparty renewed and supply grew)
+- **Exit Mechanism:** two live redemption vaults, both unpaused, each capped at 2,000,000 mGLOBAL/day instant with a 50 bps fee; larger exits route through an offchain request/approval flow
+- **Onchain capacity:** $6,237,620 of aUSDC in the RedemptionVaultWithAave — ~9.0% of NAV of genuine, verifiable instant-redemption backing where there was previously none. This is the single largest improvement since the prior assessment
+- **DEX Liquidity:** none, at any Uniswap V2 or V3 tier. The Aave Horizon listing is not an exit venue and is now saturated at its reduced 30M cap
+- **Holder Concentration:** the largest beneficial holder is InfiniFi at 30.29%, then 26.11% and 14.48% — no single dominant counterparty, versus 58% previously. Offsetting this, only 16 addresses hold any balance, so the base is broad in percentage terms but thin in absolute terms
+- **Warning time has decreased:** InfiniFi's position no longer sits behind a dated `MidasFarm` maturity. The `RWAEscrowRouter` exposes no maturity, so an exit would arrive unannounced
+- **Stress Performance:** no forced-redemption event. The June 2026 InfiniFi maturity passed without redemption
 
-**Score: 3.5/5** (was 4.0) — Still no secondary market and near-zero idle vault USDC, so exit remains dependent on Midas redemption infrastructure and offchain unwinds of an 88.61%-unclassified strategy. But the acute concentration risk eased: the InfiniFi maturity trigger that had already fired resolved via renewal, top-holder concentration dropped 81% → ~58%, and Aave Horizon added an independent institutional holder base. The score improves one notch but stays elevated because the structural illiquidity is unchanged and a ~58% holder can still exit at the next maturity (July 21, 2026)
+**Score: 3.0/5** (was 3.5) — two real improvements: instant-redemption capacity went from ~$0 to $6.24M, and top-holder concentration fell from 58% to ~30%. Structural illiquidity is unchanged — no secondary market, redemption-only exit, and a ~$21M single holder against ~$6.2M of instant capacity — and the Horizon cap reduction removes the marginal demand sink while the escrow wrapper removes advance notice of an InfiniFi exit. The score improves one notch but stays elevated.
 
 #### 5. Operational Risk (Weight: 5%)
 
-- **Midas Team:** Fully doxxed with strong institutional backgrounds. Well-funded ($8.75M from top crypto VCs). **Positive, well-established**
-- **Fasanara Capital:** **Now fully researched.** FCA Authorised since August 2011 (FRN [551020](https://register.fca.org.uk/s/firm?id=001b000000NMar0AAD)). $4B+ AUM, London HQ, 15-year track record. CEO Francesco Filia (ex-BofA Merrill Lynch). 40+ professionals. Companies House [07561210](https://find-and-update.company-information.service.gov.uk/company/07561210). Publishes MIFIDPRU Disclosure and Sustainability Report. EU SFDR Article 8 funds. Digital asset strategy transparency for mGLOBAL specifically remains limited — 88.61% of NAV is unclassified
-- **Documentation:** Midas platform docs are comprehensive. mGLOBAL-specific documentation is limited — Midas docs site timed out during scraping (GitBook). SumCap successfully scraped and provides rich NAV/price/allocation data. **Midas transparency page and app require authentication or JS-rendering that could not be fully captured**
-- **Legal:** Midas Software GmbH, German-incorporated. Base Prospectus approved by FMA Liechtenstein (July 2025, valid until July 2026).
+- **Midas Team:** fully doxxed with strong institutional backgrounds and well funded ($8.75M from top crypto VCs)
+- **Fasanara Capital:** FCA Authorised since August 2011 (FRN [551020](https://register.fca.org.uk/s/firm?id=001b000000NMar0AAD)), $4B+ AUM, London HQ, 15-year track record, CEO Francesco Filia (ex-BofA Merrill Lynch), 40+ professionals, Companies House [07561210](https://find-and-update.company-information.service.gov.uk/company/07561210), MIFIDPRU Disclosure, EU SFDR Article 8 funds. Firm-level diligence is complete; mGLOBAL-specific strategy transparency is not
+- **Operational execution has been sound** — NAV published on schedule since June, redemption vaults funded, no incidents, no emergency actions
+- **Documentation:** Midas platform docs are comprehensive but sit behind a Cloudflare challenge that blocks automated retrieval; mGLOBAL-specific documentation remains limited. SumCap / Delta Y provides usable NAV, price, and allocation data
+- **Legal:** Midas Software GmbH, German-incorporated. The FMA Liechtenstein Base Prospectus lapsed July 17, 2026 and renewal is unconfirmed (`TODO`)
 
-**Score: 2.0/5** — Midas team is strong (doxxed, institutional, well-funded). Fasanara Capital is now fully verified as FCA Authorised (FRN 551020, since 2011) — this substantively improves the operational risk profile
+**Score: 2.0/5** — unchanged. The team and manager are strong and operational execution over the period was clean. The lapsed prospectus is flagged as a monitoring item rather than scored, because renewal could not be verified either way and scoring an unverified fact would not be sound.
 
 ### Final Score
 
 | Category | Score | Weight | Weighted |
 | ------------------------ | ----- | ------ | ----------- |
 | Audits & Historical      | 2.5   | 20%    | 0.50        |
-| Centralization & Control | 3.7   | 30%    | 1.11        |
+| Centralization & Control | 3.9   | 30%    | 1.17        |
 | Funds Management         | 4.0   | 30%    | 1.20        |
-| Liquidity Risk           | 3.5   | 15%    | 0.525       |
+| Liquidity Risk           | 3.0   | 15%    | 0.45        |
 | Operational Risk         | 2.0   | 5%     | 0.10        |
-| **Final Score**          |       |        | **3.43/5.0** |
+| **Final Score**          |       |        | **3.42/5.0** |
 
 
 ### Risk Tier
@@ -703,55 +761,71 @@ updater EOA. User redeems via RedemptionVaultWithAave or RedemptionVaultWithSwap
 | 4.5-5.0     | High Risk       | Not recommended                       |
 
 
-**Final Risk Tier: Medium Risk (3.43/5.0) — borderline, just below the Elevated threshold**
+**Final Risk Tier: Medium Risk (3.42/5.0) — borderline, just below the Elevated threshold**
 
-**Recommendation:** Approved with enhanced monitoring and conservative limits. At 3.43 the score sits right at the Medium/Elevated boundary. It is driven by (a) high strategy opacity — 88.61% of NAV unclassified, down from 92.09% but still dominant, with a Funds Management score of 4.0, **unchanged** at this reassessment — and (b) residual liquidity risk (3.5): no secondary market and near-zero idle vault USDC, partly offset by eased holder concentration (81% → ~58% after InfiniFi renewed rather than exited) and new Aave Horizon demand. The Aave Horizon collateral listing is a positive third-party onboarding signal but at 0.05% LTV extends near-zero credit — it should not be over-weighted. **Strongly recommend completing mGLOBAL-specific Fasanara due diligence before any allocation**. Talk directly to Fasanara team for more information.
+**Recommendation:** Approved with enhanced monitoring and conservative limits. The headline score is essentially flat, but the composition of the risk has shifted materially. Liquidity improved on two fronts — instant-redemption capacity went from ~$0 to $6.24M of aUSDC, and top-holder concentration fell from 58% to ~30% — and the oracle stall that dominated the previous assessment resolved into a working monthly NAV cadence with ~6.3% annualized accrual. Those gains are offset by three things that got worse: strategy opacity rose to 97.03% of NAV, a 53-key unilateral blacklist surface was confirmed, and the oracle's deviation cap and `onlyUp` guard turn out not to be enforced on the path the admin can actually take. **Complete mGLOBAL-specific Fasanara due diligence and confirm the Base Prospectus renewal before any allocation.**
 
-**Path to a lower score:** This assessment is constrained primarily by opacity, not by a verified flaw. A clear investment deck, strategy mandate, or attested allocation breakdown that classifies the 88.61% "Unclassified" NAV would directly lower Collateralization, Provability, and External Dependencies — plausibly moving the final score toward the middle of the Medium tier (2.5–3.5). Resumption of regular oracle/NAV updates and tighter oracle bounds would reinforce that. The manager itself (Fasanara) is already verified as FCA-authorised; the gap is mGLOBAL-specific strategy disclosure. Note the Aave Horizon listing does **not** itself lower the score materially — at 0.05% LTV it signals onboarding, not capital-backed conviction; a future LTV increase would be the stronger signal.
+**Path to a lower score:** the binding constraint is opacity, not a verified flaw. An attested allocation breakdown that classifies the 97.03% "Unclassified" NAV would directly improve Collateralization, Provability, and External Dependencies and could move the score toward the middle of the Medium tier. Three cheaper fixes would also help: revoking `M_GLOBAL_BURN_OPERATOR_ROLE` from the unconfigured third vault, pruning the 53-address blacklist-operator set or routing it through a multisig, and either removing the public `setRoundData` path or moving the feed admin role behind a timelock so the deviation cap becomes an enforced invariant rather than a convention. Tightening `maxAnswerDeviation` from 100% and activating the PriceRaised/PriceLowered bound feeds would reinforce that.
 
 **Required Conditions:**
 
-1. **Fasanara FCA Registration** Authorised since August 2011, FRN 551020, Companies House 07561210. Full permissions scope needs manual review of the FCA register, but the firm is regulated and publishes MIFIDPRU disclosures
-2. **Verify Strategy Allocation** — Current SumCap data shows 88.61% unclassified. Obtain breakdown of the unclassified portion from Midas team or attestation reports
-3. **Limited Exposure** — Cap initial allocation at 5–10% of vault with gradual ramp-up only after oracle update cadence improves and yield reporting resumes
-4. **Enhanced Monitoring** — Real-time alerts on oracle updates (1%+ deviation from $1.00), role changes, contract upgrades, vault activity, and Aave position health (see Monitoring section)
-5. **Verify Oracle Bounds** — Confirm whether the 100% oracle deviation is intentional for a stablecoin product. If not, push for tighter bounds and activation of PriceRaised/PriceLowered bound feeds
-6. **Weekly NAV Cross-Check** — Verify mGLOBAL oracle price remains at $1.00 ± acceptable tolerance
-7. **Verify Redemption Parameters** — Confirm fees, delays, and instant redemption capacity for both vaults
-8. **Monthly Reassessment** — Given the unverified manager, short history, and loose oracle bounds, reassess monthly for the first quarter, then quarterly
+1. **Verify Strategy Allocation** — 97.03% of NAV is unclassified. Obtain a breakdown of the unclassified portion from Midas or via attestation reports
+2. **Confirm Base Prospectus renewal** — the FMA Liechtenstein prospectus lapsed July 17, 2026; obtain the successor document or written confirmation
+3. **Limited Exposure** — cap initial allocation at 5–10% of vault, sized so that a full exit stays within the $6.2M instant-redemption capacity and the 2,000,000 mGLOBAL/day per-vault limit
+4. **Enhanced Monitoring** — real-time alerts on oracle setter selector and price moves, role changes, contract upgrades, redemption-vault aUSDC balance, InfiniFi router balance, and Horizon reserve parameters (see [Monitoring](#monitoring))
+5. **Oracle hardening** — confirm with Midas whether the public `setRoundData` path is intentional; push for a timelock on the feed admin role, a tighter `maxAnswerDeviation`, and activation of the bound feeds
+6. **Burn-role hygiene** — ask Midas to revoke `M_GLOBAL_BURN_OPERATOR_ROLE` from [`0xdbd621e6…8e76`](https://etherscan.io/address/0xdbd621e67d9cffffcdcd316a27285f657c178e76) until it is configured for production
+7. **Monthly NAV Cross-Check** — verify each published round against expected accrual and confirm the guarded setter was used
+8. **Quarterly Reassessment** — the acute triggers from the prior assessment have resolved; a quarterly cadence is now appropriate absent an alert
 
 **Key Concerns Driving the Score:**
 
-- **Fasanara Capital is fully verified** — FCA Authorised (FRN 551020, since 2011), $4B+ AUM, 15-year history, London-based, 40+ team, MIFIDPRU disclosure, Companies House 07561210. The manager risk is now well-understood. However, 88.61% of mGLOBAL NAV remains "Unclassified" — the digital asset strategy mandate specifically for mGLOBAL is opaque. This is now a "strategy opacity" concern rather than a "manager risk" concern
-- **Holder concentration eased to ~58%:** Down from 81%. InfiniFi renewed its ~$30.49M position (new MidasFarm, maturity July 21, 2026) instead of redeeming; Aave Horizon now holds 37.71%. Still concentrated, and the maturity trigger re-arms in ~1 month
-- **Oracle is 39 days stale with APY at 0%** — only 2 updates since deployment. The May 15 update kept the price at $1.00000000 and set `growthApr = 0`; no onchain evidence of yield accrual or holder airdrops was found.
+- **Strategy opacity at 97.03%** — the highest since launch. Fasanara's institutional credibility is well established; what is missing is any view into this vehicle's book
+- **Oracle bounds are not invariants** — the deviation cap and `onlyUp` guard live only on `setRoundDataSafe`, while `setRoundData` is directly callable by a single non-timelocked EOA and permits any price from $0.10 to $1,000
+- **53 EOAs can freeze any holder** — unilateral, untimelocked blacklist authority across the whole Midas platform
+- **Exit remains redemption-only** — no DEX market, ~$6.2M instant capacity, 2,000,000/day per-vault cap, and a 30.29% holder whose position now carries no maturity date
 
 **Mitigating Factors:**
 
-- **Fasanara Capital is an established institution** — $4B+ AUM, 15-year track record, large professional team, MIFIDPRU disclosure. This substantially improves the operational risk profile vs the initial unverified assessment
-- **Aave integration** — $2.55M idle capital verifiably on blue-chip DeFi protocol. Structural improvement over mHYPER
-- **Aave Horizon collateral listing** — onboarded to the permissioned, curator-vetted Horizon RWA market ($19.85M supplied), a third-party institutional due-diligence signal (tempered by the 0.05% LTV)
-- **InfiniFi renewal** — the largest counterparty re-locked ~$30M after maturity rather than exiting; supply grew ~40% in a week
-- **Extensively audited shared infrastructure** — 10 audits across 3 years + $1M bug bounty
-- **Strong Midas team and institutional backing** — doxxed, well-funded, regulated
+- **NAV publication and yield accrual are demonstrably working** — five oracle rounds, current to 3.4 days, ~6.3% annualized realized return
+- **Verifiable redemption float** — $6,237,620 of aUSDC on Aave, ~9.0% of NAV, independently auditable
+- **No dominant counterparty** — the largest beneficial holder is ~30%, and the top three are 30.29%, 26.11%, and 14.48%
+- **Timelock discipline is real** — 48-hour delay, ProxyAdmin owned by the timelock, no mGLOBAL proxy ever upgraded, 82 of 87 queued operations executed cleanly
+- **Third-party scrutiny** — Aave Horizon onboarding plus a 16-transmitter Chainlink OCR2 feed republishing the NAV
+- **Fasanara is an established institution** — $4B+ AUM, 15-year track record, FCA-authorised, MIFIDPRU disclosure
+- **Extensively audited shared infrastructure** — 10 audits across 3 years plus a $1M bug bounty
+- **Strong Midas team and institutional backing** — doxxed, well funded
 - **Attestation Engine** — multi-party verification pipeline with onchain hash publication
-- **Dual redemption vaults** — redundancy for user exits
-- **Platform-level track record** — ~22 months, processed $150M+ redemptions (mHYPER)
-- **1/3 Safe signers use institutional-grade MPC** — Fordefi and Fireblocks provide offchain protection beyond the onchain threshold
+- **Dual funded redemption vaults** with explicit onchain limits and fees
+- **1/3 Safe signers use institutional-grade MPC** — Fordefi and Fireblocks, beyond the onchain threshold
 
 ---
 
 ## Reassessment Triggers
 
-- **Time-based**: Reassess in 2 months (August 2026) — accelerated due to short history and incomplete diligence
-- **InfiniFi Maturity (re-armed):** InfiniFi renewed its ~$30.49M position into a [new MidasFarm](https://etherscan.io/address/0xf4ea3ec87b1c254f17a2fb68164db0caf6c4cecf) maturing **July 21, 2026**. Monitor this holder daily and re-check `maturity()`. If InfiniFi redeems (rather than renewing again) around that date, re-evaluate mGLOBAL liquidity and concentration immediately
-- **Aave Horizon Parameters:** mGLOBAL is a collateral reserve on Aave Horizon at LTV 0.05% (near-zero credit). Reassess if the LTV / liquidation threshold is raised materially (would indicate Aave extending real credit and a stronger endorsement — and a larger liquidation dependency on mGLOBAL's loose oracle), if the supply cap (50M) is approached, or if the reserve is frozen/delisted
-- **Fasanara Due Diligence**: FCA Authorised since 2011 (FRN 551020), $4B+ AUM, 15-year track record. Digital asset strategy mandate for mGLOBAL remains the primary open question — Fasanara's institutional credibility is now well-established, but strategy-specific transparency is still needed
-- **Strategy Disclosure**: Reassess when mGLOBAL strategy allocations become verifiable (via Midas app, SumCap, or attestation reports)
-- **TVL-based**: Reassess if mGLOBAL market cap changes by more than 50% or Midas platform TVL changes by more than 40%
-- **Oracle Configuration**: Reassess if oracle bounds are tightened (current 100% is dangerously loose for a stablecoin) or if PriceRaised/PriceLowered bound feeds are activated
-- **Incident-based**: Reassess after any exploit, NAV discrepancy, governance change, contract upgrade, or regulatory action affecting Midas or Fasanara
-- **Cross-chain Activation**: Reassess if mGLOBAL is deployed on another chain or any bridge adapter is granted mGLOBAL mint/burn roles
-- **Audit**: If new audit covering mGLOBAL-specific contracts (Aave vaults, growth oracle) is published, reassess
-- **Redemption Stress**: If mGLOBAL processes a significant redemption event, reassess based on performance
-- **Attestation Engine**: If mGLOBAL-specific attestations are confirmed flowing through the pipeline, reassess for Provability score improvement
+- **Time-based**: reassess in 3 months (November 2026). The acute triggers from the prior assessment — a stalled oracle and a dated counterparty maturity — have both resolved, so the accelerated monthly cadence is no longer warranted
+- **Oracle integrity (highest priority)**: reassess immediately on any use of the raw `setRoundData` selector (`0x2b6e02c7`), any downward price revision, any single-round move beyond ~1.5%, `onlyUp` being set to false, or no update for more than 45 days
+- **Oracle governance**: reassess if the feed admin role moves behind a timelock, if `maxAnswerDeviation` is tightened, or if the PriceRaised/PriceLowered bound feeds are activated — each would materially improve Programmability and Provability
+- **InfiniFi concentration**: monitor mGLOBAL `balanceOf` on the [`RWAEscrowRouter`](https://etherscan.io/address/0x7912Eaff92B2f5Bc64Cdd21C76d79FFC12eA855E) daily. The wrapper exposes no maturity date, so any balance decrease is the only available signal and should trigger an immediate liquidity and concentration review
+- **Redemption capacity**: reassess if the RedemptionVaultWithAave's aUSDC balance falls below ~$2M or below 3% of NAV, if `instantDailyLimit` is reduced, or if either live vault is paused
+- **Aave Horizon parameters**: the reserve is saturated at a 30M supply cap with LTV 0.05%. Reassess on any further cap reduction (which would force withdrawals), any material LTV or liquidation-threshold increase, a freeze or delisting, or the Llamaguard feed going stale or diverging from the Midas oracle
+- **Burn-role hygiene**: reassess if the staged third vault [`0xdbd621e6…8e76`](https://etherscan.io/address/0xdbd621e67d9cffffcdcd316a27285f657c178e76) is activated, funded, or used while uncapped and zero-fee — or, positively, if its burn role is revoked
+- **Blacklist authority**: reassess if the 53-address `BLACKLIST_OPERATOR_ROLE` set grows materially, if any mGLOBAL holder is added to `BLACKLISTED_ROLE`, or — positively — if the set is pruned or routed through a multisig
+- **Strategy disclosure**: reassess when mGLOBAL allocations become verifiable (via Midas, SumCap / Delta Y, or attestation reports). A drop in the unclassified share below ~75% would be materially score-relevant
+- **Base Prospectus**: confirm whether the FMA Liechtenstein prospectus was renewed after July 17, 2026; reassess on the answer either way
+- **TVL-based**: reassess if mGLOBAL market cap changes by more than 50% or Midas platform TVL changes by more than 40%
+- **Incident-based**: reassess after any exploit, NAV discrepancy, governance change, mGLOBAL contract upgrade, or regulatory action affecting Midas or Fasanara
+- **Shared-infrastructure changes**: the ProxyAdmin, timelock, and MidasAccessControl are shared across all Midas products; reassess on any change to their ownership or role configuration even when the immediate target is another token
+- **Cross-chain activation**: reassess if mGLOBAL is deployed on another chain or any bridge adapter is granted mGLOBAL mint or burn roles
+- **Audit**: reassess if an audit covering the mGLOBAL-specific contracts (Aave-integrated vaults, growth oracle) is published
+- **Redemption stress**: reassess after any significant redemption event, based on observed performance
+- **Attestation Engine**: reassess if mGLOBAL-specific attestations are confirmed flowing through the pipeline
+
+## Assessment History
+
+| Date | Score | Notes |
+| --- | --- | --- |
+| [June 17, 2026](https://github.com/yearn/risk-score/pull/258) | 3.51 | Initial assessment |
+| [June 23, 2026](https://github.com/yearn/risk-score/pull/269) | 3.43 | Reassessment: InfiniFi's matured MidasFarm renewed rather than redeeming, and Aave Horizon onboarding added independent demand; top-holder concentration 81% → 58%. Liquidity Risk 4.0 → 3.5. |
+| August 24, 2026 | 3.42 | Reassessment at block 25,822,232. Supply 52.63M → 68.10M and NAV $52.63M → $69.23M as the oracle resumed publishing: five rounds now, price $1.01664609, last updated August 20 (3.4 days stale versus 39), realized ~6.3% annualized. Liquidity Risk 3.5 → 3.0 — the RedemptionVaultWithAave now holds $6.24M aUSDC where it held $0, and top-holder concentration fell 58% → 30.29% after InfiniFi moved its position from `MidasFarm` into an `RWAEscrowRouter` with no maturity date. Centralization 3.7 → 3.9: `GREENLIST_OPERATOR_ROLE` and `BLACKLIST_OPERATOR_ROLE` are each held by 53 EOAs with untimelocked unilateral freeze authority, and the oracle's `maxAnswerDeviation` and `onlyUp` guards were found to live only on `setRoundDataSafe` — the admin-callable `setRoundData` skips both and permits any price in $0.10–$1,000. Strategy opacity rose 88.61% → 97.03% of NAV. Added a fourth `M_GLOBAL_BURN_OPERATOR_ROLE` holder ([`0xdbd621e6…8e76`](https://etherscan.io/address/0xdbd621e67d9cffffcdcd316a27285f657c178e76), granted August 12), an unfunded and unconfigured swapper vault with zero fee and an uncapped daily limit. Aave Horizon's supply cap was cut 50M → 30M on July 2 and the reserve is saturated. Corrected a broken April 5 oracle transaction link. Flagged the lapsed FMA Base Prospectus as `TODO`. |
+

--- a/src/data/bridges.json
+++ b/src/data/bridges.json
@@ -66,7 +66,8 @@
       "ignore": [
         "aave-sgho",
         "infinifi",
-        "fx-fxusd"
+        "fx-fxusd",
+        "midas-mglobal"
       ],
       "dependencies": [
         {


### PR DESCRIPTION
Closes #423.

Reassessment of `reports/report/midas-mglobal.md` at **block 25,822,232** (August 24, 2026). The headline score is essentially flat (**3.43 → 3.42**, Medium Risk), but the composition of the risk moved substantially in both directions.

## Improved

- **Oracle resumed publishing.** Five rounds now exist; price **$1.01664609**, last written **August 20, 2026** — 3.4 days before snapshot, against 39 days stale previously. Yield accrual began at round 3: **+1.6646% since May 15**, ~6.3% annualized (SumCap reports 7.13% APY). The stalled-oracle finding that drove the last assessment has resolved.
- **Real redemption liquidity.** `RedemptionVaultWithAave` holds **$6,237,620 aUSDC** (~9.0% of NAV), verified via `balanceOf` on aEthUSDC. It previously held $0.
- **Concentration broadened.** Top beneficial holder fell **57.94% → 30.29%**. No holder above ~30%; top three are 30.29% / 26.11% / 14.48%.
- **Liquidity Risk 3.5 → 3.0.**

## Worsened

- **The oracle's safety bounds are not invariants.** `setRoundData(int256,uint256,int80)` is `public onlyAggregatorAdmin` and validates only `[minAnswer, maxAnswer]`, `growthApr ∈ [0,0]`, and a past timestamp. It enforces **neither `maxAnswerDeviation` nor `onlyUp`** — those live only on `setRoundDataSafe`, which then calls into it. A single non-timelocked EOA can set any price between **$0.10 and $1,000 in one transaction**. Round 1 in fact used the raw path (selector `0x2b6e02c7`); rounds 2–5 used the guarded one (`0x92260352`).
- **`onlyUp = true` blocks markdowns** on the guarded path, so a credit impairment in Fasanara's book cannot be published routinely — converting an unreported loss into a first-mover run for a redemption-only instrument.
- **53 EOAs hold both `GREENLIST_OPERATOR_ROLE` and `BLACKLIST_OPERATOR_ROLE`**, accumulated since Dec 2023 and still growing. Any one can freeze an arbitrary holder untimelocked. The token-specific `M_GLOBAL_*` variants are granted to nobody, so all such authority runs through this set.
- **Strategy opacity 88.61% → 97.03%** of NAV unclassified.
- **Centralization & Control 3.7 → 3.9.**

## Other verified changes

| Item | Value |
|---|---|
| Total supply | 52,628,652.70 → **68,097,489.96** |
| NAV / market cap | ~$52.63M → **~$69.23M** |
| Midas platform TVL | ~$112.7M → **~$152.9M** (mGLOBAL ~45%) |
| InfiniFi position | `MidasFarm` → InfiniFi [`RWAEscrowRouter`](https://etherscan.io/address/0x7912Eaff92B2f5Bc64Cdd21C76d79FFC12eA855E) on [Aug 17](https://etherscan.io/tx/0xb4d8d9c153c8242adc6701c987709f9a372e29ea538f4990902d95ebad32abde) — same size, **no maturity date**, so an exit now gives no advance notice |
| Aave Horizon supply cap | 50M → **30M** on [Jul 2](https://etherscan.io/tx/0x8f4a77b86f71129e8acc7452494a732150c963fbbef50d670d958ee3ea668acf); reserve **saturated** at 29,999,999/30,000,000 |
| `M_GLOBAL_BURN_OPERATOR_ROLE` | 3 → **4 holders**; new [`0xdbd621e6…8e76`](https://etherscan.io/address/0xdbd621e67d9cffffcdcd316a27285f657c178e76) granted [Aug 12](https://etherscan.io/tx/0x8cff72082df0ec3a239cde44bc40efd1fe608945bae172e347f62bd0f3a91524) — unfunded, sentinel `0xFFfF…FFfF` config, 0 fee, uncapped daily limit |
| Horizon price feed | Chainlink OCR2 "mGlobal NAV - Aave Llamaguard", 16 transmitters, updated ~hourly; mirrors Midas NAV rather than valuing independently |

## Unchanged critical controls

Timelock `getMinDelay()` = 48h; ProxyAdmin owned by the timelock; **no mGLOBAL proxy has ever been upgraded** (all implementations match). Admin Safe still 1/3 and holds PROPOSER + EXECUTOR + **CANCELLER**. `DEFAULT_ADMIN_ROLE` still 2 holders; mint role still 2. Zero DEX liquidity (no Uniswap V2/V3 pool at any tier). Ethereum-only — no code at the token address on Base/Arbitrum/Polygon/Sonic, absent from the LayerZero OFT registry, and no bridge holds mint/burn authority.

## Corrections

- The April 5 oracle-update link pointed at a **non-existent transaction**; replaced with the verified `0x45c0c4f317741d476578eba17e747df898834afb05a50e806b14bff75396eaca`.
- The report described mGLOBAL as a "$1.00 pegged stablecoin"; it is an **accruing growth token** and the price is now $1.0166.

## TODO

**FMA Liechtenstein Base Prospectus lapsed July 17, 2026** and renewal could not be confirmed — `docs.midas.app` sits behind a Cloudflare bot challenge and the FMA register was unreachable from this environment. Flagged in Operational Risk and Reassessment Triggers; **not** scored, since scoring an unverified fact would not be sound. Needs confirmation directly from Midas.

## Validation

- `npm run build` — passes, 108 pages, 0 errors.
- `npm run check-bridges --strict` — 0 warnings (added `midas-mglobal` to the CCIP `ignore` list; the report mentions CCIP only to state that no bridge holds mint authority).
- `check_graphs` — 0 errors, no warnings for `midas-mglobal`.
- All 10 transaction hashes cited in the report re-verified onchain via `cast tx`.
- Graph `reports/graph/midas-mglobal.yaml` updated: new staged vault node + edges, InfiniFi node repointed to the escrow router, Horizon/oracle/allocation notes refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)