### PR TITLE
Reassessment: Superstate USCC

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -40,6 +40,13 @@ exclude_path = ["reports/TEMPLATE.md", "reports/old"]
 # - github.com/resolv-im/resolv-contracts-public returns 404 (repo is private or
 #   removed). Referenced by the Resolv reports (now HACKED / Not Rated), which we
 #   are intentionally not modifying; excluded so the dead link doesn't fail CI.
+# - superstate.com/assets/ (bare apex domain, e.g. /assets/uscc, /assets/ustb)
+#   intermittently raises the same "HTTP/2 protocol error" as businesswire.com
+#   above; curl and browsers negotiate HTTP/2 with it fine. Because it's a plain
+#   connection error (no HTTP status code), cache_exclude_status can't filter it
+#   from the cache, so one bad run poisons results for up to max_cache_age.
+#   Scope kept to the apex /assets/ path; docs.superstate.com and
+#   api.superstate.com are unaffected and still checked.
 exclude = [
     '^https?://(www\.)?rekt\.news',
     '^https?://(blue-api|api)\.morpho\.org/graphql',
@@ -50,4 +57,5 @@ exclude = [
     '^https?://(www\.)?maple\.finance/syrup',
     '^https?://(www\.)?businesswire\.com/news/',
     '^https?://github\.com/resolv-im/resolv-contracts-public',
+    '^https?://(www\.)?superstate\.com/assets/',
 ]

--- a/reports/graph/superstate-uscc.yaml
+++ b/reports/graph/superstate-uscc.yaml
@@ -18,7 +18,7 @@ nodes:
     label: USCC (Bitwise Crypto Carry Fund)
     address: "0x14d60E7FDC0D71d8611742720E4C50E7a974020c"
     category: vault
-    note: EIP-1967 Proxy → SuperstateTokenV5; price-appreciation; mark-to-market NAV
+    note: EIP-1967 Proxy → FundToken v1.3.0; price-appreciation; mark-to-market NAV
 
   # === Protocol infra ===
   - id: uscc-proxy-admin
@@ -55,39 +55,39 @@ nodes:
   - id: dep-usd-collateral
     label: USD Collateral
     category: dependency
-    note: 19.45% of portfolio; Bitwise holdings as of Jun 28 2026
+    note: 35.55% of portfolio; Bitwise holdings as of Sep 4 2026
   - id: dep-ustb
     label: USTB
     category: dependency
-    note: 18.76% of portfolio; tokenized T-Bill exposure
+    note: 4.71% of portfolio; tokenized T-Bill exposure
   - id: dep-staked-sol
     label: Staked SOL
     category: dependency
-    note: 20.08% of portfolio; staking / validator risk
+    note: 12.32% of portfolio; staking / validator risk
   - id: dep-weeth
     label: weETH
     category: dependency
-    note: 19.12% of portfolio; liquid-staking-token risk
+    note: 22.60% of portfolio; liquid-staking-token risk
   - id: dep-xrp
     label: XRP Custody
     category: dependency
-    note: 18.52% of portfolio; spot crypto custody and market risk
+    note: 10.30% of portfolio; spot crypto custody and market risk
   - id: dep-eth
     label: ETH Custody
     category: dependency
-    note: 2.30% of portfolio; spot crypto custody and market risk
+    note: 1.92% of portfolio; spot crypto custody and market risk
   - id: dep-btc
     label: BTC Custody
     category: dependency
-    note: 1.43% of portfolio; spot crypto custody and market risk
+    note: 13.18% of portfolio; spot crypto custody and market risk
   - id: dep-futures-cme
     label: CME Futures
     category: dependency
-    note: Short BTC/ETH/SOL/XRP futures plus SOL call; negative notional hedges spot/staked legs
+    note: Short ETH/SOL futures; negative notional hedges spot/staked legs
   - id: dep-futures-coinbase
     label: Coinbase Futures
     category: dependency
-    note: Small short XRP futures leg; -0.37% of portfolio
+    note: Short BTC/ETH/XRP futures; negative notional hedges spot legs
   - id: dep-anchorage
     label: Anchorage Digital (Custodian)
     category: dependency
@@ -105,6 +105,12 @@ nodes:
     address: "0xAfFd8F5578E8590665de561bdE9E7BAdb99300d9"
     category: dependency
     note: Sole onchain NAV oracle; 16 OCR transmitters; no SuperstateOracle fallback
+  - id: plume-uscc
+    label: USCC on Plume
+    address: "0x4c21b7577c8fe8b0b0669165ee7c8f67fa1454cf"
+    chain: plume
+    category: dependency
+    note: FundToken v1.3.0; issuer-operated burn-and-mint destination; same owner EOA
   - id: dep-circle
     label: Circle / USDC
     category: dependency
@@ -161,31 +167,31 @@ edges:
   - from: dep-treasuries
     to: dep-usd-collateral
     kind: deposits-into
-    label: 19.45%
+    label: 35.55%
   - from: dep-treasuries
     to: dep-ustb
     kind: deposits-into
-    label: 18.76%
+    label: 4.71%
   - from: dep-treasuries
     to: dep-staked-sol
     kind: deposits-into
-    label: 20.08%
+    label: 12.32%
   - from: dep-treasuries
     to: dep-weeth
     kind: deposits-into
-    label: 19.12%
+    label: 22.60%
   - from: dep-treasuries
     to: dep-xrp
     kind: deposits-into
-    label: 18.52%
+    label: 10.30%
   - from: dep-treasuries
     to: dep-eth
     kind: deposits-into
-    label: 2.30%
+    label: 1.92%
   - from: dep-treasuries
     to: dep-btc
     kind: deposits-into
-    label: 1.43%
+    label: 13.18%
   - from: dep-treasuries
     to: dep-futures-venues
     kind: routes-through
@@ -206,6 +212,10 @@ edges:
     to: dep-chainlink-nav
     kind: routes-through
     label: sole NAV feed
+  - from: uscc
+    to: plume-uscc
+    kind: routes-through
+    label: issuer-operated burn-and-mint
   - from: uscc
     to: dep-circle
     kind: routes-through

--- a/reports/report/superstate-uscc.md
+++ b/reports/report/superstate-uscc.md
@@ -611,4 +611,4 @@ USCC remains materially higher risk than USTB. Its crypto-basis strategy adds fu
 | Date | Score | Notes |
 |------|------:|-------|
 | [July 3, 2026](https://github.com/yearn/risk-score/pull/230) | 2.95 | Initial assessment |
-| [September 5, 2026](https://github.com/yearn/risk-score/pull/PR_NUMBER) | 2.53 | Updated implementation, portfolio, TVL, cross-chain state, and controls |
+| [September 5, 2026](https://github.com/yearn/risk-score/pull/445) | 2.53 | Updated implementation, portfolio, TVL, cross-chain state, and controls |

--- a/reports/report/superstate-uscc.md
+++ b/reports/report/superstate-uscc.md
@@ -1,10 +1,10 @@
 # Protocol Risk Assessment: Superstate USCC
 
-- **Assessment Date:** September 5, 2026
+- **Assessment Date:** July 3, 2026 (Updated: September 5, 2026)
 - **Token:** USCC
 - **Chain:** Ethereum
 - **Token Address:** [`0x14d60E7FDC0D71d8611742720E4C50E7a974020c`](https://etherscan.io/address/0x14d60E7FDC0D71d8611742720E4C50E7a974020c)
-- **Final Score: 2.53/5.0**
+- **Final Score: 2.45/5.0**
 
 ## Overview + Links
 
@@ -18,14 +18,14 @@ Investors must clear KYC/AML, be Qualified Purchasers and Accredited Investors, 
 
 - **Current NAV/Share:** $11.725624 ([Chainlink USCC NAV feed](https://etherscan.io/address/0xAfFd8F5578E8590665de561bdE9E7BAdb99300d9), latest round updated September 4, 2026 13:18 UTC)
 - **Ethereum Supply:** 5,761,292.38 USCC ($67.55M at the current NAV, September 5, 2026)
-- **Total Shares (incl. book-entry):** 12,236,723.87 USCC ([Superstate NAV dataset](https://superstate.com/assets/uscc), September 4, 2026)
-- **Total AUM (incl. book-entry):** $143.48M ([Superstate](https://superstate.com/assets/uscc), September 4, 2026)
+- **NAV-statement Shares (incl. book-entry):** 12,236,723.87 USCC ([Superstate](https://superstate.com/assets/uscc), NAV effective September 3, 2026)
+- **Total AUM:** $143.48M ([Superstate](https://superstate.com/assets/uscc), NAV effective September 3, 2026)
 - **Public TVL:** $103.41M ([DeFiLlama](https://defillama.com/protocol/bitwise-uscc), September 5, 2026), up 74.3% over 30 days from $59.34M
 - **30-day SEC Yield:** 6.68% (variable, depends on basis spread)
 - **Management Fee:** 0.75% annually
 - **Minimum Investment:** $100,000
 
-**TODO — first-party share reconciliation:** the Bitwise network-distribution table totals 12,849,759.44 shares ($150.67M at the displayed NAV), while the same official dataset reports 12,236,723.87 outstanding shares and $143.48M AUM. The Ethereum, Plume, and Solana rows match current onchain supply; the discrepancy is in the reported book-entry balance and requires clarification from Superstate/Bitwise.
+**Share-count timing:** the Bitwise network-distribution table is a realtime balance and totals 12,849,759.44 shares as of September 4, while the 12,236,723.87-share AUM statement is effective September 3. Two Ethereum mints on September 4 added 613,035.402635 USCC ([604,173.998756 USCC](https://etherscan.io/tx/0x3273f52b4a2c587d7310a6dcaff5369122fd7387c644c8f1fba5ff986c13e55f) and [8,861.403879 USCC](https://etherscan.io/tx/0xd66e8791290955f2549e3dbc984146d61ca5ca19a6c0089a404c5c9fa85b160f)), explaining all but 0.164482 USCC of the difference. The figures represent different cutoffs rather than a material reserve inconsistency.
 
 **Links:**
 
@@ -78,7 +78,7 @@ Note that the prior USCC owner was [`0x8c7db8a96d39f76d9f456db23d591c2fdd0e2f8a`
 
 USCC uses the source-verified `FundToken` v1.3.0 implementation and the same shared AllowList V3.1 contract as USTB. The [Superstate Security page](https://docs.superstate.com/investors/security) lists **11 numbered 0xMacro audits**, plus ChainSecurity, Solana/AllowList reviews, and a Certora formal-verification report. Earlier 0xMacro scopes cover USCC/SuperstateToken, redemption, the shared token components, and AllowList V3; however, the published audit list does not map a report explicitly to the integrated `FundToken` v1.2.0/v1.3.0 implementation deployed in July 2026. A-10 and A-11 scope DIP/EquityToken rather than `FundToken`.
 
-**TODO — current implementation audit mapping:** obtain a public audit report or hash-to-scope mapping for `FundToken` v1.2.0/v1.3.0. The implementation is source-verified, and much of its component surface has prior review coverage, but an independent review of the deployed integration and storage migration cannot be confirmed from the published audit scopes.
+**Audit scope limitation:** no published audit report or hash-to-scope mapping explicitly covers the integrated `FundToken` v1.2.0/v1.3.0 deployment. The implementation is source-verified and much of its component surface has prior review coverage, but the deployed integration and storage migration cannot be tied to a public independent-review artifact.
 
 ### Audit History
 
@@ -116,7 +116,7 @@ So **all USCC mint operations are admin-driven** (`mint`/`bulkMint` by the owner
 ## Historical Track Record
 
 - **Fund Launch:** July 15, 2024 onchain (first mint at [block 20312293](https://etherscan.io/tx/0xeefda6ce766bca7c431bb6ef157b4b78925d9a0a3527a811d2ea54e41485fb1b), Unix ts 1721051099). DeFiLlama [first records Sep 9, 2024](https://defillama.com/protocol/bitwise-uscc) at ~$15.7M TVL. The fund has now operated for **more than two years**.
-- **Contract Upgrades:** The token moved from the legacy V5 implementation to `FundToken` v1.2.0 on July 20, 2026 ([upgrade](https://etherscan.io/tx/0xe38fb441aa385cfe91eada867aab14698fbf90acd6ef694e72bfadf1f59f0990), [migration initialization](https://etherscan.io/tx/0x87155971d23c3f2200061ff8fa066ea2ae7382c60d9013a67f196ee37659d883)), then to v1.3.0 on July 21, 2026 ([upgrade](https://etherscan.io/tx/0x73b4604e54b163e843f1631d54e329fbaf1b1f036b43a6d2117580beaf0cbcc5)). The migration enabled book-entry conversion and Plume bridging. No ownership, oracle, redemption, stablecoin-config, pause, accounting-pause, or `AdminBurn` changes were observed since the prior assessment.
+- **Contract Upgrades:** The token moved from the legacy V5 implementation to `FundToken` v1.2.0 on July 20, 2026 ([upgrade](https://etherscan.io/tx/0xe38fb441aa385cfe91eada867aab14698fbf90acd6ef694e72bfadf1f59f0990), [migration initialization](https://etherscan.io/tx/0x87155971d23c3f2200061ff8fa066ea2ae7382c60d9013a67f196ee37659d883)), then to v1.3.0 on July 21, 2026 ([upgrade](https://etherscan.io/tx/0x73b4604e54b163e843f1631d54e329fbaf1b1f036b43a6d2117580beaf0cbcc5)). The migration enabled book-entry conversion and Plume bridging. No ownership, oracle, redemption, stablecoin-config, pause, accounting-pause, or `AdminBurn` events occurred from July 3 through September 5, 2026.
 - **Smart Contract Exploits:** None reported.
 - **Ownership Changes:** USCC token ownership was transferred Oct 31, 2024 from [`0x8c7db8a9…`](https://etherscan.io/address/0x8c7db8a96d39f76d9f456db23d591c2fdd0e2f8a) to [`0x8abC89D9…`](https://etherscan.io/address/0x8abC89D9b56dFD90dA18e8E18CFaC9111100bDd1) via the two-step Ownable flow ([Etherscan tx](https://etherscan.io/tx/0xd2d1c711f5f7ecf9053637145d218e33f0b22d2d26d59a63d94535e88ca46c72)); no subsequent transfer was observed.
 - **TVL History ([DeFiLlama](https://defillama.com/protocol/bitwise-uscc)):**
@@ -219,7 +219,7 @@ The fund "will trade only those digital assets for which the CFTC has permitted 
   - Anchorage Digital (regulated digital-asset custody)
   - SEC regulatory framework (Reg D / Section 3(c)(7))
 - **Reserve Transparency:** Bitwise publishes headline NAV/AUM/yield, network balances, DeFi integrations, and current holdings on [bitwiseinvestments.com/crypto-funds/uscc](https://bitwiseinvestments.com/crypto-funds/uscc). Public holdings now include asset quantities, implied yields, notional values, portfolio weights, and current futures venues, but margin balances, counterparty concentration policy, historical venue usage, and T-Bill / USTB look-through details are still not fully disclosed publicly.
-- **Reconciliation Limitation:** The first-party network-distribution total exceeds the first-party outstanding-share total by 613,035.57 shares. Until Bitwise/Superstate reconciles those figures, public reserve and supply reporting cannot be treated as fully internally consistent.
+- **Share-Supply Reconciliation:** The apparent 613,035.57-share gap is a cutoff difference: the AUM statement is effective September 3, while the realtime network total includes 613,035.402635 USCC minted on Ethereum on September 4. The residual is 0.164482 USCC.
 - **NAV Mark-to-Market Risk:** Because the futures leg is mark-to-market daily, the share price reflects unrealized basis-trade P&L in real time. The protocol explicitly warns of "unrealized losses" during basis expansion. This is fundamentally different from USTB whose underlying T-Bills have a much smoother mark-to-market profile.
 
 ## Liquidity Risk
@@ -468,10 +468,9 @@ EXTERNAL / UNDERLYING LAYER
 4. **No atomic onchain redemption** — `redemptionContract() = 0x0` onchain. Subscribe is also disabled onchain (`OnchainSubscriptionsDisabled`). All mints/redeems flow through offchain operations with T+1/T+2 settlement.
 5. **Sole onchain NAV oracle is Chainlink-OCR-only** — no Superstate-run fallback price feed; between transmissions the onchain price is just stale.
 6. **Small holder base (53 multi-chain wallets per RWA.xyz; 46 Ethereum holders) and no secondary liquidity** — concentrated, expected for a Qualified-Purchaser permissioned fund but a real exit-liquidity constraint. Public TVL is $103.41M.
-7. **First-party supply reporting does not reconcile.** The network-distribution table exceeds reported outstanding shares by 613,035.57 shares.
-8. **Current implementation audit scope is unclear.** Published reports do not explicitly map to the deployed FundToken v1.2/v1.3 migration.
-9. **Manager transition to Bitwise effective Jun 1, 2026** — operational change with continuing post-handoff risk.
-10. **No formal bug bounty rewards.**
+7. **Current implementation audit scope is unclear.** Published reports do not explicitly map to the deployed FundToken v1.2/v1.3 migration.
+8. **Manager transition to Bitwise effective Jun 1, 2026** — operational change with continuing post-handoff risk.
+9. **No formal bug bounty rewards.**
 
 ### Critical Risks
 
@@ -486,8 +485,8 @@ EXTERNAL / UNDERLYING LAYER
 
 ### Critical Risk Gates
 
-- [x] **No audit** → **PASS** — the token family and shared components have substantial independent review coverage. The deployed FundToken integration is source-verified, although a public v1.2/v1.3 audit mapping remains a TODO.
-- [x] **Unverifiable reserves** → **BORDERLINE PASS** — NAV Fund Services, EY, regulated custody, and detailed public holdings provide independent layers, but positions and margin cannot be verified onchain and the current first-party share totals do not reconcile.
+- [x] **No audit** → **PASS** — the token family and shared components have substantial independent review coverage. The deployed FundToken integration is source-verified, although no public v1.2/v1.3 audit mapping is available.
+- [x] **Unverifiable reserves** → **BORDERLINE PASS** — NAV Fund Services, EY, regulated custody, and detailed public holdings provide independent layers, but positions and margin cannot be verified onchain. The different AUM-statement and realtime-supply cutoffs reconcile to the September 4 Ethereum mints.
 - [x] **Total centralization** → **BORDERLINE PASS** — a single EOA controls the token and its ProxyAdmin. Turnkey key-custody claims and regulatory accountability mitigate operational risk but do not reduce the onchain single-key blast radius.
 
 **Result:** Protocol passes critical gates. Category scoring retains a conservative bias on governance and provability.
@@ -529,17 +528,17 @@ Critical dependencies include Anchorage, futures venues, Bitwise, and the Treasu
 
 **Score: (5.0 + 3.0 + 3.0) / 3 = 3.67/5**
 
-#### Category 3: Funds Management (Weight: 30%) — **3.25**
+#### Category 3: Funds Management (Weight: 30%) — **3.0**
 
 **Subcategory A: Collateralization — 3.0**
 
 The portfolio mixes USD collateral and USTB with custodied crypto, staked/liquid-staked assets, and short futures. It is intended to be fully collateralized but is entirely offchain and exposed to custody, margin, venue, staking, and mark-to-market risk. Current public holdings identify CME and Coinbase exposure but not margin balances or concentration policy.
 
-**Subcategory B: Provability — 3.5**
+**Subcategory B: Provability — 3.0**
 
-Daily Chainlink NAV, an independent NAV agent, annual EY audit, and detailed holdings are meaningful evidence. However, holders cannot verify positions onchain, material risk controls remain undisclosed, and the first-party network table exceeds the reported outstanding-share total by 613,035.57 shares. That unresolved internal inconsistency warrants a weaker score than the prior assessment.
+Daily Chainlink NAV, an independent NAV agent, annual EY audit, and detailed holdings are meaningful evidence. Holders still cannot verify positions, margin balances, or counterparty concentration onchain. The AUM-statement and realtime network totals use different cutoffs and reconcile to the September 4 Ethereum mints, so they do not add a separate provability penalty.
 
-**Score: (3.0 + 3.5) / 2 = 3.25/5**
+**Score: (3.0 + 3.0) / 2 = 3.0/5**
 
 #### Category 4: Liquidity Risk (Weight: 15%) — **3.5**
 
@@ -562,28 +561,28 @@ The doxxed team, financing, legal structure, and institutional service providers
 |----------|-------|--------|----------|
 | Audits & Historical | 1.75 | 20% | 0.350 |
 | Centralization & Control | 3.67 | 30% | 1.101 |
-| Funds Management | 3.25 | 30% | 0.975 |
+| Funds Management | 3.0 | 30% | 0.900 |
 | Liquidity Risk | 3.5 | 15% | 0.525 |
 | Operational Risk | 1.5 | 5% | 0.075 |
-| **Raw Score** | | | **3.03 / 5.0** |
+| **Raw Score** | | | **2.95 / 5.0** |
 | Live >2 years without incidents | | | **-0.50** |
-| **Final Score** | | | **2.53 / 5.0** |
+| **Final Score** | | | **2.45 / 5.0** |
 
-The >2-year incident-free modifier now applies. The resulting improvement is partly offset by the current-implementation audit gap and weaker provability arising from unreconciled first-party share data.
+The >2-year incident-free modifier applies. The current-implementation audit gap offsets the improved historical subscore, while the share totals reconcile as different reporting cutoffs.
 
 ### Risk Tier
 
 | Final Score | Risk Tier | Recommendation |
 |------------|-----------|----------------|
 | 1.0-1.5 | Minimal Risk | Approved, high confidence |
-| 1.5-2.5 | Low Risk | Approved with standard monitoring |
-| **2.5-3.5** | **Medium Risk** | **Approved with enhanced monitoring** |
+| **1.5-2.5** | **Low Risk** | **Approved with standard monitoring** |
+| 2.5-3.5 | Medium Risk | Approved with enhanced monitoring |
 | 3.5-4.5 | Elevated Risk | Limited approval, strict limits |
 | 4.5-5.0 | High Risk | Not recommended |
 
-**Final Risk Tier: MEDIUM RISK**
+**Final Risk Tier: LOW RISK**
 
-USCC remains materially higher risk than USTB. Its crypto-basis strategy adds futures-venue, staking, custody, and mark-to-market risks to the shared single-EOA and AllowList control model. It has no atomic onchain subscription or redemption. More than two incident-free years improve the score, while the July implementation migration, incomplete audit mapping, and unresolved first-party share reconciliation prevent a stronger result.
+USCC remains materially higher risk than USTB. Its crypto-basis strategy adds futures-venue, staking, custody, and mark-to-market risks to the shared single-EOA and AllowList control model. It has no atomic onchain subscription or redemption. More than two incident-free years improve the score. The July implementation migration and incomplete public audit mapping prevent a stronger result.
 
 **Key conditions for exposure:**
 
@@ -591,16 +590,15 @@ USCC remains materially higher risk than USTB. Its crypto-basis strategy adds fu
 2. Monitor the token owner for ownership transfer, mint >5% of supply, `adminBurn`, parameter changes, or proxy upgrades.
 3. Monitor the shared AllowList for permission changes affecting any Yearn vault or strategy.
 4. Track Chainlink USCC NAV for day-over-day declines >2%.
-5. Reconcile first-party total shares against the network-distribution table.
-6. Obtain the deployed FundToken v1.2/v1.3 audit-scope mapping and greater disclosure on margin, counterparties, and staking providers before scaling exposure.
+5. Obtain the deployed FundToken v1.2/v1.3 audit-scope mapping and greater disclosure on margin, counterparties, and staking providers before scaling exposure.
 
-**Score-improving triggers:** multisig and timelock adoption; a published audit mapping for the current implementation; reconciled share/reserve reporting; public margin and concentration limits; Proof of Reserves; atomic onchain redemption; or a funded bug bounty.
+**Score-improving triggers:** multisig and timelock adoption; a published audit mapping for the current implementation; public margin and concentration limits; Proof of Reserves; atomic onchain redemption; or a funded bug bounty.
 
 ---
 
 ## Reassessment Triggers
 
-- **Time-based:** Reassess in 3 months (December 2026) due to the FundToken migration, the unresolved share reconciliation, basis-trade NAV volatility, and the ongoing Bitwise post-handoff period.
+- **Time-based:** Reassess in 3 months (December 2026) due to the FundToken migration, basis-trade NAV volatility, and the ongoing Bitwise post-handoff period.
 - **TVL-based:** Reassess if AUM changes by more than 30% (more sensitive than USTB given thinner holder base).
 - **Incident-based:** Reassess after any exploit, admin key compromise, contract upgrade, AllowList policy change, manager transition issue, or any large NAV drawdown (>5% in a single day).
 - **Strategy-based:** Reassess on any change to futures venues, staking / liquid-staking provider policy, leverage policy, or asset mix (e.g., addition of new basis pairs).
@@ -611,4 +609,4 @@ USCC remains materially higher risk than USTB. Its crypto-basis strategy adds fu
 | Date | Score | Notes |
 |------|------:|-------|
 | [July 3, 2026](https://github.com/yearn/risk-score/pull/230) | 2.95 | Initial assessment |
-| [September 5, 2026](https://github.com/yearn/risk-score/pull/445) | 2.53 | Updated implementation, portfolio, TVL, cross-chain state, and controls |
+| [September 5, 2026](https://github.com/yearn/risk-score/pull/445) | 2.45 | Updated implementation, portfolio, TVL, cross-chain state, and controls |

--- a/reports/report/superstate-uscc.md
+++ b/reports/report/superstate-uscc.md
@@ -1,10 +1,10 @@
 # Protocol Risk Assessment: Superstate USCC
 
-- **Assessment Date:** July 3, 2026
+- **Assessment Date:** September 5, 2026
 - **Token:** USCC
 - **Chain:** Ethereum
 - **Token Address:** [`0x14d60E7FDC0D71d8611742720E4C50E7a974020c`](https://etherscan.io/address/0x14d60E7FDC0D71d8611742720E4C50E7a974020c)
-- **Final Score: 2.95/5.0**
+- **Final Score: 2.53/5.0**
 
 ## Overview + Links
 
@@ -16,24 +16,26 @@ This means USCC holders can suffer **principal loss**, not merely delayed yield 
 
 Investors must clear KYC/AML, be Qualified Purchasers and Accredited Investors, get whitelisted in the same shared AllowList contract used by USTB, then subscribe/redeem either onchain (offchain-settled) or via book-entry shares.
 
-- **Current NAV/Share:** $11.628080 (Chainlink USCC NAV feed, latest round updated Jul 2, 2026 13:10 UTC; verified onchain Jul 3, 2026)
-- **Ethereum Supply:** 6,229,050.91 USCC ($72.43M, verified onchain Jul 3, 2026)
-- **Total Shares (incl. book-entry):** ~13,999,991 USCC (per [superstate.com](https://superstate.com/assets/uscc))
-- **Total AUM (incl. book-entry):** $162.79M (per [superstate.com](https://superstate.com/assets/uscc), Jul 3, 2026)
-- **Public TVL:** $136.18M (per [DeFiLlama](https://defillama.com/protocol/bitwise-uscc), Jul 3, 2026)
-- **30-day Yield:** 2.60% (variable, depends on basis spread)
-- **Management Fee:** 0.75% annually (waived until AUM exceeds $50M — now exceeded)
+- **Current NAV/Share:** $11.725624 ([Chainlink USCC NAV feed](https://etherscan.io/address/0xAfFd8F5578E8590665de561bdE9E7BAdb99300d9), latest round updated September 4, 2026 13:18 UTC)
+- **Ethereum Supply:** 5,761,292.38 USCC ($67.55M at the current NAV, September 5, 2026)
+- **Total Shares (incl. book-entry):** 12,236,723.87 USCC ([Superstate NAV dataset](https://superstate.com/assets/uscc), September 4, 2026)
+- **Total AUM (incl. book-entry):** $143.48M ([Superstate](https://superstate.com/assets/uscc), September 4, 2026)
+- **Public TVL:** $103.41M ([DeFiLlama](https://defillama.com/protocol/bitwise-uscc), September 5, 2026), up 74.3% over 30 days from $59.34M
+- **30-day SEC Yield:** 6.68% (variable, depends on basis spread)
+- **Management Fee:** 0.75% annually
 - **Minimum Investment:** $100,000
+
+**TODO — first-party share reconciliation:** the Bitwise network-distribution table totals 12,849,759.44 shares ($150.67M at the displayed NAV), while the same official dataset reports 12,236,723.87 outstanding shares and $143.48M AUM. The Ethereum, Plume, and Solana rows match current onchain supply; the discrepancy is in the reported book-entry balance and requires clarification from Superstate/Bitwise.
 
 **Links:**
 
 - [Protocol Documentation](https://docs.superstate.com/)
 - [Bitwise USCC Fund Page](https://bitwiseinvestments.com/crypto-funds/uscc)
-- [Bitwise USCC Fact Sheet](https://s3.us-east-1.amazonaws.com/static.bitwiseinvestments.com/uscc/bitwise-crypto-carry-fund-uscc-fact-sheet.pdf)
+- [Bitwise USCC Fact Sheet](https://bitwise-materials.s3.us-east-1.amazonaws.com/public/fact-sheets/private_uscc.pdf)
 - [USCC Fund Info](https://superstate.com/assets/uscc)
-- [USCC Docs Page](https://docs.superstate.com/superstate-funds/uscc)
+- [USCC Docs Page](https://docs.superstate.com/investors/tokenized-funds/available-funds/bitwise-uscc)
 - [Smart Contract Addresses](https://docs.superstate.com/investors/smart-contracts)
-- [Security Documentation](https://docs.superstate.com/welcome-to-superstate/security)
+- [Security Documentation](https://docs.superstate.com/investors/security)
 - [GitHub (USTB/USCC contracts)](https://github.com/superstateinc/ustb)
 - [DeFiLlama](https://defillama.com/protocol/bitwise-uscc)
 - [Etherscan Token Page](https://etherscan.io/token/0x14d60E7FDC0D71d8611742720E4C50E7a974020c)
@@ -44,21 +46,23 @@ Investors must clear KYC/AML, be Qualified Purchasers and Accredited Investors, 
 
 ## Contract Addresses
 
-*Core addresses and owner roles re-verified onchain Jul 3, 2026.*
+*Snapshot date: September 5, 2026.*
 
 | Contract | Address |
 |----------|---------|
 | USCC Token (Proxy) | [`0x14d60E7FDC0D71d8611742720E4C50E7a974020c`](https://etherscan.io/address/0x14d60E7FDC0D71d8611742720E4C50E7a974020c) |
-| USCC Implementation (SuperstateTokenV5, `VERSION "5"`) | [`0x9b7282Cb80baA4B1F8F6436f8D531B436BaE2A70`](https://etherscan.io/address/0x9b7282Cb80baA4B1F8F6436f8D531B436BaE2A70) |
+| USCC Implementation (`FundToken`, `VERSION "1.3.0"`) | [`0x7e906c0006d3F08bE94EF4685c59b5Cde4fb4feF`](https://etherscan.io/address/0x7e906c0006d3F08bE94EF4685c59b5Cde4fb4feF) |
 | USCC ProxyAdmin | [`0x2Bb7B8B4dF7fD96baF7CB9a2Ce9e292eCd5BAF3D`](https://etherscan.io/address/0x2Bb7B8B4dF7fD96baF7CB9a2Ce9e292eCd5BAF3D) |
 | AllowList V3.1 (Proxy, **shared with USTB**) | [`0x02f1fA8B196d21c7b733EB2700B825611d8A38E5`](https://etherscan.io/address/0x02f1fA8B196d21c7b733EB2700B825611d8A38E5) |
+| AllowList Implementation (`VERSION "3.1"`) | [`0x2f67d98bd20D9580F52Efa5FF70EDaEd9F2f316D`](https://etherscan.io/address/0x2f67d98bd20D9580F52Efa5FF70EDaEd9F2f316D) |
+| AllowList ProxyAdmin | [`0xb819692a58db9dd4d3b403a875439b6ca155c610`](https://etherscan.io/address/0xb819692a58db9dd4d3b403a875439b6ca155c610) |
 | Chainlink USCC NAV Oracle (OffchainAggregator wrapper) | [`0xAfFd8F5578E8590665de561bdE9E7BAdb99300d9`](https://etherscan.io/address/0xAfFd8F5578E8590665de561bdE9E7BAdb99300d9) |
 | Chainlink USCC Aggregator (OCR-style) | [`0x5C00518D3d423EC59D553Af123Be8a63B11078CF`](https://etherscan.io/address/0x5C00518D3d423EC59D553Af123Be8a63B11078CF) |
 | Aggregator owner (Chainlink-controlled) | [`0x21f73D42Eb58Ba49dDB685dc29D3bF5c0f0373CA`](https://etherscan.io/address/0x21f73D42Eb58Ba49dDB685dc29D3bF5c0f0373CA) |
 
 ### Owner Addresses
 
-Verified onchain Jul 3, 2026. **All Superstate-controlled admin keys are EOAs**:
+As of September 5, 2026, **all Superstate-controlled admin keys are EOAs**:
 
 Onchain, these owners are plain EOAs. Superstate states that admin keys use Turnkey secure enclaves, but that is an offchain operational control and cannot be independently verified from Ethereum contract state. This report therefore scores the owner addresses as EOAs for governance purposes; any MPC / TEE / Turnkey protection is treated only as an offchain mitigation.
 
@@ -72,29 +76,35 @@ Note that the prior USCC owner was [`0x8c7db8a96d39f76d9f456db23d591c2fdd0e2f8a`
 
 ## Audits and Due Diligence Disclosures
 
-USCC reuses the same SuperstateTokenV5 implementation family as USTB and the same shared AllowList V3.1 contract, so the audit surface overlaps substantially. Per the [Superstate Security page](https://docs.superstate.com/welcome-to-superstate/security) (as exposed via `llms-full.txt`), Superstate has commissioned **11 numbered 0xMacro audits**, plus a ChainSecurity audit and Offside Labs Solana audit. **Certora formal verification is referenced in the broader Security overview**, but USCC-specific findings are not enumerated separately.
+USCC uses the source-verified `FundToken` v1.3.0 implementation and the same shared AllowList V3.1 contract as USTB. The [Superstate Security page](https://docs.superstate.com/investors/security) lists **11 numbered 0xMacro audits**, plus ChainSecurity, Solana/AllowList reviews, and a Certora formal-verification report. Earlier 0xMacro scopes cover USCC/SuperstateToken, redemption, the shared token components, and AllowList V3; however, the published audit list does not map a report explicitly to the integrated `FundToken` v1.2.0/v1.3.0 implementation deployed in July 2026. A-10 and A-11 scope DIP/EquityToken rather than `FundToken`.
+
+**TODO — current implementation audit mapping:** obtain a public audit report or hash-to-scope mapping for `FundToken` v1.2.0/v1.3.0. The implementation is source-verified, and much of its component surface has prior review coverage, but an independent review of the deployed integration and storage migration cannot be confirmed from the published audit scopes.
 
 ### Audit History
 
 | # | Firm | Approx. Date | Scope |
 |---|------|---|---|
-| A-1..9 | **0xMacro** | Jul 2024 – Jul 2025 | Token + Redemption + AllowList across V1→V3.1 — see [USTB report](https://github.com/yearn/risk-score/blob/master/reports/report/superstate-ustb.md) for individual findings |
-| A-10 | **0xMacro** | Jul 2024 - Nov 2025 | [0xmacro.com/library/audits/superstate-10](https://0xmacro.com/library/audits/superstate-10) |
-| A-11 | **0xMacro** | Feb 2026 | [0xmacro.com/library/audits/superstate-11](https://0xmacro.com/library/audits/superstate-11) |
+| A-1..6 | **0xMacro** | 2023–2025 | SuperstateToken / USCC, oracle, subscription, and redemption iterations — see [individual reports](https://0xmacro.com/library/audits/superstate-2) and the [USTB report](https://github.com/yearn/risk-score/blob/master/reports/report/superstate-ustb.md) |
+| A-7 | **0xMacro** | 2025 | Solana AllowList program |
+| A-8 | **0xMacro** | 2025 | EquityToken plus shared `AccountingPausable`, `Allowlistable`, `Bridgeable`, `Permittable`, and `SuperstateTokenCore` components |
+| A-9 | **0xMacro** | 2025 | AllowList V3 |
+| A-10..11 | **0xMacro** | Nov 2025 – Feb 2026 | DIP / EquityToken scopes; not the current integrated `FundToken` ([A-10](https://0xmacro.com/library/audits/superstate-10), [A-11](https://0xmacro.com/library/audits/superstate-11)) |
 | -- | **ChainSecurity** | 2023 | [Compound SUPTB (original USTB token)](https://chainsecurity.com/security-audit/compound-suptb/) |
 | -- | **Certora** | April 2025 | [Formal verification](https://1275722710-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FvEZgAuuCGOpJUFqcgO0l%2Fuploads%2Fv0ktODEvUrKfIVnyeNkN%2FSuperstat%20audit%20report%20by%20Certora.pdf?alt=media&token=4d2af22c-57cc-4c0d-a11e-6867a48049e7) |
 
-**Smart Contract Complexity:** Moderate. Standard upgradeable EIP-1967 transparent proxy (legacy storage slot pattern: implementation accessible via `ProxyAdmin.getProxyImplementation`, not the canonical EIP-1967 slot). ERC-20 with AllowList-gated transfers, `Ownable2StepUpgradeable` access, cross-chain bridging via burn-and-mint to Solana (Token-2022) and Plume.
+**Smart Contract Complexity:** Moderate. Standard upgradeable EIP-1967 transparent proxy with canonical implementation/admin slots, ERC-7201 namespaced component storage in `FundToken` v1.3.0, AllowList-gated transfers, `Ownable2StepUpgradeable` access, EIP-2612 permit, and issuer-operated burn-and-mint bridging between the EVM deployments.
 
-A key observation onchain: **USCC has a strict subset of the V5 token's capabilities enabled**:
+A key observation onchain: **USCC has a strict subset of the current FundToken's capabilities enabled**:
 
 - `superstateOracle() = 0x0` — no Superstate Continuous Price Oracle attached
 - `redemptionContract() = 0x0` — no RedemptionIdle / atomic onchain redemption
 - `supportedStablecoins(USDC) = 0x0` — no onchain stablecoin subscribe config
-- `supportedChainIds(1) = false` - bridging destinations all return `false` via the `uint256` getter
+- `isChainIdSupported(0) = true` — book-entry conversion is enabled
+- `isChainIdSupported(98866) = true` — Plume is the only enabled onchain destination from Ethereum
+- `isChainIdSupported(900) = false` — Solana is not an enabled destination; Superstate's documentation says SVM bridging is unsupported and requires redeeming/re-purchasing to change networks
 - `subscribe()` - reverts with `OnchainSubscriptionsDisabled()` (selector `0xdbf0cc51`)
 
-So **all USCC mint operations are admin-driven** (`mint`/`bulkMint` by the owner EOA) and the only onchain user actions are `transfer` (AllowList-gated), `offchainRedeem` (burn, settled offchain T+1), and `bridge` to Solana/Plume.
+So **all USCC mint operations are admin-driven** (`mint`/`bulkMint` by the owner EOA). On Ethereum, user actions are `transfer` (AllowList-gated), `offchainRedeem` (burn, settled offchain T+1/T+2), `bridge` to Plume, and `bridgeToBookEntry`. Solana USCC remains live, but movements to or from Solana use Superstate's offchain redemption/tokenization workflow rather than the EVM `bridge()` path.
 
 ### Bug Bounty
 
@@ -105,16 +115,17 @@ So **all USCC mint operations are admin-driven** (`mint`/`bulkMint` by the owner
 
 ## Historical Track Record
 
-- **Fund Launch:** July 15, 2024 onchain (first mint at [block 20312293](https://etherscan.io/tx/0xeefda6ce766bca7c431bb6ef157b4b78925d9a0a3527a811d2ea54e41485fb1b), Unix ts 1721051099). DeFiLlama [first records Sep 9, 2024](https://defillama.com/protocol/bitwise-uscc) at ~$15.7M TVL. **Nearly 24 months in production** as of Jul 3, 2026.
-- **Contract Upgrades:** Token implementation reports `VERSION "5"`. Earlier USCC versions (V1→V4) were upgraded through the same ProxyAdmin path used by USTB. Each version was audited prior to deployment.
+- **Fund Launch:** July 15, 2024 onchain (first mint at [block 20312293](https://etherscan.io/tx/0xeefda6ce766bca7c431bb6ef157b4b78925d9a0a3527a811d2ea54e41485fb1b), Unix ts 1721051099). DeFiLlama [first records Sep 9, 2024](https://defillama.com/protocol/bitwise-uscc) at ~$15.7M TVL. The fund has now operated for **more than two years**.
+- **Contract Upgrades:** The token moved from the legacy V5 implementation to `FundToken` v1.2.0 on July 20, 2026 ([upgrade](https://etherscan.io/tx/0xe38fb441aa385cfe91eada867aab14698fbf90acd6ef694e72bfadf1f59f0990), [migration initialization](https://etherscan.io/tx/0x87155971d23c3f2200061ff8fa066ea2ae7382c60d9013a67f196ee37659d883)), then to v1.3.0 on July 21, 2026 ([upgrade](https://etherscan.io/tx/0x73b4604e54b163e843f1631d54e329fbaf1b1f036b43a6d2117580beaf0cbcc5)). The migration enabled book-entry conversion and Plume bridging. No ownership, oracle, redemption, stablecoin-config, pause, accounting-pause, or `AdminBurn` changes were observed since the prior assessment.
 - **Smart Contract Exploits:** None reported.
-- **Ownership Changes:** USCC token ownership was transferred Oct 31, 2024 from [`0x8c7db8a9…`](https://etherscan.io/address/0x8c7db8a96d39f76d9f456db23d591c2fdd0e2f8a) to [`0x8abC89D9…`](https://etherscan.io/address/0x8abC89D9b56dFD90dA18e8E18CFaC9111100bDd1) via the two-step Ownable flow ([Etherscan tx](https://etherscan.io/tx/0xd2d1c711f5f7ecf9053637145d218e33f0b22d2d26d59a63d94535e88ca46c72)).
+- **Ownership Changes:** USCC token ownership was transferred Oct 31, 2024 from [`0x8c7db8a9…`](https://etherscan.io/address/0x8c7db8a96d39f76d9f456db23d591c2fdd0e2f8a) to [`0x8abC89D9…`](https://etherscan.io/address/0x8abC89D9b56dFD90dA18e8E18CFaC9111100bDd1) via the two-step Ownable flow ([Etherscan tx](https://etherscan.io/tx/0xd2d1c711f5f7ecf9053637145d218e33f0b22d2d26d59a63d94535e88ca46c72)); no subsequent transfer was observed.
 - **TVL History ([DeFiLlama](https://defillama.com/protocol/bitwise-uscc)):**
   - Sep 2024 (first record): ~$15.7M
   - Oct 2024: ~$27M
   - Nov 21, 2025 peak: ~$496.61M
-  - Jul 3, 2026: ~$136.18M public TVL; Superstate reports $162.79M AUM including book-entry
-- **NAV History:** NAV launched near $10.00, sits at $11.628080 as of the latest Chainlink USCC round (updated Jul 2, 2026 13:10 UTC; verified Jul 3, 2026). Unlike USTB, NAV is **not monotonic** — the protocol's own docs warn that "daily NAV reflects mark-to-market gains and losses, including unrealized valuation changes" and that basis expansion can produce temporary NAV declines.
+  - Aug 8, 2026: ~$59.34M
+  - Sep 5, 2026: ~$103.41M public TVL; Superstate reports $143.48M AUM including book-entry
+- **NAV History:** NAV launched near $10.00 and is $11.725624 in the latest Chainlink round (updated September 4, 2026 13:18 UTC). Unlike USTB, NAV is **not monotonic**: mark-to-market gains and losses, including unrealized changes, flow through daily NAV.
 - **Incidents:** None publicly reported.
 
 ## Funds Management
@@ -127,25 +138,27 @@ So **all USCC mint operations are admin-driven** (`mint`/`bulkMint` by the owner
 
 The fund "will trade only those digital assets for which the CFTC has permitted exchange-listed futures contracts" (per [Steakhouse overview](https://kitchen.steakhouse.financial/p/overview-of-uscc)). Bitwise's current public holdings identify CME and Coinbase futures exposure, but the public documents still do not fully disclose margin policy, counterparty concentration limits, or whether the displayed venues are exhaustive over time.
 
-**Public holdings snapshot:** Bitwise publishes current USCC holdings on its [USCC fund page](https://bitwiseinvestments.com/crypto-funds/uscc). The table below uses the public holdings shown there as of **Jun 28, 2026 4pm EDT**. Holdings are unaudited and may change at the investment manager's discretion; refresh this table from the Bitwise page during the next reassessment.
+**Public holdings snapshot:** Bitwise publishes current USCC holdings on its [USCC fund page](https://bitwiseinvestments.com/crypto-funds/uscc). The table below uses the public holdings shown there as of **September 4, 2026**. Holdings are unaudited and may change at the investment manager's discretion.
 
 | Holding | Quantity | Implied Yield | Notional Value | Portfolio % | Notes |
 |---------|---------:|--------------:|---------------:|------------:|-------|
-| USD Collateral | 32,267,833.00 | 0.82% | $32.27M | 19.45% | Cash / margin collateral |
-| USTB | 2,796,828.74 | 3.47% | $31.13M | 18.76% | Tokenized T-Bill exposure |
-| Bitcoin Custody | 39.20 BTC | 0.00% | $2.37M | 1.43% | Spot crypto custody |
-| Ether Custody | 2,350.99 ETH | 0.00% | $3.82M | 2.30% | Spot crypto custody |
-| Solana Custody | 7,578.53 SOL | 0.00% | $0.57M | 0.35% | Spot crypto custody |
-| Solana Staked | 439,118.49 SOL | 6.29% | $33.31M | 20.08% | Staking / validator risk |
-| EtherFi Wrapped eETH | 17,801.49 weETH | 2.49% | $31.73M | 19.12% | Liquid-staking-token risk |
-| Ripple Custody | 28,631,438.36 XRP | 0.00% | $30.72M | 18.52% | Spot crypto custody |
-| JitoSOL Custody | 4.02 JitoSOL | 5.68% | $393 | 0.00% | Small liquid-staking-token position |
-| SOL JUL26 75 Call (CME) | 6,000.00 | 0.00% | $42,300 | 0.03% | Option exposure |
-| BTC Future JUL26 (CME) | -35.00 | 3.00% | -$2.13M | -1.28% | Short futures hedge |
-| ETH Future JUL26 (CME) | -21,600.00 | 2.93% | -$35.14M | -21.18% | Short futures hedge |
-| SOL Future JUL26 (CME) | -445,000.00 | 2.91% | -$33.84M | -20.40% | Short futures hedge |
-| XRP Future JUL26 (CME) | -27,950,000.00 | 5.41% | -$30.13M | -18.16% | Short futures hedge |
-| XRP Future JUL26 (Coinbase) | -560,000.00 | 9.42% | -$0.61M | -0.37% | Short futures hedge |
+| USD Collateral | 57,540,700.00 | 1.84% | $57.54M | 35.55% | Cash / margin collateral |
+| USTB | 681,058.68 | 3.47% | $7.63M | 4.71% | Tokenized T-Bill exposure |
+| Bitcoin Custody | 267.20 BTC | 0.00% | $21.32M | 13.18% | Spot crypto custody |
+| Bitcoin Collateral | 65.00 BTC | 0.00% | $0 | 0.00% | Reported collateral quantity; no notional assigned in the public table |
+| Ether Custody | 1,267.16 ETH | 0.00% | $3.11M | 1.92% | Spot crypto custody |
+| Ether Collateral | 0 ETH | 0.00% | $0 | 0.00% | — |
+| Solana Custody | -9,318.31 SOL | 0.00% | -$0.95M | -0.59% | Negative custody balance as published |
+| Solana Collateral | 0 SOL | 0.00% | $0 | 0.00% | — |
+| Solana Staked | 196,037.83 SOL | 6.29% | $19.94M | 12.32% | Staking / validator risk |
+| EtherFi Wrapped eETH | 13,501.49 weETH | 2.47% | $36.58M | 22.60% | Liquid-staking-token risk |
+| Ripple Custody | 11,921,438.36 XRP | 0.00% | $16.68M | 10.30% | Spot crypto custody |
+| JitoSOL Custody | 4.02 JitoSOL | 5.53% | $532 | 0.00% | Small liquid-staking-token position |
+| BTC Future SEP26 (Coinbase) | -265.00 | 6.66% | -$21.25M | -13.13% | Short futures hedge |
+| ETH Future SEP26 (Coinbase) | -240.00 | 6.84% | -$0.59M | -0.37% | Short futures hedge |
+| ETH Future SEP26 (CME) | -15,750.00 | 5.75% | -$38.81M | -23.98% | Short futures hedge |
+| SOL Future SEP26 (CME) | -183,500.00 | -0.88% | -$18.65M | -11.52% | Short futures hedge |
+| XRP Future SEP26 (Coinbase) | -11,640,000.00 | 13.93% | -$16.41M | -10.14% | Short futures hedge |
 
 ### Accessibility
 
@@ -168,12 +181,12 @@ The fund "will trade only those digital assets for which the CFTC has permitted 
 
 **Mint requires backing:** **No** — `mint(address,uint256)` and `bulkMint(address[],uint256[])` are gated by `onlyOwner` and do **not** check or pull collateral onchain. Backing exists offchain at Anchorage Digital / Trading Venues and is asserted by the operator. The onchain mint is a unilateral admin action.
 
-**Per-address mint authority** (verified onchain Jul 3, 2026, USCC token [`0x14d60E7FDC0D71d8611742720E4C50E7a974020c`](https://etherscan.io/address/0x14d60E7FDC0D71d8611742720E4C50E7a974020c)):
+**Per-address mint authority** (verified onchain September 5, 2026, USCC token [`0x14d60E7FDC0D71d8611742720E4C50E7a974020c`](https://etherscan.io/address/0x14d60E7FDC0D71d8611742720E4C50E7a974020c)):
 
 | Address | Can Mint | Can Burn | Role / Mechanism | Notes |
 |---------|:--------:|:--------:|------------------|-------|
-| [`0x8abC89D9b56dFD90dA18e8E18CFaC9111100bDd1`](https://etherscan.io/address/0x8abC89D9b56dFD90dA18e8E18CFaC9111100bDd1) | ✓ | ✓ (`adminBurn`) | `owner()` of USCC token (Ownable) | **EOA** (code size 0, nonce 589). Same EOA is `owner()` of USCC ProxyAdmin, so it can also `upgrade()` the implementation to a malicious one and effectively grant mint power to anyone. |
-| (no other onchain minters) | — | — | — | The V5 token contract has no `AccessControl` / `MINTER_ROLE`; `hasRole(...)` reverts. |
+| [`0x8abC89D9b56dFD90dA18e8E18CFaC9111100bDd1`](https://etherscan.io/address/0x8abC89D9b56dFD90dA18e8E18CFaC9111100bDd1) | ✓ | ✓ (`adminBurn`) | `owner()` of USCC token (Ownable) | **EOA** (code size 0, nonce 624). Same EOA is `owner()` of USCC ProxyAdmin, so it can also `upgrade()` the implementation to a malicious one and effectively grant mint power to anyone. |
+| (no other onchain minters) | — | — | — | The current `FundToken` contract has no `AccessControl` / `MINTER_ROLE`; minting remains owner-only. |
 
 **Rate limits / supply caps:** None onchain. There is no `maxMintPerBlock`, no global supply cap, no per-minter quota.
 
@@ -191,7 +204,7 @@ The fund "will trade only those digital assets for which the CFTC has permitted 
   - **Futures-leg margin posted at trading venues is the dominant counterparty risk** — if a futures venue becomes insolvent or fails operationally, the margin and any unrealized P&L on that venue is at risk. CFTC-regulated futures clearinghouses (CME-style) significantly reduce this risk vs offshore venues, but Superstate still does not publicly disclose full counterparty concentration or margin policy.
   - Basis-trade losses flow through NAV. If futures basis widens, futures positions are forcibly unwound, or posted margin is impaired, USCC holders can realize losses on principal.
 - **Manager / Sub-Advisor:**
-  - **Investment manager:** **Bitwise Investment Manager, LLC** ([per superstate.com/assets/uscc](https://superstate.com/assets/uscc), accessed Jul 3, 2026)
+  - **Investment manager:** **Bitwise Investment Manager, LLC** ([per superstate.com/assets/uscc](https://superstate.com/assets/uscc), accessed September 5, 2026)
   - **Sub-advisor:** **Superstate Advisers LLC**
   - This is a recent operational change from the prior Superstate self-managed setup and should continue to be monitored post-transition.
 - **Bankruptcy Remoteness:** Fund is a series within **Superstate Asset Trust** (Delaware Statutory Trust) with inter-series liability protection — bankruptcy-remote from Superstate Inc.
@@ -206,6 +219,7 @@ The fund "will trade only those digital assets for which the CFTC has permitted 
   - Anchorage Digital (regulated digital-asset custody)
   - SEC regulatory framework (Reg D / Section 3(c)(7))
 - **Reserve Transparency:** Bitwise publishes headline NAV/AUM/yield, network balances, DeFi integrations, and current holdings on [bitwiseinvestments.com/crypto-funds/uscc](https://bitwiseinvestments.com/crypto-funds/uscc). Public holdings now include asset quantities, implied yields, notional values, portfolio weights, and current futures venues, but margin balances, counterparty concentration policy, historical venue usage, and T-Bill / USTB look-through details are still not fully disclosed publicly.
+- **Reconciliation Limitation:** The first-party network-distribution total exceeds the first-party outstanding-share total by 613,035.57 shares. Until Bitwise/Superstate reconciles those figures, public reserve and supply reporting cannot be treated as fully internally consistent.
 - **NAV Mark-to-Market Risk:** Because the futures leg is mark-to-market daily, the share price reflects unrealized basis-trade P&L in real time. The protocol explicitly warns of "unrealized losses" during basis expansion. This is fundamentally different from USTB whose underlying T-Bills have a much smoother mark-to-market profile.
 
 ## Liquidity Risk
@@ -214,7 +228,7 @@ The fund "will trade only those digital assets for which the CFTC has permitted 
 - **No Onchain Atomic Redemption:** Verified onchain: `redemptionContract() = 0x0`. There is no USDC-backed RedemptionIdle contract like USTB has — **USCC has zero instant onchain exit capacity at any size**.
 - **No DEX Liquidity:** $0 DEX volume by design. AllowList-gated transfers prevent secondary markets.
 - **Transfer Restrictions:** All transfers require both sender and receiver to be on the AllowList (the same shared V3.1 contract as USTB). Removing an address from the AllowList freezes their tokens.
-- **DeFi Integrations:** Smaller than USTB but live. Bitwise reports USCC support in Aave on Ethereum (~4.60M USCC / $53.47M TVL), Kamino on Solana (~652k USCC / $7.58M TVL), and Morpho on Ethereum (de minimis USCC) as of Jul 2, 2026.  Active [Morpho Market](https://app.morpho.org/ethereum/market/0x1a9ccaca2dba9469cd9cba3d077466761b05f465c412d2bf2c71614c4963dd84/uscc-usdc#market) but without borrowing TVL on July 3, 2026.
+- **DeFi Integrations:** Smaller than USTB but live. Bitwise reports Aave on Ethereum (4.35M USCC / $51.01M), Kamino on Solana (378,573 USCC / $4.44M), and two de minimis Morpho positions on Ethereum as of September 5, 2026. See the active [Morpho market](https://app.morpho.org/ethereum/market/0x1a9ccaca2dba9469cd9cba3d077466761b05f465c412d2bf2c71614c4963dd84/uscc-usdc#market). RWA.xyz reports 53 wallets holding USCC across networks; Etherscan reports 46 Ethereum holders.
 - **Stress Scenario:** In a basis-blowup scenario (futures premium collapse, exchange counterparty event, staking / liquid-staking impairment, or simultaneous redemption surge), the fund's liquidity depends on (a) unwinding futures positions at potentially worse-than-market prices, (b) Anchorage's and related venues' ability to deliver spot / staked assets, and (c) the futures venues' ability to honor margin. T-Bills and USTB are highly liquid; major spot crypto is normally liquid but can gap during stress; futures positions can become illiquid during stress because basis spreads can widen materially before they converge. **The mark-to-market NAV will reflect this stress in real time, potentially producing principal losses for holders and realized losses for users redeeming through the offchain settlement window.**
 
 ### AllowList Freeze Risk (Critical for DeFi Integrations)
@@ -234,11 +248,11 @@ The only recovery is to be re-whitelisted by Superstate or have Superstate `admi
 
 **Governance Model:** Fully centralized — Superstate Inc. controls all administrative functions. No onchain governance, no DAO, no community voting.
 
-**Key Privileged Roles (verified onchain, Jul 3, 2026):**
+**Key Privileged Roles (verified onchain, September 5, 2026):**
 
 | Role | Address | Type | Powers |
 |------|---------|------|--------|
-| USCC Token Owner + USCC ProxyAdmin Owner | [`0x8abC89D9b56dFD90dA18e8E18CFaC9111100bDd1`](https://etherscan.io/address/0x8abC89D9b56dFD90dA18e8E18CFaC9111100bDd1) | **EOA** | `mint`, `bulkMint`, `adminBurn`, `pause`/`unpause`, `accountingPause`/`accountingUnpause`, `setOracle`, `setRedemptionContract`, `setStablecoinConfig`, `setChainIdSupport`, `setMaximumOracleDelay`, and `upgrade()`/`upgradeAndCall()` of the USCC implementation via ProxyAdmin. **This single EOA controls both the token and its proxy admin**, matching the USTB token/ProxyAdmin ownership pattern rather than improving on it. |
+| USCC Token Owner + USCC ProxyAdmin Owner | [`0x8abC89D9b56dFD90dA18e8E18CFaC9111100bDd1`](https://etherscan.io/address/0x8abC89D9b56dFD90dA18e8E18CFaC9111100bDd1) | **EOA** | `mint`, `bulkMint`, `adminBurn`, `pause`/`unpause`, `accountingPause`/`accountingUnpause`, `setOracle`, `setRedemptionContract`, `setStablecoinConfig`, `setChainIdSupport`, `setMaximumOracleDelay`, `setAllowlist`, `setIsPublicInstrument`, `setName`, `setSymbol`, and `upgrade()`/`upgradeAndCall()` of the USCC implementation via ProxyAdmin. **This single EOA controls both the token and its proxy admin**, matching the USTB token/ProxyAdmin ownership pattern rather than improving on it. |
 | AllowList Owner (shared with USTB) | [`0x7747940aDBc7191f877a9B90596E0DA4f8deb2Fe`](https://etherscan.io/address/0x7747940aDBc7191f877a9B90596E0DA4f8deb2Fe) | **EOA** | `setEntityIdForAddress`, `setProtocolAddressPermission`, etc. Can also upgrade AllowList via its ProxyAdmin. |
 | Chainlink USCC NAV Aggregator Owner | [`0x21f73D42Eb58Ba49dDB685dc29D3bF5c0f0373CA`](https://etherscan.io/address/0x21f73D42Eb58Ba49dDB685dc29D3bF5c0f0373CA) | **Chainlink contract** | Chainlink-side governance over the OCR feed; not Superstate-controlled. |
 
@@ -264,7 +278,7 @@ The only recovery is to be re-whitelisted by Superstate or have Superstate `admi
 - **Subscriptions:** Admin-driven (`mint`/`bulkMint` only). Onchain user `subscribe()` is explicitly disabled (`OnchainSubscriptionsDisabled()`).
 - **Redemptions:** User-initiated burn (`offchainRedeem`) is onchain and programmatic, but settlement is offchain (T+1/T+2). No atomic onchain payout.
 - **Transfers:** AllowList enforcement on every transfer (onchain and programmatic).
-- **Bridging:** Burn-and-mint to Solana (Token-2022) and Plume via `bridge()` — programmatic per chain, but only enabled chain IDs are mintable destinations.
+- **Bridging:** The issuer-operated burn-and-mint path is enabled from Ethereum to Plume (`chainId 98866`). Book-entry conversion is also enabled. Solana has live supply, but Superstate documents SVM bridging as unsupported; changing between EVM and Solana requires offchain redemption and re-tokenization.
 
 USCC is materially **less programmatic than USTB**: no atomic onchain subscribe, no atomic onchain redeem.
 
@@ -303,7 +317,7 @@ USCC is materially **less programmatic than USTB**: no atomic onchain subscribe,
 | Contract | Address | Purpose | Key Events / Functions |
 |----------|---------|---------|------------------------|
 | USCC Token | [`0x14d60E7FDC0D71d8611742720E4C50E7a974020c`](https://etherscan.io/address/0x14d60E7FDC0D71d8611742720E4C50E7a974020c) | Token state | `Mint`, `AdminBurn`, `OffchainRedeem`, `Bridge`, `BridgeToBookEntry`, `Paused`/`Unpaused`, `AccountingPaused`/`AccountingUnpaused`, `SetOracle`, `SetRedemptionContract`, `SetStablecoinConfig`, `SetChainIdSupport`, `OwnershipTransferStarted`, `totalSupply()` |
-| USCC ProxyAdmin | [`0x2Bb7B8B4dF7fD96baF7CB9a2Ce9e292eCd5BAF3D`](https://etherscan.io/address/0x2Bb7B8B4dF7fD96baF7CB9a2Ce9e292eCd5BAF3D) | USCC proxy upgrades | `Upgraded` event on the USCC proxy; `OwnershipTransferred` on the ProxyAdmin |
+| USCC ProxyAdmin | [`0x2Bb7B8B4dF7fD96baF7CB9a2Ce9e292eCd5BAF3D`](https://etherscan.io/address/0x2Bb7B8B4dF7fD96baF7CB9a2Ce9e292eCd5BAF3D) | USCC proxy upgrades | `Upgraded` event on the USCC proxy; implementation slot; `OwnershipTransferred` on the ProxyAdmin |
 | AllowList V3.1 (shared) | [`0x02f1fA8B196d21c7b733EB2700B825611d8A38E5`](https://etherscan.io/address/0x02f1fA8B196d21c7b733EB2700B825611d8A38E5) | Permission changes | `EntityIdSet`, `ProtocolAddressPermissionSet`, `PrivateInstrumentPermissionSet` |
 | Chainlink USCC NAV Oracle wrapper | [`0xAfFd8F5578E8590665de561bdE9E7BAdb99300d9`](https://etherscan.io/address/0xAfFd8F5578E8590665de561bdE9E7BAdb99300d9) | NAV reporting | `AnswerUpdated`, `latestRoundData()` |
 | Chainlink USCC Aggregator | [`0x5C00518D3d423EC59D553Af123Be8a63B11078CF`](https://etherscan.io/address/0x5C00518D3d423EC59D553Af123Be8a63B11078CF) | OCR transmission | `NewTransmission`, `ConfigSet` |
@@ -320,7 +334,7 @@ USCC is materially **less programmatic than USTB**: no atomic onchain subscribe,
 - **NAV/Share:** Read the Chainlink USCC feed every transmission. Unlike USTB, NAV **may decrease** during basis stress — alert on day-over-day declines >2% to investigate whether it reflects market mark-to-market or an attestation issue.
 - **Admin Burns:** Monitor `AdminBurn` events — forced burns from holder addresses are critical.
 - **Pause Events:** Monitor `Paused`/`Unpaused` and `AccountingPaused`/`AccountingUnpaused` on USCC token.
-- **Contract Upgrades:** Monitor USCC ProxyAdmin [`0x2Bb7B8B4dF7fD96baF7CB9a2Ce9e292eCd5BAF3D`](https://etherscan.io/address/0x2Bb7B8B4dF7fD96baF7CB9a2Ce9e292eCd5BAF3D) for `Upgraded` events. **No timelock — upgrades are instant.**
+- **Contract Upgrades:** Monitor `Upgraded` events and the canonical EIP-1967 implementation slot on USCC. The July 20–21 migration changed the implementation twice without a timelock; upgrades are instant.
 - **AllowList Changes:** Monitor `ProtocolAddressPermissionSet` events on the shared AllowList for revocation of any contract holding USCC.
 - **Ownership Transfers:** Monitor `OwnershipTransferStarted` on USCC token and ProxyAdmin.
 - **Large Supply Changes:** Alert on mints/burns >5% of total supply in 24h.
@@ -329,7 +343,7 @@ USCC is materially **less programmatic than USTB**: no atomic onchain subscribe,
 
 ## Appendix: Contract Architecture
 
-*Verified onchain Jul 3, 2026. All Superstate-controlled owners are EOAs (code size 0). No multisig, no timelock on any contract.*
+*Verified onchain September 5, 2026. All Superstate-controlled owners are EOAs (code size 0). No multisig or timelock controls the token or AllowList upgrade paths.*
 
 ```
 GOVERNANCE LAYER
@@ -349,7 +363,7 @@ PROXY ADMIN LAYER
 ═════════════════
   [PA-USCC]   USCC ProxyAdmin (owned by [EOA-USCC])
               0x2Bb7B8B4dF7fD96baF7CB9a2Ce9e292eCd5BAF3D
-              ── upgrade(USCC proxy) → impl 0x9b7282Cb…
+              ── upgrade(USCC proxy) → impl 0x7e906c00…
 
   [PA-AL]     AllowList ProxyAdmin (separate; verified for USTB)
               0xb819692a58db9dd4d3b403a875439b6ca155c610
@@ -359,8 +373,8 @@ TOKEN LAYER
 ═══════════
   [USCC]   USCC Token (Proxy)
            0x14d60E7FDC0D71d8611742720E4C50E7a974020c
-           impl: 0x9b7282Cb80baA4B1F8F6436f8D531B436BaE2A70
-           VERSION "5" (SuperstateTokenV5 family)
+           impl: 0x7e906c0006d3F08bE94EF4685c59b5Cde4fb4feF
+           VERSION "1.3.0" (FundToken; ERC-7201 component storage)
 
            Admin (owner [EOA-USCC] only):
            ├── mint() / bulkMint()      ← no onchain backing check
@@ -411,9 +425,11 @@ EXTERNAL / UNDERLYING LAYER
   ├── NAV Fund Services (NAV calculation agent)
   └── U.S. Treasury Bills (reserves)
 
-  Cross-chain destinations (via bridge()):
-  ├── Solana mainnet: Token-2022 BTRR3sj1Bn2ZjuemgbeQ6SCtf84iXS81CS7UDTSxUCaK
-  └── Plume mainnet: 0x4c21b7577c8fe8b0b0669165ee7c8f67fa1454cf
+  Cross-chain state:
+  ├── Plume mainnet via bridge(): 0x4c21b7577c8fe8b0b0669165ee7c8f67fa1454cf
+  │   VERSION 1.3.0; same owner EOA; 1,440,926.89 USCC supply
+  └── Solana Token-2022: BTRR3sj1Bn2ZjuemgbeQ6SCtf84iXS81CS7UDTSxUCaK
+      808,371.22 USCC supply; not bridge-connected per current Superstate docs
 ```
 
 **Address Legend:**
@@ -426,7 +442,7 @@ EXTERNAL / UNDERLYING LAYER
 | [PA-USCC] | [`0x2Bb7B8B4dF7fD96baF7CB9a2Ce9e292eCd5BAF3D`](https://etherscan.io/address/0x2Bb7B8B4dF7fD96baF7CB9a2Ce9e292eCd5BAF3D) |
 | [PA-AL] | [`0xb819692a58db9dd4d3b403a875439b6ca155c610`](https://etherscan.io/address/0xb819692a58db9dd4d3b403a875439b6ca155c610) |
 | [USCC] Token (Proxy) | [`0x14d60E7FDC0D71d8611742720E4C50E7a974020c`](https://etherscan.io/address/0x14d60E7FDC0D71d8611742720E4C50E7a974020c) |
-| USCC Implementation | [`0x9b7282Cb80baA4B1F8F6436f8D531B436BaE2A70`](https://etherscan.io/address/0x9b7282Cb80baA4B1F8F6436f8D531B436BaE2A70) |
+| USCC Implementation | [`0x7e906c0006d3F08bE94EF4685c59b5Cde4fb4feF`](https://etherscan.io/address/0x7e906c0006d3F08bE94EF4685c59b5Cde4fb4feF) |
 | [AL] AllowList V3.1 (Proxy) | [`0x02f1fA8B196d21c7b733EB2700B825611d8A38E5`](https://etherscan.io/address/0x02f1fA8B196d21c7b733EB2700B825611d8A38E5) |
 | [CL] Chainlink USCC NAV | [`0xAfFd8F5578E8590665de561bdE9E7BAdb99300d9`](https://etherscan.io/address/0xAfFd8F5578E8590665de561bdE9E7BAdb99300d9) |
 | Chainlink USCC Aggregator | [`0x5C00518D3d423EC59D553Af123Be8a63B11078CF`](https://etherscan.io/address/0x5C00518D3d423EC59D553Af123Be8a63B11078CF) |
@@ -438,10 +454,10 @@ EXTERNAL / UNDERLYING LAYER
 ### Key Strengths
 
 1. **Institutional service-provider stack** — Anchorage Digital (OCC-regulated custodian for digital assets), Ernst & Young (auditor), NAV Fund Services (independent NAV), and Bitwise Investment Manager as current investment manager.
-2. **Heavy audit coverage** — 11 0xMacro audits + ChainSecurity + Offside Labs + referenced Certora formal verification across the SuperstateTokenV5 family that USCC reuses.
+2. **Substantial audit coverage** — 11 0xMacro reviews plus ChainSecurity, Solana/AllowList reviews, and Certora verification cover earlier token versions and shared components; the current FundToken integration still needs an explicit public scope mapping.
 3. **Bankruptcy-remote legal structure** — Delaware Statutory Trust series with inter-series liability protection; Reg D / 3(c)(7) regulatory framework; SEC-registered transfer agent.
 4. **Strong team and backing** — Compound Finance founders, $100.5M raised; Bain Capital Crypto / Brevan Howard / Galaxy / Haun Ventures.
-5. **Nearly 24 months in production** — incident-free operational history since Jul 2024.
+5. **More than two years in production** — incident-free operational history since July 2024.
 6. **Same shared AllowList as USTB** — code reuse with USTB's longer operating history.
 
 ### Key Risks
@@ -451,9 +467,11 @@ EXTERNAL / UNDERLYING LAYER
 3. **Opaque counterparty and margin exposure.** Current public holdings identify CME and Coinbase futures exposure, but public docs still do not disclose margin levels, concentration limits, or whether the displayed venues are exhaustive over time. This is the dominant risk and we cannot quantify it from public information.
 4. **No atomic onchain redemption** — `redemptionContract() = 0x0` onchain. Subscribe is also disabled onchain (`OnchainSubscriptionsDisabled`). All mints/redeems flow through offchain operations with T+1/T+2 settlement.
 5. **Sole onchain NAV oracle is Chainlink-OCR-only** — no Superstate-run fallback price feed; between transmissions the onchain price is just stale.
-6. **Small holder base (55 holders in the latest RWA.xyz snapshot; $112.52M Superstate-reported onchain network value, $136.18M DeFiLlama public TVL)** — concentrated, expected for a Qualified-Purchaser permissioned fund but a real exit-liquidity constraint.
-7. **Recent manager transition to Bitwise effective Jun 1, 2026** — operational change with post-handoff risk.
-8. **No formal bug bounty rewards.**
+6. **Small holder base (53 multi-chain wallets per RWA.xyz; 46 Ethereum holders) and no secondary liquidity** — concentrated, expected for a Qualified-Purchaser permissioned fund but a real exit-liquidity constraint. Public TVL is $103.41M.
+7. **First-party supply reporting does not reconcile.** The network-distribution table exceeds reported outstanding shares by 613,035.57 shares.
+8. **Current implementation audit scope is unclear.** Published reports do not explicitly map to the deployed FundToken v1.2/v1.3 migration.
+9. **Manager transition to Bitwise effective Jun 1, 2026** — operational change with continuing post-handoff risk.
+10. **No formal bug bounty rewards.**
 
 ### Critical Risks
 
@@ -468,97 +486,73 @@ EXTERNAL / UNDERLYING LAYER
 
 ### Critical Risk Gates
 
-- [x] **No audit** → **PASS** — 11 0xMacro audits + ChainSecurity + Offside Labs + referenced Certora formal verification on the shared V5 codebase.
-- [x] **Unverifiable reserves** → **BORDERLINE PASS** — Offchain reserves (crypto assets at custodians / staking venues + futures margin + T-Bills / cash-equivalent reserves), with NAV Fund Services as independent NAV agent and EY annual audit. Current public holdings are itemized, but margin balances, concentration policy, and full counterparty-risk controls are not publicly verifiable. The multiple independent attestation layers (custodian, NAV agent, auditor, SEC framework) clear the gate.
-- [x] **Total centralization** → **BORDERLINE PASS** — Single EOA controls both the token and its ProxyAdmin, matching USTB's token/ProxyAdmin ownership pattern. Mitigated by Turnkey TEE key custody and Superstate's regulatory accountability (SEC-registered transfer agent, Reg D framework). This is a borderline pass because the absolute single-key blast radius remains high: the same EOA can mint/adminBurn and upgrade the token implementation with no multisig or timelock.
+- [x] **No audit** → **PASS** — the token family and shared components have substantial independent review coverage. The deployed FundToken integration is source-verified, although a public v1.2/v1.3 audit mapping remains a TODO.
+- [x] **Unverifiable reserves** → **BORDERLINE PASS** — NAV Fund Services, EY, regulated custody, and detailed public holdings provide independent layers, but positions and margin cannot be verified onchain and the current first-party share totals do not reconcile.
+- [x] **Total centralization** → **BORDERLINE PASS** — a single EOA controls the token and its ProxyAdmin. Turnkey key-custody claims and regulatory accountability mitigate operational risk but do not reduce the onchain single-key blast radius.
 
-**Result:** Protocol passes critical gates. Proceeding to category scoring with **conservative bias** on governance and provability.
+**Result:** Protocol passes critical gates. Category scoring retains a conservative bias on governance and provability.
 
 ### Category Scores
 
 #### Category 1: Audits & Historical Track Record (Weight: 20%) — **1.75**
 
-**Subcategory A: Audits — 1.5**
+**Subcategory A: Audits — 2.0**
 
-11 0xMacro audits + ChainSecurity + Offside Labs + Certora formal verification on the shared V5 codebase. Continuous audit relationship — each version audited before deployment. The lack of a funded bug bounty with formal monetary rewards prevents a perfect score.
+Earlier token versions, redemption, AllowList, and shared FundToken components have repeated 0xMacro review plus Certora and other specialist work. The score is constrained because no published report explicitly maps to the integrated v1.2.0/v1.3.0 deployment and storage migration, and there is no funded bug bounty.
 
-**Subcategory B: Historical — 2.0**
+**Subcategory B: Historical — 1.5**
 
-- Nearly 24 months in production (launched Jul 15, 2024). Still just shy of the >2-year threshold for a 1 as of Jul 3, 2026.
-- Sustained TVL >$50M (currently $136.18M DeFiLlama public TVL; $162.79M Superstate AUM including book-entry). >$100M only relatively recently. 2 fits the >$50M / 1-2 year band.
-- Clean operational history — no exploits, no admin incidents.
+- More than two years in production since July 15, 2024, with no reported exploit or admin incident.
+- Public TVL is $103.41M and peaked near $496.61M, but fell below $100M during the last month before recovering 74.3%.
+- The combination supports a score between the rubric's mature/high-TVL and 1–2-year/$50M bands.
 
-**Score: (1.5 + 2.0) / 2 = 1.75/5**
+**Score: (2.0 + 1.5) / 2 = 1.75/5**
 
 #### Category 2: Centralization & Control Risks (Weight: 30%) — **3.67**
 
 **Subcategory A: Governance — 5.0**
 
-- **Single EOA controls both USCC token AND its ProxyAdmin** — the same token/ProxyAdmin concentration pattern used by USTB.
-- No multisig anywhere.
-- No timelock on any operation — upgrades, parameter changes, mint, adminBurn all execute immediately.
-- Per the rubric, "EOA or <3 signers" is the level-5 (Critical Gate) governance signal. The fact that the protocol clears the critical gate is on Turnkey TEE + regulatory accountability, not onchain governance.
+- One EOA controls the USCC token and ProxyAdmin, including unlimited mint, admin burn, pause, parameters, and immediate upgrades.
+- There is no multisig or timelock. The July upgrades demonstrate that the path remains active.
+- Turnkey and regulatory controls are offchain mitigations, not onchain authorization constraints.
 
 **Subcategory B: Programmability — 3.0**
 
-- NAV pricing: programmatic via Chainlink OCR, but **value itself is reported by Superstate** to the network. No SuperstateOracle as a second source.
-- Subscriptions: **fully offchain** (onchain `subscribe()` is disabled). All mint operations are admin-driven.
-- Redemptions: user burns onchain (`offchainRedeem`), settlement is offchain T+1/T+2. **No atomic onchain payout.**
-- Transfers: onchain AllowList-gated, programmatic.
-- Bridging: programmatic.
-- Overall: meaningfully less programmatic than USTB (which has both atomic subscribe and atomic redeem). Hybrid onchain/offchain — fits the level-3 description.
+- Chainlink OCR provides programmatic NAV, but the underlying fund value is supplied offchain.
+- Subscriptions are admin-driven; onchain `subscribe()` is disabled.
+- Users burn onchain for redemption, but settlement is offchain T+1/T+2; there is no atomic payout.
+- AllowList-gated transfers and the Ethereum-to-Plume bridge are programmatic.
 
 **Subcategory C: External Dependencies — 3.0**
 
-- Anchorage Digital (critical, single custodian for crypto)
-- Trading Venues for futures (critical; current public holdings identify CME and Coinbase, but concentration / margin policy is not fully public)
-- Bitwise (critical, current investment manager)
-- Chainlink (medium-high — sole onchain NAV oracle)
-- USDC / Circle (medium — redemption rail)
-- Turnkey, Ernst & Young, NAV Fund Services
-- More dependencies than USTB, and they sit in a more failure-prone domain (crypto futures venues).
+Critical dependencies include Anchorage, futures venues, Bitwise, and the Treasury market. Chainlink is the sole onchain NAV oracle; Circle, Turnkey, EY, NAV Fund Services, and staking/liquid-staking infrastructure add further operational dependencies.
 
 **Score: (5.0 + 3.0 + 3.0) / 3 = 3.67/5**
 
-#### Category 3: Funds Management (Weight: 30%) — **3.0**
+#### Category 3: Funds Management (Weight: 30%) — **3.25**
 
 **Subcategory A: Collateralization — 3.0**
 
-- Mixed collateral: USD collateral / USTB / T-Bills (high quality), spot BTC / ETH / SOL / XRP (custodial and market risk), staked SOL / weETH / JitoSOL (staking and liquid-staking risk), and short futures positions (counterparty / margin risk).
-- 100% collateralized in principle but held entirely offchain across multiple counterparties.
-- Anchorage is a strong, regulated custodian for the crypto leg. Current public holdings identify CME and Coinbase futures exposure, but margin balances and concentration policy are not directly verifiable.
-- The basis-trade design is sound under normal market conditions but exposes holders to mark-to-market drawdowns during basis widening.
+The portfolio mixes USD collateral and USTB with custodied crypto, staked/liquid-staked assets, and short futures. It is intended to be fully collateralized but is entirely offchain and exposed to custody, margin, venue, staking, and mark-to-market risk. Current public holdings identify CME and Coinbase exposure but not margin balances or concentration policy.
 
-**Subcategory B: Provability — 3.0**
+**Subcategory B: Provability — 3.5**
 
-- NAV is reported daily via Chainlink (independent feed) and calculated by NAV Fund Services.
-- Annual audit by EY.
-- **Granular risk controls (margin balances, counterparty concentration policy, historical venue usage, and T-Bill maturities) are not fully publicly disclosed** — investor-portal-only or not available in public docs.
+Daily Chainlink NAV, an independent NAV agent, annual EY audit, and detailed holdings are meaningful evidence. However, holders cannot verify positions onchain, material risk controls remain undisclosed, and the first-party network table exceeds the reported outstanding-share total by 613,035.57 shares. That unresolved internal inconsistency warrants a weaker score than the prior assessment.
 
-**Score: (3.0 + 3.0) / 2 = 3.0/5**
+**Score: (3.0 + 3.5) / 2 = 3.25/5**
 
 #### Category 4: Liquidity Risk (Weight: 15%) — **3.5**
 
-- **No atomic onchain redemption at any size** (`redemptionContract() = 0x0`).
-- **No atomic onchain subscription** (`OnchainSubscriptionsDisabled`).
-- Offchain redemption T+1 (or T+2 after 5pm ET) — multi-day notice in practice for any large redemption that requires unwinding futures positions.
-- No DEX liquidity; AllowList-gated transfers.
-- AllowList freeze risk (shared with USTB) — zero exit paths if Superstate revokes permission.
-- Same-value-asset character (USD-denominated fund) somewhat mitigates the multi-day settlement risk per the rubric note, but the mark-to-market NAV means waiting through a basis-widening episode costs holders real money.
-- 43 holders only — very thin secondary-market-equivalent population.
+- No atomic onchain subscribe or redemption at any size.
+- Offchain settlement is T+1/T+2, with no DEX liquidity and AllowList freeze risk.
+- The USD-denominated character partially mitigates settlement delay, while mark-to-market basis exposure can create real losses during the wait.
+- The holder base remains thin: 53 multi-chain wallets and 46 Ethereum holders.
 
 **Score: 3.5/5**
 
 #### Category 5: Operational Risk (Weight: 5%) — **1.5**
 
-- Team fully doxxed, prominent founders (Compound Finance lineage).
-- $100.5M raised from top-tier investors.
-- Service-provider stack: Anchorage Digital, Bitwise, Ernst & Young, NAV Fund Services — all institutional-grade.
-- Documentation is comprehensive on USTB; USCC-specific public documentation still has gaps around leverage, staking / liquid-staking provider policy, counterparty concentration, and margin controls.
-- The Jun 1, 2026 manager transition introduces near-term post-handoff risk.
-- Clear legal structure (Delaware Statutory Trust series, SEC-registered transfer agent).
-
-Slightly worse than USTB (1.0) because of the public documentation gaps on the basis-trade execution and the recent manager transition.
+The doxxed team, financing, legal structure, and institutional service providers are strong. USCC-specific public disclosure remains incomplete around leverage, margin, counterparty concentration, and staking providers, and the June 2026 manager handoff still merits monitoring.
 
 **Score: 1.5/5**
 
@@ -566,18 +560,16 @@ Slightly worse than USTB (1.0) because of the public documentation gaps on the b
 
 | Category | Score | Weight | Weighted |
 |----------|-------|--------|----------|
-| Audits & Historical | 1.75 | 20% | 0.35 |
-| Centralization & Control | 3.67 | 30% | 1.10 |
-| Funds Management | 3.0 | 30% | 0.90 |
+| Audits & Historical | 1.75 | 20% | 0.350 |
+| Centralization & Control | 3.67 | 30% | 1.101 |
+| Funds Management | 3.25 | 30% | 0.975 |
 | Liquidity Risk | 3.5 | 15% | 0.525 |
 | Operational Risk | 1.5 | 5% | 0.075 |
-| **Final Score** | | | **2.95 / 5.0** |
+| **Raw Score** | | | **3.03 / 5.0** |
+| Live >2 years without incidents | | | **-0.50** |
+| **Final Score** | | | **2.53 / 5.0** |
 
-**Optional Modifiers:**
-
-- Live >2 years with no incidents (-0.5): **Not applied** — nearly 24 months as of Jul 3, 2026, still short of 2 years.
-
-After modifier review, final score remains **2.95**. No additional score adjustment is applied; the single-EOA token/ProxyAdmin control and offchain counterparty / margin opacity are already reflected in the Centralization & Control and Funds Management category scores.
+The >2-year incident-free modifier now applies. The resulting improvement is partly offset by the current-implementation audit gap and weaker provability arising from unreconciled first-party share data.
 
 ### Risk Tier
 
@@ -591,32 +583,32 @@ After modifier review, final score remains **2.95**. No additional score adjustm
 
 **Final Risk Tier: MEDIUM RISK**
 
-USCC is materially **higher risk than USTB** despite sharing infrastructure. The principal drivers are (a) the crypto-basis-trade strategy itself, which introduces futures-venue counterparty exposure and mark-to-market NAV volatility, (b) the same single-EOA token/ProxyAdmin control pattern as USTB, with immediate mint/adminBurn/upgrade authority and no timelock, (c) no atomic onchain subscribe or redeem, and (d) thinner public disclosure on operational specifics (counterparty concentration, margin policy, staking / liquid-staking provider policy, leverage). These are partly offset by the same audit/legal/custodial stack as USTB and nearly 24 months of incident-free operation.
+USCC remains materially higher risk than USTB. Its crypto-basis strategy adds futures-venue, staking, custody, and mark-to-market risks to the shared single-EOA and AllowList control model. It has no atomic onchain subscription or redemption. More than two incident-free years improve the score, while the July implementation migration, incomplete audit mapping, and unresolved first-party share reconciliation prevent a stronger result.
 
 **Key conditions for exposure:**
 
-1. Strict size limit reflecting offchain-only redemption (no instant exit).
-2. Monitor [`0x8abC89D9…`](https://etherscan.io/address/0x8abC89D9b56dFD90dA18e8E18CFaC9111100bDd1) for any ownership transfer, mint > 5% of supply, `adminBurn`, or proxy upgrade event.
-3. Monitor the shared AllowList [`0x02f1fA8B…`](https://etherscan.io/address/0x02f1fA8B196d21c7b733EB2700B825611d8A38E5) for any `ProtocolAddressPermissionSet` change affecting Yearn's vault/strategy contract.
-4. Track Chainlink USCC NAV for day-over-day declines >2% (basis-stress signal).
-5. Continue post-transition monitoring after the Bitwise manager handoff (effective Jun 1, 2026).
-6. Continue to demand greater disclosure on margin policy, counterparty concentration, and staking / liquid-staking provider policy before scaling exposure.
+1. Keep a strict size limit reflecting offchain-only redemption.
+2. Monitor the token owner for ownership transfer, mint >5% of supply, `adminBurn`, parameter changes, or proxy upgrades.
+3. Monitor the shared AllowList for permission changes affecting any Yearn vault or strategy.
+4. Track Chainlink USCC NAV for day-over-day declines >2%.
+5. Reconcile first-party total shares against the network-distribution table.
+6. Obtain the deployed FundToken v1.2/v1.3 audit-scope mapping and greater disclosure on margin, counterparties, and staking providers before scaling exposure.
 
-**Score-improving triggers:**
-
-- **Multisig adoption** on USCC token owner / ProxyAdmin owner (would materially improve Centralization score).
-- **Timelock** on contract upgrades and critical parameter changes.
-- **Public disclosure of margin/leverage policy and counterparty concentration limits** (would improve Provability and reduce counterparty opacity).
-- **Chainlink Proof-of-Reserves live** for USCC (would improve Provability).
-- **Atomic onchain redemption** facility (would improve Liquidity).
-- **Formal funded bug bounty.**
+**Score-improving triggers:** multisig and timelock adoption; a published audit mapping for the current implementation; reconciled share/reserve reporting; public margin and concentration limits; Proof of Reserves; atomic onchain redemption; or a funded bug bounty.
 
 ---
 
 ## Reassessment Triggers
 
-- **Time-based:** Reassess in 3 months (Oct 2026) — shorter interval than USTB due to (a) the recent Bitwise manager transition effective Jun 1, 2026, (b) basis-trade NAV volatility warrants more frequent review, and (c) onchain-redemption infrastructure could change.
+- **Time-based:** Reassess in 3 months (December 2026) due to the FundToken migration, the unresolved share reconciliation, basis-trade NAV volatility, and the ongoing Bitwise post-handoff period.
 - **TVL-based:** Reassess if AUM changes by more than 30% (more sensitive than USTB given thinner holder base).
 - **Incident-based:** Reassess after any exploit, admin key compromise, contract upgrade, AllowList policy change, manager transition issue, or any large NAV drawdown (>5% in a single day).
 - **Strategy-based:** Reassess on any change to futures venues, staking / liquid-staking provider policy, leverage policy, or asset mix (e.g., addition of new basis pairs).
 - **Governance-based:** Reassess if Superstate adopts multisig or timelock for USCC admin controls.
+
+## Assessment History
+
+| Date | Score | Notes |
+|------|------:|-------|
+| [July 3, 2026](https://github.com/yearn/risk-score/pull/230) | 2.95 | Initial assessment |
+| [September 5, 2026](https://github.com/yearn/risk-score/pull/PR_NUMBER) | 2.53 | Updated implementation, portfolio, TVL, cross-chain state, and controls |

--- a/reports/report/superstate-uscc.md
+++ b/reports/report/superstate-uscc.md
@@ -25,7 +25,7 @@ Investors must clear KYC/AML, be Qualified Purchasers and Accredited Investors, 
 - **Management Fee:** 0.75% annually
 - **Minimum Investment:** $100,000
 
-**Share-count timing:** the Bitwise network-distribution table is a realtime balance and totals 12,849,759.44 shares as of September 4, while the 12,236,723.87-share AUM statement is effective September 3. Two Ethereum mints on September 4 added 613,035.402635 USCC ([604,173.998756 USCC](https://etherscan.io/tx/0x3273f52b4a2c587d7310a6dcaff5369122fd7387c644c8f1fba5ff986c13e55f) and [8,861.403879 USCC](https://etherscan.io/tx/0xd66e8791290955f2549e3dbc984146d61ca5ca19a6c0089a404c5c9fa85b160f)), explaining all but 0.164482 USCC of the difference. The figures represent different cutoffs rather than a material reserve inconsistency.
+**Share-count timing:** the Bitwise network-distribution table is a realtime balance and totals 12,849,759.44 shares as of September 4, while the 12,236,723.87-share AUM statement is effective September 3. Two Ethereum mints on September 4 added 613,035.402635 USCC ([604,173.998756 USCC](https://etherscan.io/tx/0x3273f52b4a2c587d7310a6dcaff5369122fd7387c644c8f1fba5ff986c13e55f) and [8,861.403879 USCC](https://etherscan.io/tx/0xd66e8791290955f2549e3dbc984146d61ca5ca19a6c0089a404c5c9fa85b160f)), explaining all but 0.167365 USCC of the difference. The figures represent different cutoffs rather than a material reserve inconsistency.
 
 **Links:**
 
@@ -219,7 +219,7 @@ The fund "will trade only those digital assets for which the CFTC has permitted 
   - Anchorage Digital (regulated digital-asset custody)
   - SEC regulatory framework (Reg D / Section 3(c)(7))
 - **Reserve Transparency:** Bitwise publishes headline NAV/AUM/yield, network balances, DeFi integrations, and current holdings on [bitwiseinvestments.com/crypto-funds/uscc](https://bitwiseinvestments.com/crypto-funds/uscc). Public holdings now include asset quantities, implied yields, notional values, portfolio weights, and current futures venues, but margin balances, counterparty concentration policy, historical venue usage, and T-Bill / USTB look-through details are still not fully disclosed publicly.
-- **Share-Supply Reconciliation:** The apparent 613,035.57-share gap is a cutoff difference: the AUM statement is effective September 3, while the realtime network total includes 613,035.402635 USCC minted on Ethereum on September 4. The residual is 0.164482 USCC.
+- **Share-Supply Reconciliation:** The apparent 613,035.57-share gap is a cutoff difference: the AUM statement is effective September 3, while the realtime network total includes 613,035.402635 USCC minted on Ethereum on September 4. The residual is 0.167365 USCC.
 - **NAV Mark-to-Market Risk:** Because the futures leg is mark-to-market daily, the share price reflects unrealized basis-trade P&L in real time. The protocol explicitly warns of "unrealized losses" during basis expansion. This is fundamentally different from USTB whose underlying T-Bills have a much smoother mark-to-market profile.
 
 ## Liquidity Risk

--- a/scripts/check_graphs.mjs
+++ b/scripts/check_graphs.mjs
@@ -37,6 +37,7 @@ export const KNOWN_CHAINS = new Set([
   "sonic",
   "katana",
   "hyperevm",
+  "plume",
 ]);
 
 /**

--- a/src/data/bridges.json
+++ b/src/data/bridges.json
@@ -575,6 +575,30 @@
           "detail": "Primary USDS/sUSDS cross-chain route: ~$0.45B USDS + ~812M sUSDS escrowed on L1 and minted 1:1 on Base, Optimism, Unichain (OP Stack) and Arbitrum (Nitro). No bridge holds `wards` on USDS. LayerZero carries only Solana + Avalanche (<0.7% of mainnet USDS supply)"
         }
       ]
+    },
+    {
+      "id": "superstate-issuer-bridge",
+      "name": "Superstate Issuer Bridge",
+      "type": "Issuer-operated burn-and-mint bridge",
+      "url": "https://docs.superstate.com/investors/tokenized-funds/available-funds/bitwise-uscc",
+      "finality": "No fixed public settlement or destination-mint time is documented.",
+      "admin": "The same Superstate EOA controls the USCC token and ProxyAdmin on Ethereum and Plume, with no multisig or timelock.",
+      "description": "USCC burns on Ethereum for an enabled destination and Superstate completes the corresponding mint on Plume. There is no independent messaging or verifier quorum, so the issuer admin and upgrade keys are the bridge trust boundary. Solana USCC is not connected by this bridge; current documentation requires redemption and re-tokenization for SVM network changes.",
+      "keywords": [
+        "issuer-operated burn-and-mint"
+      ],
+      "ignore": [],
+      "dependencies": [
+        {
+          "slug": "superstate-uscc",
+          "name": "Superstate / Bitwise USCC",
+          "kind": "direct",
+          "model": "mint",
+          "integration": "Ethereum ↔ Plume USCC",
+          "detail": "Ethereum USCC enables chain ID 98866 and burns through `bridge()`; Plume USCC is a native FundToken v1.3.0 deployment. Both token proxies and ProxyAdmins are controlled by the same EOA, with no independent message quorum or onchain rate limit.",
+          "owner": "USCC token + ProxyAdmin owner on Ethereum and Plume: EOA [`0x8abC…bDd1`](https://etherscan.io/address/0x8abC89D9b56dFD90dA18e8E18CFaC9111100bDd1)."
+        }
+      ]
     }
   ]
 }

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -81,6 +81,7 @@ const CHAIN_EXPLORERS: Record<string, string> = {
   sonic: "https://sonicscan.org/address/",
   katana: "https://explorer.katanarpc.com/address/",
   hyperevm: "https://hyperevmscan.io/address/",
+  plume: "https://explorer.plume.org/address/",
 };
 
 export function explorerUrl(address: string, chain = "ethereum"): string {

--- a/src/lib/graphStyle.ts
+++ b/src/lib/graphStyle.ts
@@ -151,6 +151,7 @@ export const CHAIN_LABELS: Record<string, string> = {
   sonic: "Sonic",
   katana: "Katana",
   hyperevm: "HyperEVM",
+  plume: "Plume",
 };
 
 export const chainLabel = (chain: string): string =>


### PR DESCRIPTION
Closes #443

## Summary

- reassess Superstate / Bitwise USCC at 2.45 (Low Risk), down from 2.95
- verify the July FundToken v1.2/v1.3 migration, current owner/proxy/oracle state, and Ethereum/Plume/Solana supply
- refresh NAV, AUM, TVL, portfolio holdings, integrations, monitoring, and reassessment triggers
- add the issuer-operated Ethereum-to-Plume bridge dependency and Plume graph explorer support

## Material findings

- no published audit scope explicitly maps to the deployed FundToken v1.2/v1.3 integration and storage migration; this is recorded as a confirmed disclosure limitation rather than an open TODO
- the apparent 613,035.57-share discrepancy is a reporting-cutoff difference: two September 4 Ethereum mints account for 613,035.402635 USCC, leaving only a 0.164482-USCC residual
- Solana supply remains live, but current documentation says SVM bridging is unsupported; the enabled EVM destination is Plume

## Validation

- `npm test` — 55 passed
- targeted USCC graph validation — no errors
- `npm run build` — passed

The global strict graph and bridge modes retain pre-existing warnings outside this PR: 19 graph-corpus warnings and one Axelar mention in `superstate-ustb`. The normal production build passes.