### PR TITLE
feat(vaults): add report field linking vaults to risk assessment reports

### DIFF
--- a/vaults/1.json
+++ b/vaults/1.json
@@ -65,7 +65,8 @@
             "review": 0,
             "riskExposure": 0,
             "testing": 0
-        }
+        },
+        "report": "https://curation.yearn.fi/report/yearn-yvdai/"
     },
     "0x05329aab081b125eef7fbbc8b857428d478e692b": {
         "riskLevel": 2,
@@ -269,7 +270,8 @@
             "review": 0,
             "riskExposure": 0,
             "testing": 0
-        }
+        },
+        "report": "https://curation.yearn.fi/report/yearn-yvusds/"
     },
     "0x1d0bcbf0f80cc47e7766d48d61c5fe7ad8a19640": {
         "riskLevel": 1,
@@ -456,7 +458,8 @@
             "review": 0,
             "riskExposure": 0,
             "testing": 0
-        }
+        },
+        "report": "https://curation.yearn.fi/report/yearn-yvusdt/"
     },
     "0x378ffd482c767f847d48818552f8438b17335c89": {
         "riskLevel": 1,
@@ -781,6 +784,24 @@
             "testing": 1
         }
     },
+    "0x696d02db93291651ed510704c9b286841d506987": {
+        "riskLevel": 2,
+        "riskScore": {
+            "centralizationRisk": 0,
+            "comment": "",
+            "complexity": 0,
+            "externalProtocolAudit": 0,
+            "externalProtocolCentralisation": 0,
+            "externalProtocolLongevity": 0,
+            "externalProtocolTvl": 0,
+            "externalProtocolType": 0,
+            "protocolIntegration": 0,
+            "review": 0,
+            "riskExposure": 0,
+            "testing": 0
+        },
+        "report": "https://curation.yearn.fi/report/yearn-yvusd/"
+    },
     "0x6aceda98725505737c0f00a3da0d047304052948": {
         "riskLevel": 1,
         "riskScore": {
@@ -847,7 +868,8 @@
             "review": 0,
             "riskExposure": 0,
             "testing": 0
-        }
+        },
+        "report": "https://curation.yearn.fi/report/yearn-yvwbtc/"
     },
     "0x75f35498e0d053d0dbd2472bc06e7cba1f0c7d3a": {
         "riskLevel": 2,
@@ -934,23 +956,6 @@
             "testing": 0
         }
     },
-    "0x696d02db93291651ed510704c9b286841d506987": {
-        "riskLevel": 2,
-        "riskScore": {
-            "centralizationRisk": 0,
-            "comment": "",
-            "complexity": 0,
-            "externalProtocolAudit": 0,
-            "externalProtocolCentralisation": 0,
-            "externalProtocolLongevity": 0,
-            "externalProtocolTvl": 0,
-            "externalProtocolType": 0,
-            "protocolIntegration": 0,
-            "review": 0,
-            "riskExposure": 0,
-            "testing": 0
-        }
-    },
     "0x832c30802054f60f0cedb5be1f9a0e3da2a0cab4": {
         "riskLevel": 1,
         "riskScore": {
@@ -984,6 +989,24 @@
             "riskExposure": 4,
             "testing": 1
         }
+    },
+    "0x863687e4e9751b57f38b4b0eba04744c72d0f7b8": {
+        "riskLevel": 3,
+        "riskScore": {
+            "centralizationRisk": 0,
+            "comment": "",
+            "complexity": 0,
+            "externalProtocolAudit": 0,
+            "externalProtocolCentralisation": 0,
+            "externalProtocolLongevity": 0,
+            "externalProtocolTvl": 0,
+            "externalProtocolType": 0,
+            "protocolIntegration": 0,
+            "review": 0,
+            "riskExposure": 0,
+            "testing": 0
+        },
+        "report": "https://curation.yearn.fi/report/flex/"
     },
     "0x888239ffa9a0613f9142c808aa9f7d1948a14f75": {
         "riskLevel": 1,
@@ -1510,7 +1533,8 @@
             "review": 0,
             "riskExposure": 0,
             "testing": 0
-        }
+        },
+        "report": "https://curation.yearn.fi/report/yearn-yvusdc/"
     },
     "0xbf2e5bed692c09af8b39677e315f36adf39bd685": {
         "riskLevel": 2,
@@ -1595,7 +1619,8 @@
             "review": 0,
             "riskExposure": 0,
             "testing": 0
-        }
+        },
+        "report": "https://curation.yearn.fi/report/yearn-yvweth/"
     },
     "0xc5ab829b2f7cb3e869949747bc8c6f66ef2250cc": {
         "riskLevel": 1,

--- a/vaults/VAULT.md
+++ b/vaults/VAULT.md
@@ -14,13 +14,15 @@ JSON structure:
       "review": 3,
       "testing": 1,
       ...
-    }
+    },
+    "report": "https://curation.yearn.fi/report/yearn-yvusdc/"
   }
 }
 ```
 
 - `riskLevel` is the final risk of the vault displayed on Yearn frontend.
 - `riskScore` is object with detailed values of each risk category.
+- `report` is an optional URL linking to the full risk assessment report for the vault (e.g. `https://curation.yearn.fi/report/<slug>/`). Only add it for vaults that have a dedicated report in [`reports/report/`](../reports/report/); do not add it for single strategies.
 
 This data is used by [yDaemon](https://github.com/yearn/ydaemon). yDaemon fetches the vaults from blockchain registry and creates new JSON item for each vault. yDaemon was extended in [this commit](https://github.com/yearn/ydaemon/commit/b8296457af78cf97f41ef15cb502ff0744fd0a8b) to fetch the vault risk score from this folder.
 
@@ -33,6 +35,7 @@ TODO: Make Kong use this data and reference the file/commit where this repo is u
 3. The value must contain `riskLevel` and `riskScore` fields assigned by the SAM team.
    - Multistrategy vaults contain `riskLevel` field, `riskScore` fields are all 0 and should not be used.
    - Single-strategy vaults contains both `riskLevel` and `riskScore` fields. `riskScore` fields should be filled with the risk score for the strategy. Check [RISK_FRAMEWORK.md](./RISK_FRAMEWORK.md) for more information on how to fill the `riskScore` fields.
-4. Keep addresses sorted alphabetically for easier maintenance.
+4. Optionally add a `report` field with the URL to the vault's risk assessment report. The report slug must match a file in `reports/report/` (e.g. `yearn-yvusdc` for `yearn-yvusdc.md`).
+5. Keep addresses sorted alphabetically for easier maintenance.
 
 For reference, check [1.json](./1.json) for examples of vault entries.


### PR DESCRIPTION
## Summary

Adds an optional `report` field to vault entries in `vaults/*.json`, linking each vault to its full risk assessment report URL.

- Links the Yearn yVaults with existing reports (`yv` slugs): yvDAI, yvUSD, yvUSDC, yvUSDS, yvUSDT, yvWBTC, yvWETH.
- Adds the `yvFlexUSDC` allocator vault (`0x863687…`) entry with its `flex` report.
- Fixes the yvUSD entry's alphabetical ordering (pre-existing misplacement).
- Documents the new `report` field in `vaults/VAULT.md`.

## Validation

- `vaults/1.json` parses as valid JSON (126 entries), all keys lowercase, sorted alphabetically.
- `npm test` passes (60/60).
- No schema validation exists for `vaults/*.json`; `report` is a plain optional string consumed by yDaemon.

## Notes

The `report` field is only added to multistrategy vaults, not single-strategy entries.