### PR TITLE
feat(web): add contact page

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -158,6 +158,7 @@ const schemaJson = JSON.stringify(schema)
           <a href="/monitoring/">Monitoring</a>
         </nav>
         </div>
+        <a href="/contact/" class="nav-contact">Contact</a>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle light mode">
           <svg class="icon-sun" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5" />
@@ -182,6 +183,7 @@ const schemaJson = JSON.stringify(schema)
     <footer class="site-footer">
       <div class="container">
         <p>Risk Assessments by <a href="https://docs.yearn.fi/getting-started/products/curating/introduction" target="_blank" rel="noopener noreferrer">Yearn Curation</a></p>
+        <p class="footer-contact">Need curation, monitoring or a risk assessment? <a href="/contact/">Get in touch</a></p>
       </div>
     </footer>
     <script is:inline>
@@ -384,6 +386,32 @@ const schemaJson = JSON.stringify(schema)
     color: var(--text-primary);
     text-decoration: none;
   }
+  /* Contact is the one nav item asking for an action, so it reads as a chip
+     rather than a plain link. It sits outside .header-nav because that list
+     scrolls horizontally on narrow screens — inside it, the CTA would be the
+     first thing to disappear off the right edge on a phone. */
+  .nav-contact {
+    flex-shrink: 0;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--brand-blue);
+    text-decoration: none;
+    white-space: nowrap;
+    padding: 0.3rem 0.75rem;
+    border: 1px solid color-mix(in srgb, var(--brand-blue) 40%, transparent);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--brand-blue) 10%, transparent);
+    transition: background 0.2s, border-color 0.2s;
+  }
+  .nav-contact:hover {
+    color: var(--brand-blue);
+    text-decoration: none;
+    background: color-mix(in srgb, var(--brand-blue) 18%, transparent);
+    border-color: var(--brand-blue);
+  }
+  .footer-contact {
+    margin-top: 0.4rem;
+  }
   .nav-external {
     display: inline-flex;
     align-items: center;
@@ -409,7 +437,7 @@ const schemaJson = JSON.stringify(schema)
     display: block;
   }
   .theme-toggle {
-    margin-left: auto;
+    flex-shrink: 0;
     background: none;
     border: 1px solid var(--border);
     border-radius: 6px;
@@ -456,6 +484,10 @@ const schemaJson = JSON.stringify(schema)
     }
     .header-nav {
       gap: 0.75rem;
+    }
+    .nav-contact {
+      padding: 0.25rem 0.6rem;
+      font-size: 0.8rem;
     }
   }
   .site-footer {

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -21,17 +21,17 @@ const services = [
   {
     num: "01",
     title: "Risk assessments",
-    body: `Independent, published reviews of protocols, vaults and yield-bearing assets, scored 1.0–5.0 on the same rubric behind the ${reportCount} reports on this site. Useful before listing an asset, onboarding a market, or defending an allocation to a risk committee.`,
+    body: `Independent, published reviews of protocols, vaults and yield-bearing assets, scored 1-5 on the same framework behind the ${reportCount} reports on this site. Useful before listing an asset, onboarding a market, or defending an allocation to a risk committee.`,
   },
   {
     num: "02",
     title: "Vault curation",
-    body: "We run curator vaults on Morpho and other lending venues — market selection, supply caps, allocation policy, and the ongoing decisions that keep a vault inside its stated risk envelope.",
+    body: "We run curator vaults on Morpho and other lending venues — market selection, supply caps, allocation policy, and the ongoing decisions that keep a vault inside its stated risk profile.",
   },
   {
     num: "03",
     title: "Curation advice",
-    body: "Working sessions for teams building their own curation practice: what to score, how to weight it, where the hidden fund-loss paths tend to sit, and how to turn all of it into a policy you can actually operate.",
+    body: "Working sessions for teams building their own curation practice: what to score, how to weight it, where the hidden fund-loss paths are, and how to turn all of it into a policy you can actually operate.",
   },
   {
     num: "04",
@@ -43,17 +43,16 @@ const services = [
 
 <BaseLayout
   title="Contact — Yearn Curation"
-  description="Talk to the Yearn Curation team about risk assessments, vault curation, curation advice, and onchain monitoring."
+  description="Talk to the Yearn Curation team about risk assessments, vault curation, curation advice, and monitoring."
   ogUrl="/contact/"
   ogImage="/og/default.png"
   jsonLd={jsonLd}
 >
   <section class="page-hero">
-    <h1>Get in touch</h1>
+    <h1>Let's talk</h1>
     <p class="page-sub">
-      The Yearn Curation team works with protocols, DAOs and allocators on risk
-      assessments, vault curation and onchain monitoring. Tell us what you are
-      building and we will tell you whether we can help.
+      The Yearn Curation team works with protocols, DAOs and allocators on risk assessments, vault curation and monitoring.
+      Tell us what you are building and we will help you secure it.
     </p>
     <div class="hero-cta">
       <a href={`mailto:${EMAIL}`} class="btn btn-primary">
@@ -71,13 +70,11 @@ const services = [
     <div class="card-glow" aria-hidden="true"></div>
     <div class="cred-copy">
       <div class="cred-eyebrow">Track record</div>
-      <h2>We curate $250M+ in TVL</h2>
+      <h2>We manage $250M+ in TVL</h2>
       <p>
         Yearn manages and curates over $250 million across Ethereum, Katana,
-        Arbitrum, Base, Optimism and Polygon — the same book the assessments on
-        this site are written against. Our curation is not theoretical: every
-        framework we would apply for you is one we already run our own capital
-        through.
+        Arbitrum, Base, Optimism and Polygon. Our curation is not theoretical,
+        funds and accounting are onchain. Inhouse monitoring keeps everything inline with defined risk.
       </p>
       <a href={DEFILLAMA_URL} target="_blank" rel="noopener noreferrer" class="cred-link">
         View Yearn on DefiLlama
@@ -120,7 +117,6 @@ const services = [
         <div class="reach-body">
           <div class="reach-title">Email</div>
           <div class="reach-detail">{EMAIL}</div>
-          <p>Best for engagements, scoping a review, or anything with a document attached.</p>
         </div>
       </a>
       <a href={X_URL} target="_blank" rel="noopener noreferrer" class="reach-card">
@@ -131,7 +127,6 @@ const services = [
         <div class="reach-body">
           <div class="reach-title">X</div>
           <div class="reach-detail">@yearnfi</div>
-          <p>Quick questions and DMs. Slower than email for anything detailed.</p>
         </div>
       </a>
     </div>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,0 +1,426 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import stats from "../data/stats.json";
+
+const EMAIL = "curation@yearn.fi";
+const X_URL = "https://x.com/yearnfi";
+const DEFILLAMA_URL = "https://defillama.com/protocol/yearn";
+
+const reportCount = stats.reportCount;
+
+// ContactPage schema so search engines can surface the enquiry route directly.
+const jsonLd = {
+  "@type": "ContactPage",
+  name: "Contact Yearn Curation",
+  description:
+    "Get in touch with the Yearn Curation team about risk assessments, vault curation, and monitoring.",
+  url: "https://curation.yearn.fi/contact/",
+};
+
+const services = [
+  {
+    num: "01",
+    title: "Risk assessments",
+    body: `Independent, published reviews of protocols, vaults and yield-bearing assets, scored 1.0–5.0 on the same rubric behind the ${reportCount} reports on this site. Useful before listing an asset, onboarding a market, or defending an allocation to a risk committee.`,
+  },
+  {
+    num: "02",
+    title: "Vault curation",
+    body: "We run curator vaults on Morpho and other lending venues — market selection, supply caps, allocation policy, and the ongoing decisions that keep a vault inside its stated risk envelope.",
+  },
+  {
+    num: "03",
+    title: "Curation advice",
+    body: "Working sessions for teams building their own curation practice: what to score, how to weight it, where the hidden fund-loss paths tend to sit, and how to turn all of it into a policy you can actually operate.",
+  },
+  {
+    num: "04",
+    title: "Monitoring",
+    body: "Design and deployment of onchain monitors — governance actions, oracle changes, owner and role transfers, collateralization and peg drift — streamed to the channel your team already watches.",
+  },
+];
+---
+
+<BaseLayout
+  title="Contact — Yearn Curation"
+  description="Talk to the Yearn Curation team about risk assessments, vault curation, curation advice, and onchain monitoring."
+  ogUrl="/contact/"
+  ogImage="/og/default.png"
+  jsonLd={jsonLd}
+>
+  <section class="page-hero">
+    <h1>Get in touch</h1>
+    <p class="page-sub">
+      The Yearn Curation team works with protocols, DAOs and allocators on risk
+      assessments, vault curation and onchain monitoring. Tell us what you are
+      building and we will tell you whether we can help.
+    </p>
+    <div class="hero-cta">
+      <a href={`mailto:${EMAIL}`} class="btn btn-primary">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="4" width="20" height="16" rx="2"/><polyline points="2 6 12 13 22 6"/></svg>
+        {EMAIL}
+      </a>
+      <a href={X_URL} target="_blank" rel="noopener noreferrer" class="btn btn-secondary">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+        Message us on X
+      </a>
+    </div>
+  </section>
+
+  <section class="cred" data-mouse-glow>
+    <div class="card-glow" aria-hidden="true"></div>
+    <div class="cred-copy">
+      <div class="cred-eyebrow">Track record</div>
+      <h2>We curate $250M+ in TVL</h2>
+      <p>
+        Yearn manages and curates over $250 million across Ethereum, Katana,
+        Arbitrum, Base, Optimism and Polygon — the same book the assessments on
+        this site are written against. Our curation is not theoretical: every
+        framework we would apply for you is one we already run our own capital
+        through.
+      </p>
+      <a href={DEFILLAMA_URL} target="_blank" rel="noopener noreferrer" class="cred-link">
+        View Yearn on DefiLlama
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+      </a>
+    </div>
+    <dl class="cred-stats">
+      <div>
+        <dt>TVL curated</dt>
+        <dd>$250M+</dd>
+      </div>
+      <div>
+        <dt>Public reports</dt>
+        <dd>{reportCount}</dd>
+      </div>
+    </dl>
+  </section>
+
+  <section class="services">
+    <h2 class="section-title">What we can help with</h2>
+    <div class="service-grid">
+      {services.map((s) => (
+        <div class="service">
+          <div class="service-num">{s.num}</div>
+          <h3>{s.title}</h3>
+          <p>{s.body}</p>
+        </div>
+      ))}
+    </div>
+  </section>
+
+  <section class="reach">
+    <h2 class="section-title">How to reach us</h2>
+    <div class="reach-grid">
+      <a href={`mailto:${EMAIL}`} class="reach-card">
+        <div class="card-glow" aria-hidden="true"></div>
+        <div class="reach-icon">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><polyline points="2 6 12 13 22 6"/></svg>
+        </div>
+        <div class="reach-body">
+          <div class="reach-title">Email</div>
+          <div class="reach-detail">{EMAIL}</div>
+          <p>Best for engagements, scoping a review, or anything with a document attached.</p>
+        </div>
+      </a>
+      <a href={X_URL} target="_blank" rel="noopener noreferrer" class="reach-card">
+        <div class="card-glow" aria-hidden="true"></div>
+        <div class="reach-icon">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+        </div>
+        <div class="reach-body">
+          <div class="reach-title">X</div>
+          <div class="reach-detail">@yearnfi</div>
+          <p>Quick questions and DMs. Slower than email for anything detailed.</p>
+        </div>
+      </a>
+    </div>
+    <p class="reach-note">
+      Spotted something wrong in a report? Open an issue on <a href="https://github.com/yearn/risk-score/issues" target="_blank" rel="noopener noreferrer">GitHub</a> — corrections are handled in public.
+    </p>
+  </section>
+
+  <script is:inline>
+    // Mouse-tracking glow, matching the report cards on the homepage.
+    (() => {
+      document.querySelectorAll(".cred, .reach-card").forEach((card) => {
+        card.addEventListener("pointermove", (e) => {
+          const r = card.getBoundingClientRect();
+          card.style.setProperty("--mx", `${e.clientX - r.left}px`);
+          card.style.setProperty("--my", `${e.clientY - r.top}px`);
+        });
+        card.addEventListener("pointerleave", () => {
+          card.style.removeProperty("--mx");
+          card.style.removeProperty("--my");
+        });
+      });
+    })();
+  </script>
+</BaseLayout>
+
+<style>
+  .page-hero {
+    padding: 3rem 0 2rem;
+    text-align: center;
+  }
+  .page-hero h1 {
+    font-size: clamp(1.9rem, 4vw, 2.8rem);
+    letter-spacing: -0.02em;
+    margin: 0 auto 0.9rem;
+    line-height: 1.15;
+  }
+  .page-sub {
+    color: var(--text-secondary);
+    max-width: 58ch;
+    margin: 0 auto 2rem;
+    font-size: 1.02rem;
+    line-height: 1.55;
+  }
+  .hero-cta {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.4rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    border-radius: 8px;
+    transition: transform 0.15s, background 0.15s, border-color 0.15s;
+    text-decoration: none;
+  }
+  .btn-primary {
+    background: var(--brand-blue);
+    color: #fff;
+    border: 1px solid var(--brand-blue);
+  }
+  .btn-primary:hover {
+    background: #0560d4;
+    border-color: #0560d4;
+    color: #fff;
+    text-decoration: none;
+    transform: translateY(-1px);
+  }
+  .btn-secondary {
+    background: color-mix(in srgb, var(--bg-secondary) 70%, transparent);
+    border: 1px solid var(--border);
+    color: var(--text-primary);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+  }
+  .btn-secondary:hover {
+    border-color: var(--text-secondary);
+    text-decoration: none;
+    transform: translateY(-1px);
+  }
+
+  /* Shared frosted-card recipe (see reports.astro / index.astro). */
+  .cred,
+  .reach-card {
+    --mx: 50%;
+    --my: 50%;
+    position: relative;
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    background: color-mix(in srgb, var(--bg-card) 65%, transparent);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    overflow: hidden;
+    isolation: isolate;
+  }
+  .card-glow {
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    opacity: 0;
+    background: radial-gradient(
+      300px circle at var(--mx, 50%) var(--my, 50%),
+      color-mix(in srgb, var(--brand-blue) 16%, transparent),
+      transparent 60%
+    );
+    transition: opacity 0.25s;
+  }
+  .cred:hover .card-glow,
+  .reach-card:hover .card-glow {
+    opacity: 1;
+  }
+
+  /* === Track record === */
+  .cred {
+    display: grid;
+    grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+    gap: 2rem;
+    align-items: center;
+    margin: 3rem 0 0;
+    padding: 2rem;
+    background:
+      linear-gradient(135deg, rgba(6, 117, 249, 0.1), transparent 60%),
+      color-mix(in srgb, var(--bg-card) 65%, transparent);
+  }
+  .cred-eyebrow {
+    font-size: 0.72rem;
+    color: var(--brand-blue);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 600;
+  }
+  .cred-copy h2 {
+    font-size: 1.35rem;
+    letter-spacing: -0.01em;
+    margin: 0.15rem 0 0.75rem;
+  }
+  .cred-copy p {
+    color: var(--text-secondary);
+    font-size: 0.92rem;
+    line-height: 1.6;
+    margin-bottom: 1rem;
+  }
+  .cred-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--brand-blue);
+  }
+  .cred-stats {
+    display: grid;
+    gap: 0.75rem;
+  }
+  .cred-stats > div {
+    padding: 0.85rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--bg-secondary) 40%, transparent);
+  }
+  .cred-stats dt {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-secondary);
+  }
+  .cred-stats dd {
+    font-size: 1.35rem;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* === Services === */
+  .section-title {
+    font-size: 1.3rem;
+    letter-spacing: -0.01em;
+    margin-bottom: 1.25rem;
+  }
+  .services,
+  .reach {
+    margin: 3.5rem 0 0;
+  }
+  .service-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+  }
+  .service {
+    padding: 1.5rem;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--bg-card) 55%, transparent);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+  }
+  .service-num {
+    font-family: "SF Mono", "Fira Code", monospace;
+    font-size: 0.75rem;
+    color: var(--brand-blue);
+    margin-bottom: 0.5rem;
+    letter-spacing: 0.1em;
+  }
+  .service h3 {
+    font-size: 1.05rem;
+    margin-bottom: 0.5rem;
+  }
+  .service p {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    line-height: 1.55;
+  }
+
+  /* === Reach === */
+  .reach-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+  }
+  .reach-card {
+    display: flex;
+    gap: 1rem;
+    padding: 1.4rem;
+    color: var(--text-primary);
+    text-decoration: none;
+    transition: transform 0.2s ease, border-color 0.2s ease;
+  }
+  .reach-card:hover {
+    text-decoration: none;
+    transform: translateY(-2px);
+    border-color: color-mix(in srgb, var(--brand-blue) 65%, var(--border));
+  }
+  .reach-icon {
+    flex-shrink: 0;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+    background: color-mix(in srgb, var(--bg-secondary) 50%, transparent);
+    color: var(--brand-blue);
+  }
+  .reach-title {
+    font-weight: 600;
+    font-size: 1rem;
+  }
+  .reach-detail {
+    font-family: "SF Mono", "Fira Code", monospace;
+    font-size: 0.85rem;
+    color: var(--brand-blue);
+    word-break: break-all;
+  }
+  .reach-body p {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    line-height: 1.5;
+    margin-top: 0.4rem;
+  }
+  .reach-note {
+    margin-top: 1rem;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+  }
+
+  @media (max-width: 720px) {
+    .cred {
+      grid-template-columns: 1fr;
+      gap: 1.5rem;
+    }
+    .cred-stats {
+      grid-template-columns: repeat(2, 1fr);
+    }
+    .service-grid,
+    .reach-grid {
+      grid-template-columns: 1fr;
+    }
+    .hero-cta {
+      flex-direction: column;
+      align-items: stretch;
+    }
+    .btn {
+      justify-content: center;
+    }
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -28,6 +28,7 @@ const excerpt = (html: string, maxLen = 180): string => {
 const reportCount = stats.reportCount;
 
 const morphoUrl = "https://app.morpho.org/ethereum/curator/yearn";
+const defillamaUrl = "https://defillama.com/protocol/yearn";
 
 // Homepage highlights scored assessments; Not Rated (terminal) reports live on /reports.
 const recent = getAllReports()
@@ -249,6 +250,28 @@ const followups = recent.slice(1);
     <a href={morphoUrl} target="_blank" rel="noopener noreferrer" class="btn btn-primary">
       Open Yearn vaults on Morpho
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+    </a>
+  </section>
+
+  <section class="contact-cta">
+    <div class="contact-copy">
+      <div class="contact-eyebrow">Work with us</div>
+      <h2>Get in touch</h2>
+      <p>
+        Yearn manages and curates <a href={defillamaUrl} target="_blank" rel="noopener noreferrer">$250M+ in TVL</a>.
+        We take on risk assessments, vault curation, curation advice and onchain
+        monitoring for protocols, DAOs and allocators.
+      </p>
+      <div class="contact-tags">
+        <span>Risk assessments</span>
+        <span>Vault curation</span>
+        <span>Curation advice</span>
+        <span>Monitoring</span>
+      </div>
+    </div>
+    <a href="/contact/" class="btn btn-primary contact-btn">
+      Contact us
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
     </a>
   </section>
 </BaseLayout>
@@ -689,9 +712,71 @@ const followups = recent.slice(1);
     max-width: 60ch;
   }
 
+  /* === Work-with-us CTA === */
+  .contact-cta {
+    margin: 3rem 0 1rem;
+    padding: 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    background:
+      linear-gradient(135deg, rgba(6, 117, 249, 0.1), transparent 60%),
+      color-mix(in srgb, var(--bg-card) 65%, transparent);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+  }
+  .contact-copy {
+    min-width: 0;
+    flex: 1 1 22rem;
+  }
+  .contact-eyebrow {
+    font-size: 0.72rem;
+    color: var(--brand-blue);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 600;
+  }
+  .contact-cta h2 {
+    font-size: 1.25rem;
+    margin-top: 0.1rem;
+  }
+  .contact-cta p {
+    color: var(--text-secondary);
+    max-width: 60ch;
+    margin-top: 0.35rem;
+  }
+  .contact-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin-top: 1rem;
+  }
+  .contact-tags span {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    padding: 0.2rem 0.6rem;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--bg-secondary) 40%, transparent);
+  }
+  .contact-btn {
+    flex-shrink: 0;
+  }
+
   @media (max-width: 720px) {
     .features {
       grid-template-columns: 1fr;
+    }
+    .contact-cta {
+      padding: 1.5rem;
+    }
+    .contact-btn {
+      width: 100%;
+      justify-content: center;
     }
     .hero {
       padding: 2rem 0 1.5rem;

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -96,6 +96,7 @@ export const GET: APIRoute = async () => {
     `- [Token exposures](${SITE}/tokens/): shared-asset overlap across curated protocols`,
     `- [Bridge dependencies](${SITE}/bridges/): cross-chain bridge risk`,
     `- [Live monitoring](${SITE}/monitoring/): real-time protocol alerts (governance, oracle, owner changes)`,
+    `- [Contact](${SITE}/contact/): work with Yearn Curation on risk assessments, vault curation, curation advice, and monitoring — curation@yearn.fi`,
     "- [Yearn Curation introduction](https://docs.yearn.fi/getting-started/products/curating/introduction)",
     "- [Source repository](https://github.com/yearn/risk-score)",
     "",


### PR DESCRIPTION
## Summary

Adds a **Get in touch** page at `/contact/` plus the entry points that lead to it.

The page covers the four things people approach the curation team about — risk assessments, vault curation, curation advice, and onchain monitoring — and gives two contact routes: email (`curation@yearn.fi`) and X (`@yearnfi`). Report corrections are pointed at GitHub issues so they stay public.

### Entry points
- **Header** — a `Contact` chip. It sits *outside* `.header-nav` on purpose: that list scrolls horizontally on narrow screens, and inside it the CTA was the first item to fall off the right edge on a phone.
- **Homepage** — a "Work with us" CTA section below the Morpho card.
- **Footer** — a one-line prompt, so it's reachable from every page.
- **`llms.txt`** — listed under Other resources.

### TVL claim
The page cites **$250M+ curated TVL** and links https://defillama.com/protocol/yearn.

Verified against `api.llama.fi/protocols`: the `yearn` parent protocol totals **$250.67M** today — `yearn-finance` $188.80M + `yearn-curating` $61.87M. `yearn` is a valid parent slug under the rules in `scripts/check_defillama_links.py`.

This is static copy, so it needs a manual refresh if TVL moves materially. (A build-time fetch into `stats.json` is the alternative if that becomes annoying.)

### Validation
- `npm run build` — 115 pages, `/contact/` present in `dist/sitemap-0.xml`
- `npm test` — 55/55 passing
- Visual check of the page and both CTAs in dark, light, and a 390px-wide viewport

Both `x.com` and `defillama.com/protocol/` are already in `lychee.toml`'s exclude list, so link-check CI is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

TODO:
- [ ] configure mail
- [ ] add catcha or cloudflare Turnstile on sending form